### PR TITLE
rename module kuadrant-dns-operator -> dns-operator

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -13,9 +13,9 @@ env:
   IMG_TAGS: ${{ github.sha }} ${{ github.ref_name }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
-  IMG_REGISTRY_REPO: kuadrant-dns-operator
+  IMG_REGISTRY_REPO: dns-operator
   MAIN_BRANCH_NAME: main
-  OPERATOR_NAME: kuadrant-dns-operator
+  OPERATOR_NAME: dns-operator
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# quay.io/kuadrant/kuadrant-dns-operator-bundle:$VERSION and quay.io/kuadrant/kuadrant-dns-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/kuadrant/kuadrant-dns-operator
+# quay.io/kuadrant/dns-operator-bundle:$VERSION and quay.io/kuadrant/dns-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= quay.io/kuadrant/dns-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -118,7 +118,7 @@ lint: ## Run golangci-lint against code.
 
 .PHONY: imports
 imports: openshift-goimports ## Run openshift goimports against code.
-	$(OPENSHIFT_GOIMPORTS) -m github.com/kuadrant/kuadrant-dns-operator -i github.com/kuadrant
+	$(OPENSHIFT_GOIMPORTS) -m github.com/kuadrant/dns-operator -i github.com/kuadrant
 
 .PHONY: test
 test: test-unit test-integration ## Run tests.

--- a/PROJECT
+++ b/PROJECT
@@ -8,8 +8,8 @@ layout:
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
-projectName: kuadrant-dns-operator
-repo: github.com/kuadrant/kuadrant-dns-operator
+projectName: dns-operator
+repo: github.com/kuadrant/dns-operator
 resources:
 - api:
     crdVersion: v1
@@ -17,7 +17,7 @@ resources:
   controller: true
   domain: kuadrant.io
   kind: ManagedZone
-  path: github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1
+  path: github.com/kuadrant/dns-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -25,7 +25,7 @@ resources:
   controller: true
   domain: kuadrant.io
   kind: DNSRecord
-  path: github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1
+  path: github.com/kuadrant/dns-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -33,6 +33,6 @@ resources:
   controller: true
   domain: kuadrant.io
   kind: DNSHealthCheckProbe
-  path: github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1
+  path: github.com/kuadrant/dns-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kuadrant-dns-operator
+# dns-operator
 // TODO(user): Add simple overview of use/purpose
 
 ## Description
@@ -18,13 +18,13 @@ kubectl apply -f config/samples/
 2. Build and push your image to the location specified by `IMG`:
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/kuadrant-dns-operator:tag
+make docker-build docker-push IMG=<some-registry>/dns-operator:tag
 ```
 
 3. Deploy the controller to the cluster with the image specified by `IMG`:
 
 ```sh
-make deploy IMG=<some-registry>/kuadrant-dns-operator:tag
+make deploy IMG=<some-registry>/dns-operator:tag
 ```
 
 ### Uninstall CRDs

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,7 +4,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=kuadrant-dns-operator
+LABEL operators.operatorframework.io.bundle.package.v1=dns-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1

--- a/bundle/manifests/dns-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/dns-operator-controller-manager-metrics-service_v1_service.yaml
@@ -4,13 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/part-of: dns-operator
     control-plane: controller-manager
-  name: kuadrant-dns-operator-controller-manager-metrics-service
+  name: dns-operator-controller-manager-metrics-service
 spec:
   ports:
   - name: https

--- a/bundle/manifests/dns-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/dns-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,12 +4,12 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: kuadrant-dns-operator
-  name: kuadrant-dns-operator-metrics-reader
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -9,11 +9,11 @@ metadata:
           "kind": "DNSHealthCheckProbe",
           "metadata": {
             "labels": {
-              "app.kubernetes.io/created-by": "kuadrant-dns-operator",
+              "app.kubernetes.io/created-by": "dns-operator",
               "app.kubernetes.io/instance": "dnshealthcheckprobe-sample",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "dnshealthcheckprobe",
-              "app.kubernetes.io/part-of": "kuadrant-dns-operator"
+              "app.kubernetes.io/part-of": "dns-operator"
             },
             "name": "dnshealthcheckprobe-sample"
           },
@@ -24,11 +24,11 @@ metadata:
           "kind": "DNSRecord",
           "metadata": {
             "labels": {
-              "app.kubernetes.io/created-by": "kuadrant-dns-operator",
+              "app.kubernetes.io/created-by": "dns-operator",
               "app.kubernetes.io/instance": "dnsrecord-sample",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "dnsrecord",
-              "app.kubernetes.io/part-of": "kuadrant-dns-operator"
+              "app.kubernetes.io/part-of": "dns-operator"
             },
             "name": "dnsrecord-sample"
           },
@@ -54,11 +54,11 @@ metadata:
           "kind": "ManagedZone",
           "metadata": {
             "labels": {
-              "app.kubernetes.io/created-by": "kuadrant-dns-operator",
+              "app.kubernetes.io/created-by": "dns-operator",
               "app.kubernetes.io/instance": "managedzone-sample",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "managedzone",
-              "app.kubernetes.io/part-of": "kuadrant-dns-operator"
+              "app.kubernetes.io/part-of": "dns-operator"
             },
             "name": "managedzone-sample"
           },
@@ -69,10 +69,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-02-08T09:42:33Z"
+    createdAt: "2024-02-12T11:25:42Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: kuadrant-dns-operator.v0.0.0
+  name: dns-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -94,8 +94,8 @@ spec:
       kind: ManagedZone
       name: managedzones.kuadrant.io
       version: v1alpha1
-  description: Kuadrant DNS Operator
-  displayName: Kuadrant DNS Operator
+  description: DNS Operator
+  displayName: DNS Operator
   icon:
   - base64data: ""
     mediatype: ""
@@ -203,29 +203,29 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: kuadrant-dns-operator-controller-manager
+        serviceAccountName: dns-operator-controller-manager
       deployments:
       - label:
           app.kubernetes.io/component: manager
-          app.kubernetes.io/created-by: kuadrant-dns-operator
+          app.kubernetes.io/created-by: dns-operator
           app.kubernetes.io/instance: controller-manager
           app.kubernetes.io/managed-by: kustomize
           app.kubernetes.io/name: deployment
-          app.kubernetes.io/part-of: kuadrant-dns-operator
-          control-plane: kuadrant-dns-operator-controller-manager
-        name: kuadrant-dns-operator-controller-manager
+          app.kubernetes.io/part-of: dns-operator
+          control-plane: dns-operator-controller-manager
+        name: dns-operator-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: kuadrant-dns-operator-controller-manager
+              control-plane: dns-operator-controller-manager
           strategy: {}
           template:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                control-plane: kuadrant-dns-operator-controller-manager
+                control-plane: dns-operator-controller-manager
             spec:
               containers:
               - args:
@@ -257,7 +257,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/kuadrant/kuadrant-dns-operator:latest
+                image: quay.io/kuadrant/dns-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -285,7 +285,7 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: kuadrant-dns-operator-controller-manager
+              serviceAccountName: dns-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -320,7 +320,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: kuadrant-dns-operator-controller-manager
+        serviceAccountName: dns-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: false
@@ -334,13 +334,15 @@ spec:
   keywords:
   - dns
   links:
-  - name: Kuadrant DNS Operator
-    url: https://kuadrant-dns-operator.domain
+  - name: DNS Operator
+    url: https://dns-operator.domain
   maintainers:
   - email: mnairn@redhat.com
     name: Michael Nairn
   - email: pbrookes@redhat.com
     name: Phil Brookes
+  - email: cbrookes@redhat.com
+    name: Craig Brookes
   maturity: alpha
   provider:
     name: Red Hat

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: kuadrant-dns-operator
+  operators.operatorframework.io.bundle.package.v1: dns-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,12 +31,12 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	kuadrantiov1alpha1 "github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/controller"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/health"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
-	_ "github.com/kuadrant/kuadrant-dns-operator/internal/provider/aws"
-	_ "github.com/kuadrant/kuadrant-dns-operator/internal/provider/google"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/controller"
+	"github.com/kuadrant/dns-operator/internal/health"
+	"github.com/kuadrant/dns-operator/internal/provider"
+	_ "github.com/kuadrant/dns-operator/internal/provider/aws"
+	_ "github.com/kuadrant/dns-operator/internal/provider/google"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -48,7 +48,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(kuadrantiov1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: kuadrant-dns-operator-system
+namespace: dns-operator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: kuadrant-dns-operator-
+namePrefix: dns-operator-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/kuadrant/kuadrant-dns-operator
+  newName: quay.io/kuadrant/dns-operator
   newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: kuadrant-dns-operator-controller-manager
+    control-plane: dns-operator-controller-manager
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -17,24 +17,24 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: kuadrant-dns-operator-controller-manager
+    control-plane: dns-operator-controller-manager
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
-      control-plane: kuadrant-dns-operator-controller-manager
+      control-plane: dns-operator-controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: kuadrant-dns-operator-controller-manager
+        control-plane: dns-operator-controller-manager
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/manifests/bases/dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dns-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: kuadrant-dns-operator.v0.0.0
+  name: dns-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -26,8 +26,8 @@ spec:
       kind: ManagedZone
       name: managedzones.kuadrant.io
       version: v1alpha1
-  description: Kuadrant DNS Operator
-  displayName: Kuadrant DNS Operator
+  description: DNS Operator
+  displayName: DNS Operator
   icon:
   - base64data: ""
     mediatype: ""
@@ -47,13 +47,15 @@ spec:
   keywords:
   - dns
   links:
-  - name: Kuadrant DNS Operator
-    url: https://kuadrant-dns-operator.domain
+  - name: DNS Operator
+    url: https://dns-operator.domain
   maintainers:
   - email: mnairn@redhat.com
     name: Michael Nairn
   - email: pbrookes@redhat.com
     name: Phil Brookes
+  - email: cbrookes@redhat.com
+    name: Craig Brookes
   maturity: alpha
   provider:
     name: Red Hat

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/kuadrant-dns-operator.clusterserviceversion.yaml
+- bases/dns-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: metrics-reader
 rules:

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: proxy-role
 rules:

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: proxy-rolebinding
 roleRef:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system

--- a/config/rbac/dnshealthcheckprobe_editor_role.yaml
+++ b/config/rbac/dnshealthcheckprobe_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: dnshealthcheckprobe-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: dnshealthcheckprobe-editor-role
 rules:

--- a/config/rbac/dnshealthcheckprobe_viewer_role.yaml
+++ b/config/rbac/dnshealthcheckprobe_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: dnshealthcheckprobe-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: dnshealthcheckprobe-viewer-role
 rules:

--- a/config/rbac/dnsrecord_editor_role.yaml
+++ b/config/rbac/dnsrecord_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: dnsrecord-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: dnsrecord-editor-role
 rules:

--- a/config/rbac/dnsrecord_viewer_role.yaml
+++ b/config/rbac/dnsrecord_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: dnsrecord-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: dnsrecord-viewer-role
 rules:

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: role
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/config/rbac/managedzone_editor_role.yaml
+++ b/config/rbac/managedzone_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: managedzone-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: managedzone-editor-role
 rules:

--- a/config/rbac/managedzone_viewer_role.yaml
+++ b/config/rbac/managedzone_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: managedzone-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: managedzone-viewer-role
 rules:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kuadrant-dns-operator
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/samples/kuadrant.io_v1alpha1_dnshealthcheckprobe.yaml
+++ b/config/samples/kuadrant.io_v1alpha1_dnshealthcheckprobe.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: dnshealthcheckprobe
     app.kubernetes.io/instance: dnshealthcheckprobe-sample
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
   name: dnshealthcheckprobe-sample
 spec:
   # TODO(user): Add fields here

--- a/config/samples/kuadrant.io_v1alpha1_dnsrecord.yaml
+++ b/config/samples/kuadrant.io_v1alpha1_dnsrecord.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: dnsrecord
     app.kubernetes.io/instance: dnsrecord-sample
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
   name: dnsrecord-sample
 spec:
   managedZone:

--- a/config/samples/kuadrant.io_v1alpha1_managedzone.yaml
+++ b/config/samples/kuadrant.io_v1alpha1_managedzone.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: managedzone
     app.kubernetes.io/instance: managedzone-sample
-    app.kubernetes.io/part-of: kuadrant-dns-operator
+    app.kubernetes.io/part-of: dns-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: kuadrant-dns-operator
+    app.kubernetes.io/created-by: dns-operator
   name: managedzone-sample
 spec:
   domainName: example.com

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kuadrant/kuadrant-dns-operator
+module github.com/kuadrant/dns-operator
 
 go 1.21
 

--- a/internal/controller/dnshealthcheckprobe_controller.go
+++ b/internal/controller/dnshealthcheckprobe_controller.go
@@ -17,9 +17,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/common/slice"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/health"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common/slice"
+	"github.com/kuadrant/dns-operator/internal/health"
 )
 
 //ToDO This should not require sigs.k8s.io/gateway-api/apis/v1

--- a/internal/controller/dnsheathcheckprobe_controller_test.go
+++ b/internal/controller/dnsheathcheckprobe_controller_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 var _ = Describe("DNSHealthCheckProbe controller", func() {

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -32,9 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/common/conditions"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common/conditions"
+	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
 const (

--- a/internal/controller/managedzone_controller.go
+++ b/internal/controller/managedzone_controller.go
@@ -30,9 +30,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/common/conditions"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common/conditions"
+	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
 const (

--- a/internal/controller/managedzone_controller_test.go
+++ b/internal/controller/managedzone_controller_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -36,12 +36,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	kuadrantiov1alpha1 "github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/health"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
-	_ "github.com/kuadrant/kuadrant-dns-operator/internal/provider/aws"
-	providerFake "github.com/kuadrant/kuadrant-dns-operator/internal/provider/fake"
-	_ "github.com/kuadrant/kuadrant-dns-operator/internal/provider/google"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/health"
+	"github.com/kuadrant/dns-operator/internal/provider"
+	_ "github.com/kuadrant/dns-operator/internal/provider/aws"
+	providerFake "github.com/kuadrant/dns-operator/internal/provider/fake"
+	_ "github.com/kuadrant/dns-operator/internal/provider/google"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -54,18 +54,18 @@ var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 var dnsProviderFactory = &providerFake.Factory{
-	ProviderForFunc: func(ctx context.Context, pa kuadrantiov1alpha1.ProviderAccessor) (provider.Provider, error) {
+	ProviderForFunc: func(ctx context.Context, pa v1alpha1.ProviderAccessor) (provider.Provider, error) {
 		return &providerFake.Provider{
-			EnsureFunc: func(record *kuadrantiov1alpha1.DNSRecord, zone *kuadrantiov1alpha1.ManagedZone) error {
+			EnsureFunc: func(record *v1alpha1.DNSRecord, zone *v1alpha1.ManagedZone) error {
 				return nil
 			},
-			DeleteFunc: func(record *kuadrantiov1alpha1.DNSRecord, zone *kuadrantiov1alpha1.ManagedZone) error {
+			DeleteFunc: func(record *v1alpha1.DNSRecord, zone *v1alpha1.ManagedZone) error {
 				return nil
 			},
-			EnsureManagedZoneFunc: func(zone *kuadrantiov1alpha1.ManagedZone) (provider.ManagedZoneOutput, error) {
+			EnsureManagedZoneFunc: func(zone *v1alpha1.ManagedZone) (provider.ManagedZoneOutput, error) {
 				return provider.ManagedZoneOutput{}, nil
 			},
-			DeleteManagedZoneFunc: func(zone *kuadrantiov1alpha1.ManagedZone) error {
+			DeleteManagedZoneFunc: func(zone *v1alpha1.ManagedZone) error {
 				return nil
 			},
 		}, nil
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = kuadrantiov1alpha1.AddToScheme(scheme.Scheme)
+	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/internal/health/notifier.go
+++ b/internal/health/notifier.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 type StatusUpdateProbeNotifier struct {

--- a/internal/health/probeQueuer.go
+++ b/internal/health/probeQueuer.go
@@ -8,7 +8,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 type ProbeQueuer struct {

--- a/internal/health/queuedProbeWorker.go
+++ b/internal/health/queuedProbeWorker.go
@@ -15,7 +15,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 // QueuedProbeWorker funnels incoming health check requests from health probes,

--- a/internal/provider/aws/aws.go
+++ b/internal/provider/aws/aws.go
@@ -32,8 +32,8 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
 const (

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch

--- a/internal/provider/fake/factory.go
+++ b/internal/provider/fake/factory.go
@@ -3,8 +3,8 @@ package fake
 import (
 	"context"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
 type Factory struct {

--- a/internal/provider/fake/provider.go
+++ b/internal/provider/fake/provider.go
@@ -1,8 +1,8 @@
 package fake
 
 import (
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
 type Provider struct {

--- a/internal/provider/google/google.go
+++ b/internal/provider/google/google.go
@@ -33,8 +33,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
 type action string

--- a/internal/provider/google/google_test.go
+++ b/internal/provider/google/google_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	dnsv1 "google.golang.org/api/dns/v1"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
 func TestGoogleDNSProvider_toManagedZoneOutput(t *testing.T) {

--- a/internal/provider/iso3166.go
+++ b/internal/provider/iso3166.go
@@ -1,6 +1,6 @@
 package provider
 
-import "github.com/kuadrant/kuadrant-dns-operator/internal/common/slice"
+import "github.com/kuadrant/dns-operator/internal/common/slice"
 
 // nolint
 type countryCodes struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"regexp"
 
-	"github.com/kuadrant/kuadrant-dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 // Provider knows how to manage DNS zones only as pertains to routing.


### PR DESCRIPTION
quay.io repos created:
* https://quay.io/repository/kuadrant/dns-operator
* https://quay.io/repository/kuadrant/dns-operator-bundle
* https://quay.io/repository/kuadrant/dns-operator-catalog

Repo rename will follow. 