### PR TITLE
Remove metrics auth proxy

### DIFF
--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2024-02-13T21:19:36Z"
+    createdAt: "2024-02-16T12:20:36Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -196,18 +196,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
         serviceAccountName: dns-operator-controller-manager
       deployments:
       - label:
@@ -234,31 +222,7 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=:8080
                 - --leader-elect
                 command:
                 - /manager
@@ -270,6 +234,9 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 8080
+                  name: metrics
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -278,7 +245,7 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 500m
+                    cpu: 200m
                     memory: 128Mi
                   requests:
                     cpu: 10m

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -27,12 +27,7 @@ resources:
 #- ../prometheus
 
 patchesStrategicMerge:
-# Protect the /metrics endpoint by putting it behind auth.
-# If you want your controller-manager to expose the /metrics
-# endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
-
-
+- manager_metrics_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+          - "--metrics-bind-address=:8080"
+          - "--leader-elect"
+        ports:
+          - containerPort: 8080
+            name: metrics

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
 - manager.yaml
+- metrics_service.yaml
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
+            cpu: 200m
             memory: 128Mi
           requests:
             cpu: 10m

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     control-plane: dns-operator-controller-manager
-  name: dns-operator-controller-manager-metrics-service
+  name: controller-manager-metrics-service
+  namespace: system
 spec:
   ports:
   - name: metrics
@@ -12,5 +13,3 @@ spec:
     targetPort: metrics
   selector:
     control-plane: dns-operator-controller-manager
-status:
-  loadBalancer: {}

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,11 +16,8 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+      port: metrics
+      scheme: http
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml


### PR DESCRIPTION
Removes the metrics auth proxy container from the default deployment to make it consistent with all other kuadrant components.

**Verifiction**

Terminal 1:
```
make local-setup local-deploy
kubectl -n dns-operator-system port-forward service/dns-operator-controller-manager-metrics-service 28080:8080
```
Terminal 2:
```
curl http://127.0.0.1:28080/metrics                               
# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors                               
# TYPE certwatcher_read_certificate_errors_total counter                                                               
certwatcher_read_certificate_errors_total 0                                                                            
# HELP certwatcher_read_certificate_total Total number of certificate reads                                            
# TYPE certwatcher_read_certificate_total counter                                                                      
certwatcher_read_certificate_total 0                                                                                                                                                                                                          
# HELP controller_runtime_active_workers Number of currently used workers per controller                               
# TYPE controller_runtime_active_workers gauge                                                                         
controller_runtime_active_workers{controller="dnshealthcheckprobe"} 0                                                  
controller_runtime_active_workers{controller="dnsrecord"} 0                                                            
controller_runtime_active_workers{controller="managedzone"} 0 
...
```