### PR TITLE
ci: Enable CI jobs for GH merge queue

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -22,6 +22,7 @@ on:
       - 'samples/**'
       - 'LICENSE'
   workflow_dispatch:
+  merge_group:
 
 env:
   TEST_NAMESPACE: e2e-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ on:
       - '**.md'
       - 'samples/**'
       - 'LICENSE'
+  merge_group:
 
 jobs:
   lint:


### PR DESCRIPTION
Add merge_group trigger to ci and ci-e2e. These must pass before PRs can merge.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions