### PR TITLE
 GH-36 dns record lifecycle

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -1,4 +1,4 @@
-package conditions
+package v1alpha1
 
 type ConditionType string
 type ConditionReason string

--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -87,6 +87,19 @@ type DNSRecordStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// QueuedAt is a time when DNS record was received for the reconciliation
+	QueuedAt metav1.Time `json:"queuedAt,omitempty"`
+
+	// QueuedFor is a time when we expect a DNS record to be reconciled again
+	QueuedFor metav1.Time `json:"queuedFor,omitempty"`
+
+	// ValidFor indicates duration since the last reconciliation we consider data in the record to be valid
+	ValidFor string `json:"validFor,omitempty"`
+
+	// WriteCounter represent a number of consecutive write attempts on the same generation of the record.
+	// It is being reset to 0 when the generation changes or there are no changes to write.
+	WriteCounter int64 `json:"writeCounter,omitempty"`
+
 	// endpoints are the last endpoints that were successfully published by the provider
 	//
 	// Provides a simple mechanism to store the current provider records in order to

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -142,6 +142,8 @@ func (in *DNSRecordStatus) DeepCopyInto(out *DNSRecordStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.QueuedAt.DeepCopyInto(&out.QueuedAt)
+	in.QueuedFor.DeepCopyInto(&out.QueuedFor)
 	if in.Endpoints != nil {
 		in, out := &in.Endpoints, &out.Endpoints
 		*out = make([]*endpoint.Endpoint, len(*in))

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -330,6 +330,26 @@ spec:
                   it needs to retry the update for that specific zone.
                 format: int64
                 type: integer
+              queuedAt:
+                description: QueuedAt is a time when DNS record was received for the
+                  reconciliation
+                format: date-time
+                type: string
+              queuedFor:
+                description: QueuedFor is a time when we expect a DNS record to be
+                  reconciled again
+                format: date-time
+                type: string
+              validFor:
+                description: ValidFor indicates duration since the last reconciliation
+                  we consider data in the record to be valid
+                type: string
+              writeCounter:
+                description: WriteCounter represent a number of consecutive write
+                  attempts on the same generation of the record. It is being reset
+                  to 0 when the generation changes or there are no changes to write.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -330,6 +330,26 @@ spec:
                   it needs to retry the update for that specific zone.
                 format: int64
                 type: integer
+              queuedAt:
+                description: QueuedAt is a time when DNS record was received for the
+                  reconciliation
+                format: date-time
+                type: string
+              queuedFor:
+                description: QueuedFor is a time when we expect a DNS record to be
+                  reconciled again
+                format: date-time
+                type: string
+              validFor:
+                description: ValidFor indicates duration since the last reconciliation
+                  we consider data in the record to be valid
+                type: string
+              writeCounter:
+                description: WriteCounter represent a number of consecutive write
+                  attempts on the same generation of the record. It is being reset
+                  to 0 when the generation changes or there are no changes to write.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -31,7 +31,6 @@ import (
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
-	"github.com/kuadrant/dns-operator/internal/common/conditions"
 )
 
 var _ = Describe("DNSRecordReconciler", func() {
@@ -89,7 +88,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(dnsRecord.Status.Conditions).To(
 				ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Type":               Equal(string(conditions.ConditionTypeReady)),
+					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
 					"Status":             Equal(metav1.ConditionTrue),
 					"Reason":             Equal("ProviderSuccess"),
 					"Message":            Equal("Provider ensured the dns record"),
@@ -108,7 +107,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(dnsRecord.Status.Conditions).To(
 				ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Type":               Equal(string(conditions.ConditionTypeReady)),
+					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
 					"Status":             Equal(metav1.ConditionTrue),
 					"Reason":             Equal("ProviderSuccess"),
 					"Message":            Equal("Provider ensured the dns record"),

--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
@@ -53,19 +52,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				ManagedZoneRef: &v1alpha1.ManagedZoneReference{
 					Name: managedZone.Name,
 				},
-				Endpoints: []*externaldnsendpoint.Endpoint{
-					{
-						DNSName: "foo.example.com",
-						Targets: []string{
-							"127.0.0.1",
-						},
-						RecordType:       "A",
-						SetIdentifier:    "",
-						RecordTTL:        60,
-						Labels:           nil,
-						ProviderSpecific: nil,
-					},
-				},
+				Endpoints: getTestEndpoints(),
 			},
 		}
 	})
@@ -96,6 +83,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				})),
 			)
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+			g.Expect(dnsRecord.Status.WriteCounter).To(BeZero())
 		}, TestTimeoutMedium, time.Second).Should(Succeed())
 	})
 
@@ -142,6 +130,33 @@ var _ = Describe("DNSRecordReconciler", func() {
 			g.Expect(dnsRecord.Spec.OwnerID).To(PointTo(Equal("foobar")))
 		}, TestTimeoutMedium, time.Second).Should(Succeed())
 
+	})
+
+	It("should increase write counter if fail to publish record or record is overridden", func() {
+		dnsRecord.Spec.Endpoints = getTestNonExistingEndpoints()
+		Expect(k8sClient.Create(ctx, dnsRecord)).To(Succeed())
+
+		// should be requeue record for validation after the write attempt
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dnsRecord.Status.Conditions).To(
+				ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+					"Status":             Equal(metav1.ConditionFalse),
+					"Reason":             Equal("AwaitingValidation"),
+					"Message":            Equal("Awaiting validation"),
+					"ObservedGeneration": Equal(dnsRecord.Generation),
+				})),
+			)
+		}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+		// should be increasing write counter
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dnsRecord.Status.WriteCounter).To(BeNumerically(">", int64(0)))
+		}, TestTimeoutLong, time.Second).Should(Succeed())
 	})
 
 })

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	kuadrantdnsv1alpha1 "github.com/kuadrant/dns-operator/api/v1alpha1"
 )
@@ -14,6 +15,8 @@ const (
 	TestTimeoutMedium       = time.Second * 10
 	TestTimeoutLong         = time.Second * 30
 	TestRetryIntervalMedium = time.Millisecond * 250
+	RequeueDuration         = time.Second * 6
+	ValidityDuration        = time.Second * 3
 	defaultNS               = "default"
 	providerCredential      = "secretname"
 )
@@ -31,6 +34,38 @@ func testBuildManagedZone(name, ns, domainName string) *kuadrantdnsv1alpha1.Mana
 			SecretRef: kuadrantdnsv1alpha1.ProviderRef{
 				Name: "secretname",
 			},
+		},
+	}
+}
+
+func getTestEndpoints() []*externaldnsendpoint.Endpoint {
+	return []*externaldnsendpoint.Endpoint{
+		{
+			DNSName: "foo.example.com",
+			Targets: []string{
+				"127.0.0.1",
+			},
+			RecordType:       "A",
+			SetIdentifier:    "",
+			RecordTTL:        60,
+			Labels:           nil,
+			ProviderSpecific: nil,
+		},
+	}
+}
+
+func getTestNonExistingEndpoints() []*externaldnsendpoint.Endpoint {
+	return []*externaldnsendpoint.Endpoint{
+		{
+			DNSName: "nope.example.com",
+			Targets: []string{
+				"127.0.0.1",
+			},
+			RecordType:       "A",
+			SetIdentifier:    "",
+			RecordTTL:        60,
+			Labels:           nil,
+			ProviderSpecific: nil,
 		},
 	}
 }

--- a/internal/controller/managedzone_controller.go
+++ b/internal/controller/managedzone_controller.go
@@ -32,7 +32,6 @@ import (
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
-	"github.com/kuadrant/dns-operator/internal/common/conditions"
 	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
@@ -144,7 +143,7 @@ func (r *ManagedZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	managedZone.Status.ObservedGeneration = managedZone.Generation
-	setManagedZoneCondition(managedZone, string(conditions.ConditionTypeReady), status, reason, message)
+	setManagedZoneCondition(managedZone, string(v1alpha1.ConditionTypeReady), status, reason, message)
 	err = r.Status().Update(ctx, managedZone)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -192,7 +191,7 @@ func (r *ManagedZoneReconciler) deleteManagedZone(ctx context.Context, managedZo
 		reason = "ProviderError"
 		message = fmt.Sprintf("The DNS provider creation failed: %v", err)
 		managedZone.Status.ObservedGeneration = managedZone.Generation
-		setManagedZoneCondition(managedZone, string(conditions.ConditionTypeReady), status, reason, message)
+		setManagedZoneCondition(managedZone, string(v1alpha1.ConditionTypeReady), status, reason, message)
 		return err
 	}
 	err = dnsProvider.DeleteManagedZone(managedZone)
@@ -336,7 +335,7 @@ func (r *ManagedZoneReconciler) parentZoneNSRecordReady(ctx context.Context, man
 		}
 	}
 
-	nsRecordReady := meta.IsStatusConditionTrue(nsRecord.Status.Conditions, string(conditions.ConditionTypeReady))
+	nsRecordReady := meta.IsStatusConditionTrue(nsRecord.Status.Conditions, string(v1alpha1.ConditionTypeReady))
 	if !nsRecordReady {
 		return fmt.Errorf("the ns record is not in a ready state : %s", nsRecord.Name)
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -53,6 +53,11 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
+const (
+	RequeueDuration  = time.Minute * 1
+	ValidityDuration = time.Second * 30
+)
+
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
@@ -132,7 +137,7 @@ var _ = BeforeSuite(func() {
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: dnsProviderFactory,
-	}).SetupWithManager(mgr)
+	}).SetupWithManager(mgr, RequeueDuration, ValidityDuration)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -53,11 +53,6 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-const (
-	RequeueDuration  = time.Minute * 1
-	ValidityDuration = time.Second * 30
-)
-
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
@@ -67,7 +62,7 @@ var dnsProviderFactory = &providerFake.Factory{
 	ProviderForFunc: func(ctx context.Context, pa v1alpha1.ProviderAccessor, c provider.Config) (provider.Provider, error) {
 		return &providerFake.Provider{
 			RecordsFunc: func(context.Context) ([]*externaldnsendpoint.Endpoint, error) {
-				return []*externaldnsendpoint.Endpoint{}, nil
+				return getTestEndpoints(), nil
 			},
 			ApplyChangesFunc: func(context.Context, *externaldnsplan.Changes) error {
 				return nil

--- a/test/e2e/single_cluster_record_test.go
+++ b/test/e2e/single_cluster_record_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 						"Status": Equal(metav1.ConditionTrue),
 					})),
 				)
-			}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+			}, 5*time.Minute, 10*time.Second, ctx).Should(Succeed())
 
 			By("ensuring the authoritative nameserver resolves the hostname")
 			// speed up things by using the authoritative nameserver
@@ -213,7 +213,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 						"Status": Equal(metav1.ConditionTrue),
 					})),
 				)
-			}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+			}, 5*time.Minute, 10*time.Second, ctx).Should(Succeed())
 
 			By("ensuring the authoritative nameserver resolves the hostname")
 			// speed up things by using the authoritative nameserver
@@ -365,7 +365,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
-				}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+				}, 5*time.Minute, 10*time.Second, ctx).Should(Succeed())
 
 				By("ensuring the authoritative nameserver resolves the hostname")
 				// speed up things by using the authoritative nameserver
@@ -498,7 +498,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
-				}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+				}, 5*time.Minute, 10*time.Second, ctx).Should(Succeed())
 
 				By("ensuring the authoritative nameserver resolves the hostname")
 				// speed up things by using the authoritative nameserver

--- a/test/e2e/single_cluster_record_test.go
+++ b/test/e2e/single_cluster_record_test.go
@@ -17,7 +17,6 @@ import (
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
-	"github.com/kuadrant/dns-operator/internal/common/conditions"
 )
 
 var _ = Describe("Single Cluster Record Test", func() {
@@ -86,7 +85,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(dnsRecord.Status.Conditions).To(
 					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(string(conditions.ConditionTypeReady)),
+						"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
 						"Status": Equal(metav1.ConditionTrue),
 					})),
 				)
@@ -210,7 +209,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(dnsRecord.Status.Conditions).To(
 					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(string(conditions.ConditionTypeReady)),
+						"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
 						"Status": Equal(metav1.ConditionTrue),
 					})),
 				)
@@ -362,7 +361,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(dnsRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(string(conditions.ConditionTypeReady)),
+							"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
@@ -495,7 +494,7 @@ var _ = Describe("Single Cluster Record Test", func() {
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(dnsRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(string(conditions.ConditionTypeReady)),
+							"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)


### PR DESCRIPTION
After applying changes to the DNS provider ruqueue DNS Record for validation; mark the Record as ready only after the validation success. 
Also, reconcile records with a default timeout to ensure the validity of the content. 