### PR TITLE
Gh49 distributed dns plan

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -356,6 +356,7 @@ func (r *DNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord *v1alp
 		Policies: []externaldnsplan.Policy{policy},
 		Current:  zoneEndpoints,
 		Desired:  specEndpoints,
+		Previous: statusEndpoints,
 		//Note: We can't just filter domains by `managedZone.Spec.DomainName` it needs to be the exact root domain for this particular record
 		DomainFilter:   externaldnsendpoint.MatchAllDomainFilters{&rootDomainFilter},
 		ManagedRecords: managedDNSRecordTypes,

--- a/internal/external-dns/plan/labels.go
+++ b/internal/external-dns/plan/labels.go
@@ -1,0 +1,6 @@
+package plan
+
+const (
+	// OwnerLabelDeliminator is a deliminator used between owners in the OwnerLabelKey value when multiple owners are assigned.
+	OwnerLabelDeliminator = "&&"
+)

--- a/internal/external-dns/plan/plan.go
+++ b/internal/external-dns/plan/plan.go
@@ -18,7 +18,7 @@ package plan
 
 import (
 	"fmt"
-	"strconv"
+	"slices"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -35,6 +35,8 @@ type PropertyComparator func(name string, previous string, current string) bool
 type Plan struct {
 	// List of current records
 	Current []*endpoint.Endpoint
+	// List of the records that were successfully resolved by this instance previously.
+	Previous []*endpoint.Endpoint
 	// List of desired records
 	Desired []*endpoint.Endpoint
 	// Policies under which the desired changes are calculated
@@ -93,6 +95,8 @@ type planTableRow struct {
 	//
 	// [RFC 1034 3.6.2]: https://datatracker.ietf.org/doc/html/rfc1034#autoid-15
 	current []*endpoint.Endpoint
+	// previous corresponds to the list of records that were last used to create/update this dnsName.
+	previous []*endpoint.Endpoint
 	// candidates corresponds to the list of records which would like to have this dnsName.
 	candidates []*endpoint.Endpoint
 	// records is a grouping of current and candidates by record type, for example A, AAAA, CNAME.
@@ -104,6 +108,8 @@ type planTableRow struct {
 type domainEndpoints struct {
 	// current corresponds to existing record from the registry. Maybe nil if no current record of the type exists.
 	current *endpoint.Endpoint
+	// previous corresponds to the record which was previously used doe dnsName during the last create/update.
+	previous *endpoint.Endpoint
 	// candidates corresponds to the list of records which would like to have this dnsName.
 	candidates []*endpoint.Endpoint
 }
@@ -116,6 +122,12 @@ func (t planTable) addCurrent(e *endpoint.Endpoint) {
 	key := t.newPlanKey(e)
 	t.rows[key].current = append(t.rows[key].current, e)
 	t.rows[key].records[e.RecordType].current = e
+}
+
+func (t planTable) addPrevious(e *endpoint.Endpoint) {
+	key := t.newPlanKey(e)
+	t.rows[key].previous = append(t.rows[key].previous, e)
+	t.rows[key].records[e.RecordType].previous = e
 }
 
 func (t planTable) addCandidate(e *endpoint.Endpoint) {
@@ -156,76 +168,133 @@ func (p *Plan) Calculate() *Plan {
 	for _, current := range filterRecordsForPlan(p.Current, p.DomainFilter, p.ManagedRecords, p.ExcludeRecords) {
 		t.addCurrent(current)
 	}
+	for _, previous := range filterRecordsForPlan(p.Previous, p.DomainFilter, p.ManagedRecords, p.ExcludeRecords) {
+		t.addPrevious(previous)
+	}
 	for _, desired := range filterRecordsForPlan(p.Desired, p.DomainFilter, p.ManagedRecords, p.ExcludeRecords) {
 		t.addCandidate(desired)
 	}
 
-	changes := &externaldnsplan.Changes{}
+	managedChanges := managedRecordSetChanges{
+		ownerID:       p.OwnerID,
+		creates:       []*endpoint.Endpoint{},
+		deletes:       []*endpoint.Endpoint{},
+		updates:       []*endpointUpdate{},
+		dnsNameOwners: map[string][]string{},
+	}
 
 	for key, row := range t.rows {
-		// dns name not taken
+		if _, ok := managedChanges.dnsNameOwners[key.dnsName]; !ok {
+			managedChanges.dnsNameOwners[key.dnsName] = []string{}
+		}
+
+		// dns name not taken (Create)
 		if len(row.current) == 0 {
 			recordsByType := t.resolver.ResolveRecordTypes(key, row)
 			for _, records := range recordsByType {
 				if len(records.candidates) > 0 {
-					changes.Create = append(changes.Create, t.resolver.ResolveCreate(records.candidates))
+					managedChanges.creates = append(managedChanges.creates, t.resolver.ResolveCreate(records.candidates))
+					managedChanges.dnsNameOwners[key.dnsName] = []string{p.OwnerID}
 				}
 			}
 		}
 
-		// dns name released or possibly owned by a different external dns
+		// dns name released or possibly owned by a different external dns (Delete)
 		if len(row.current) > 0 && len(row.candidates) == 0 {
-			changes.Delete = append(changes.Delete, row.current...)
+			recordsByType := t.resolver.ResolveRecordTypes(key, row)
+			for _, records := range recordsByType {
+				if records.current != nil {
+					candidate := records.current.DeepCopy()
+					owners := []string{}
+					if endpointOwner, hasOwner := records.current.Labels[endpoint.OwnerLabelKey]; hasOwner && p.OwnerID != "" {
+						owners = strings.Split(endpointOwner, OwnerLabelDeliminator)
+						for i, v := range owners {
+							if v == p.OwnerID {
+								owners = append(owners[:i], owners[i+1:]...)
+								break
+							}
+						}
+						slices.Sort(owners)
+						owners = slices.Compact[[]string, string](owners)
+						candidate.Labels[endpoint.OwnerLabelKey] = strings.Join(owners, OwnerLabelDeliminator)
+						managedChanges.dnsNameOwners[key.dnsName] = append(managedChanges.dnsNameOwners[key.dnsName], owners...)
+					}
+
+					if len(owners) == 0 {
+						managedChanges.deletes = append(managedChanges.deletes, records.current)
+					} else {
+						//ToDO Not ideal that this is also manipulating the desired record values here but we dont know if
+						// the update was caused by the deletion of a record or not later so we have to remove the previous
+						// values from the desired like this for now.
+						if records.previous != nil && len(candidate.Targets) > 1 {
+							removeEndpointTargets(records.previous.Targets, candidate)
+						}
+						//ToDo Need a test that tests the deletion of a record with two owners who are adding the same value
+						// If you delete one owner record, it currently removes the endpoint form desired causing an invalid record
+
+						managedChanges.updates = append(managedChanges.updates, &endpointUpdate{desired: candidate, current: records.current, previous: records.previous})
+					}
+				}
+			}
 		}
 
-		// dns name is taken
+		// dns name is taken (Update)
 		if len(row.current) > 0 && len(row.candidates) > 0 {
-			creates := []*endpoint.Endpoint{}
-
 			// apply changes for each record type
 			recordsByType := t.resolver.ResolveRecordTypes(key, row)
 			for _, records := range recordsByType {
-				// record type not desired
-				if records.current != nil && len(records.candidates) == 0 {
-					changes.Delete = append(changes.Delete, records.current)
-				}
 
-				// new record type desired
-				if records.current == nil && len(records.candidates) > 0 {
-					update := t.resolver.ResolveCreate(records.candidates)
-					// creates are evaluated after all domain records have been processed to
-					// validate that this external dns has ownership claim on the domain before
-					// adding the records to planned changes.
-					creates = append(creates, update)
-				}
+				//ToDo Deal with record type changing
+				//ToDo Mark this is a conflict so we can propagate it out
+				//// record type not desired
+				//if records.current != nil && len(records.candidates) == 0 {
+				//	changes.Delete = append(changes.Delete, records.current)
+				//}
+				//
+				//// new record type desired
+				//if records.current == nil && len(records.candidates) > 0 {
+				//	update := t.resolver.ResolveCreate(records.candidates)
+				//	// creates are evaluated after all domain records have been processed to
+				//	// validate that this external dns has ownership claim on the domain before
+				//	// adding the records to planned changes.
+				//	creates = append(creates, update)
+				//}
 
 				// update existing record
 				if records.current != nil && len(records.candidates) > 0 {
-					update := t.resolver.ResolveUpdate(records.current, records.candidates)
+					candidate := t.resolver.ResolveUpdate(records.current, records.candidates)
+					current := records.current.DeepCopy()
+					if endpointOwner, hasOwner := current.Labels[endpoint.OwnerLabelKey]; hasOwner {
+						if p.OwnerID == "" {
+							// Only allow owned records to be updated by other owned records
+							//ToDo Mark this is a conflict so we can propagate it out
+							continue
+						}
 
-					if shouldUpdateTTL(update, records.current) || targetChanged(update, records.current) || p.shouldUpdateProviderSpecific(update, records.current) {
-						inheritOwner(records.current, update)
-						changes.UpdateNew = append(changes.UpdateNew, update)
-						changes.UpdateOld = append(changes.UpdateOld, records.current)
+						owners := strings.Split(endpointOwner, OwnerLabelDeliminator)
+						owners = append(owners, p.OwnerID)
+						slices.Sort(owners)
+						owners = slices.Compact[[]string, string](owners)
+						current.Labels[endpoint.OwnerLabelKey] = strings.Join(owners, OwnerLabelDeliminator)
+						managedChanges.dnsNameOwners[key.dnsName] = append(managedChanges.dnsNameOwners[key.dnsName], owners...)
+					} else {
+						if p.OwnerID != "" {
+							// Only allow unowned records to be updated by other unowned records
+							//ToDo Mark this is a conflict so we can propagate it out
+							continue
+						}
 					}
-				}
-			}
-
-			if len(creates) > 0 {
-				// only add creates if the external dns has ownership claim on the domain
-				ownersMatch := true
-				for _, current := range row.current {
-					if p.OwnerID != "" && !current.IsOwnedBy(p.OwnerID) {
-						ownersMatch = false
-					}
-				}
-
-				if ownersMatch {
-					changes.Create = append(changes.Create, creates...)
+					inheritOwner(current, candidate)
+					managedChanges.updates = append(managedChanges.updates, &endpointUpdate{desired: candidate, current: records.current, previous: records.previous})
 				}
 			}
 		}
+
+		slices.Sort(managedChanges.dnsNameOwners[key.dnsName])
+		managedChanges.dnsNameOwners[key.dnsName] = slices.Compact[[]string, string](managedChanges.dnsNameOwners[key.dnsName])
 	}
+
+	changes := managedChanges.Calculate()
 
 	for _, pol := range p.Policies {
 		changes = pol.Apply(changes)
@@ -234,8 +303,9 @@ func (p *Plan) Calculate() *Plan {
 	// filter out updates this external dns does not have ownership claim over
 	if p.OwnerID != "" {
 		changes.Delete = endpoint.FilterEndpointsByOwnerID(p.OwnerID, changes.Delete)
-		changes.UpdateOld = endpoint.FilterEndpointsByOwnerID(p.OwnerID, changes.UpdateOld)
-		changes.UpdateNew = endpoint.FilterEndpointsByOwnerID(p.OwnerID, changes.UpdateNew)
+		//ToDo Ideally we would still be able to ensure ownership on update
+		//changes.UpdateOld = endpoint.FilterEndpointsByOwnerID(p.OwnerID, changes.UpdateOld)
+		//changes.UpdateNew = endpoint.FilterEndpointsByOwnerID(p.OwnerID, changes.UpdateNew)
 	}
 
 	plan := &Plan{
@@ -258,8 +328,162 @@ func inheritOwner(from, to *endpoint.Endpoint) {
 	to.Labels[endpoint.OwnerLabelKey] = from.Labels[endpoint.OwnerLabelKey]
 }
 
+type endpointUpdate struct {
+	current  *endpoint.Endpoint
+	previous *endpoint.Endpoint
+	desired  *endpoint.Endpoint
+}
+
+func (e *endpointUpdate) ShouldUpdate() bool {
+	return shouldUpdateOwner(e.desired, e.current) || shouldUpdateTTL(e.desired, e.current) || targetChanged(e.desired, e.current) || shouldUpdateProviderSpecific(e.desired, e.current)
+}
+
+type managedRecordSetChanges struct {
+	ownerID       string
+	creates       []*endpoint.Endpoint
+	deletes       []*endpoint.Endpoint
+	updates       []*endpointUpdate
+	dnsNameOwners map[string][]string
+}
+
+func (e *managedRecordSetChanges) Calculate() *externaldnsplan.Changes {
+	changes := &externaldnsplan.Changes{
+		Create: e.creates,
+		Delete: e.deletes,
+	}
+
+	for _, update := range e.updates {
+		e.calculateDesired(update)
+		if update.ShouldUpdate() {
+			changes.UpdateNew = append(changes.UpdateNew, update.desired)
+			changes.UpdateOld = append(changes.UpdateOld, update.current)
+		}
+	}
+
+	return changes
+}
+
+// calculateDesired changes the value of update.desired based on all information (desired/current/previous) available about the endpoint.
+func (e *managedRecordSetChanges) calculateDesired(update *endpointUpdate) {
+	if e.ownerID == "" {
+		log.Debugf("skipping update of desired for %s, no ownerID set for plan", update.desired.DNSName)
+		return
+	}
+
+	// If the record is using a `SetIdentifier` the provider will only ever allow a single target value for any record type (A or CNAME)
+	// In the case just return and the desired target value will be used (i.e. AWS route53 geo or weighted records)
+	if update.current.SetIdentifier != "" {
+		log.Debugf("skipping update of desired for %s, has SetIdentifier", update.desired.DNSName)
+		return
+	}
+
+	currentCopy := update.current.DeepCopy()
+
+	// A Records can be merged, but we remove the known previous target values first in order to ensure potentially stale values are removed
+	if update.current.RecordType == endpoint.RecordTypeA {
+		if update.previous != nil {
+			removeEndpointTargets(update.previous.Targets, currentCopy)
+		}
+		mergeEndpointTargets(update.desired, currentCopy)
+	}
+
+	// CNAME records can be merged, it's expected that the provider implementation understands that a CNAME might have
+	// multiple target values and adjusts accordingly during apply.
+	if update.current.RecordType == endpoint.RecordTypeCNAME {
+		if update.previous != nil {
+			removeEndpointTargets(update.previous.Targets, currentCopy)
+		}
+		mergeEndpointTargets(update.desired, currentCopy)
+
+		//ToDo manirn Check this is actually needed, and if it is add a test that requires it to be here
+		if len(update.desired.Targets) <= 1 {
+			log.Infof("skipping check for managed dnsNames for CNAME with single target value")
+			return
+		}
+
+		desiredCopy := update.desired.DeepCopy()
+
+		// Calculate if any of the new desired targets are also managed dnsNames within this record set.
+		// If a target is not managed, do nothing and continue with the current targets.
+		// If a target is managed:
+		// - If after the update the dnsName will no longer be owned by this endpoint(update.desired), remove it from the list of targets.
+		// - If after the update the dnsName will have no owners (it's going to be deleted), remove it from the list of targets.
+		for idx := range desiredCopy.Targets {
+			t := desiredCopy.Targets[idx]
+			tDNSName := normalizeDNSName(t)
+			log.Debugf("checking target %s owners", t)
+			if tOwners, tIsManaged := e.dnsNameOwners[tDNSName]; tIsManaged {
+				log.Debugf("target dnsName %s is managed and has owners %v", tDNSName, tOwners)
+
+				// If the target has no owners we can just remove it
+				if len(tOwners) == 0 {
+					removeEndpointTarget(t, update.desired)
+					break
+				}
+
+				// Remove the target if there is no mutual ownership between the desired endpoint and the managed target
+				if eOwners, eIsManaged := e.dnsNameOwners[normalizeDNSName(desiredCopy.DNSName)]; eIsManaged {
+					hasMutualOwner := false
+					for _, ownerID := range eOwners {
+						if slices.Contains(tOwners, ownerID) {
+							hasMutualOwner = true
+							break
+						}
+					}
+					if !hasMutualOwner {
+						removeEndpointTarget(t, update.desired)
+					}
+				}
+
+			}
+		}
+	}
+}
+
+func removeEndpointTarget(target string, endpoint *endpoint.Endpoint) {
+	removeEndpointTargets([]string{target}, endpoint)
+}
+
+func removeEndpointTargets(targets []string, endpoint *endpoint.Endpoint) {
+	undesiredMap := map[string]string{}
+	for idx := range targets {
+		undesiredMap[targets[idx]] = targets[idx]
+	}
+	desiredTargets := []string{}
+	for idx := range endpoint.Targets {
+		if _, ok := undesiredMap[endpoint.Targets[idx]]; ok {
+			endpoint.DeleteProviderSpecificProperty(endpoint.Targets[idx])
+		} else {
+			desiredTargets = append(desiredTargets, endpoint.Targets[idx])
+		}
+	}
+	endpoint.Targets = desiredTargets
+}
+
+func mergeEndpointTargets(desired, current *endpoint.Endpoint) {
+	desired.Targets = append(desired.Targets, current.Targets...)
+	slices.Sort(desired.Targets)
+	desired.Targets = slices.Compact[[]string, string](desired.Targets)
+
+	for idx := range desired.Targets {
+		if val, ok := current.GetProviderSpecificProperty(desired.Targets[idx]); ok {
+			desired.DeleteProviderSpecificProperty(desired.Targets[idx])
+			desired.SetProviderSpecificProperty(desired.Targets[idx], val)
+		}
+	}
+}
+
 func targetChanged(desired, current *endpoint.Endpoint) bool {
 	return !desired.Targets.Same(current.Targets)
+}
+
+func shouldUpdateOwner(desired, current *endpoint.Endpoint) bool {
+	currentOwner, hasCurrentOwner := current.Labels[endpoint.OwnerLabelKey]
+	desiredOwner, hasDesiredOwner := desired.Labels[endpoint.OwnerLabelKey]
+	if hasCurrentOwner && hasDesiredOwner {
+		return currentOwner != desiredOwner
+	}
+	return false
 }
 
 func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
@@ -269,7 +493,7 @@ func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
 	return desired.RecordTTL != current.RecordTTL
 }
 
-func (p *Plan) shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
+func shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
 	desiredProperties := map[string]endpoint.ProviderSpecificProperty{}
 
 	for _, d := range desired.ProviderSpecific {
@@ -321,31 +545,6 @@ func normalizeDNSName(dnsName string) string {
 		s += "."
 	}
 	return s
-}
-
-// CompareBoolean is an implementation of PropertyComparator for comparing boolean-line values
-// For example external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-// If value doesn't parse as boolean, the defaultValue is used
-func CompareBoolean(defaultValue bool, name, current, previous string) bool {
-	var err error
-
-	v1, v2 := defaultValue, defaultValue
-
-	if previous != "" {
-		v1, err = strconv.ParseBool(previous)
-		if err != nil {
-			v1 = defaultValue
-		}
-	}
-
-	if current != "" {
-		v2, err = strconv.ParseBool(current)
-		if err != nil {
-			v2 = defaultValue
-		}
-	}
-
-	return v1 == v2
 }
 
 func IsManagedRecord(record string, managedRecords, excludeRecords []string) bool {

--- a/internal/external-dns/plan/plan_test.go
+++ b/internal/external-dns/plan/plan_test.go
@@ -571,8 +571,9 @@ func (suite *PlanTestSuite) TestSyncFirstRound() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRound() {
@@ -596,8 +597,9 @@ func (suite *PlanTestSuite) TestSyncSecondRound() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "owner conflict, cannot update 'foo' with no owner when existing record is already owned")
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRoundMigration() {
@@ -621,8 +623,9 @@ func (suite *PlanTestSuite) TestSyncSecondRoundMigration() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRoundWithTTLChange() {
@@ -646,8 +649,9 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithTTLChange() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificChange() {
@@ -671,8 +675,9 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificChange() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificRemoval() {
@@ -696,8 +701,9 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificRemoval() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificAddition() {
@@ -721,8 +727,9 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificAddition() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRoundWithOwnerInherited() {
@@ -757,8 +764,9 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithOwnerInherited() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestIdempotency() {
@@ -781,8 +789,9 @@ func (suite *PlanTestSuite) TestIdempotency() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestRecordTypeChange() {
@@ -808,8 +817,9 @@ func (suite *PlanTestSuite) TestRecordTypeChange() {
 		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestExistingCNameWithDualStackDesired() {
@@ -835,8 +845,9 @@ func (suite *PlanTestSuite) TestExistingCNameWithDualStackDesired() {
 		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestExistingDualStackWithCNameDesired() {
@@ -864,8 +875,9 @@ func (suite *PlanTestSuite) TestExistingDualStackWithCNameDesired() {
 		OwnerID:        suite.fooA5.Labels[endpoint.OwnerLabelKey],
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // TestExistingOwnerNotMatchingDualStackDesired validates that if there is an existing
@@ -895,8 +907,9 @@ func (suite *PlanTestSuite) TestExistingOwnerNotMatchingDualStackDesired() {
 		OwnerID:        "pwner",
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "record type conflict, cannot update 'foo' with record type 'CNAME' when record already exists with record type 'A'")
 }
 
 // TestConflictingCurrentNonConflictingDesired is a bit of a corner case as it would indicate
@@ -927,8 +940,9 @@ func (suite *PlanTestSuite) TestConflictingCurrentNonConflictingDesired() {
 		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // TestConflictingCurrentNoDesired is a bit of a corner case as it would indicate
@@ -958,8 +972,9 @@ func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
 		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // TestCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
@@ -989,8 +1004,9 @@ func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
 		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // TestNoCurrentWithConflictingDesired simulates where the desired records result in conflicting records types.
@@ -1017,8 +1033,9 @@ func (suite *PlanTestSuite) TestNoCurrentWithConflictingDesired() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestIgnoreTXT() {
@@ -1042,8 +1059,9 @@ func (suite *PlanTestSuite) TestIgnoreTXT() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestExcludeTXT() {
@@ -1068,8 +1086,9 @@ func (suite *PlanTestSuite) TestExcludeTXT() {
 		ExcludeRecords: []string{endpoint.RecordTypeTXT},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestIgnoreTargetCase() {
@@ -1092,8 +1111,9 @@ func (suite *PlanTestSuite) TestIgnoreTargetCase() {
 		Desired:  desired,
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestRemoveEndpoint() {
@@ -1117,8 +1137,9 @@ func (suite *PlanTestSuite) TestRemoveEndpoint() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "owner conflict, cannot update 'foo' with no owner when existing record is already owned")
 }
 
 func (suite *PlanTestSuite) TestRemoveEndpointWithUpsert() {
@@ -1142,8 +1163,9 @@ func (suite *PlanTestSuite) TestRemoveEndpointWithUpsert() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "owner conflict, cannot update 'foo' with no owner when existing record is already owned")
 }
 
 func (suite *PlanTestSuite) TestMultipleRecordsSameNameDifferentSetIdentifier() {
@@ -1167,8 +1189,9 @@ func (suite *PlanTestSuite) TestMultipleRecordsSameNameDifferentSetIdentifier() 
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestSetIdentifierUpdateCreatesAndDeletes() {
@@ -1192,8 +1215,9 @@ func (suite *PlanTestSuite) TestSetIdentifierUpdateCreatesAndDeletes() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestDomainFiltersInitial() {
@@ -1219,8 +1243,9 @@ func (suite *PlanTestSuite) TestDomainFiltersInitial() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestDomainFiltersUpdate() {
@@ -1246,8 +1271,9 @@ func (suite *PlanTestSuite) TestDomainFiltersUpdate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestAAAARecords() {
@@ -1269,8 +1295,9 @@ func (suite *PlanTestSuite) TestAAAARecords() {
 		ManagedRecords: []string{endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestDualStackRecords() {
@@ -1292,8 +1319,9 @@ func (suite *PlanTestSuite) TestDualStackRecords() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestDualStackRecordsDelete() {
@@ -1315,8 +1343,9 @@ func (suite *PlanTestSuite) TestDualStackRecordsDelete() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func (suite *PlanTestSuite) TestDualStackToSingleStack() {
@@ -1339,8 +1368,9 @@ func (suite *PlanTestSuite) TestDualStackToSingleStack() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Multiple Owner Tests
@@ -1366,8 +1396,9 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordCreate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should not merge targets of records with a shared dnsName, type and a set identifier.
@@ -1389,8 +1420,9 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordWithSetIdentifierCreate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should allow owned records to be updated from the creation of records with a shared dnsName and type by a plan with a different owner.
@@ -1414,8 +1446,9 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateCreate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should allow owned records to be updated from the change to a record with a shared dnsName and type by a plan with the same owner.
@@ -1441,12 +1474,12 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateSameOwner() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should not allow the update of a record with a shared dnsName to a different record type (A -> CNAME) (CONFLICT).
-// ToDo This needs to expose the conflicting endpoints
 func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateRecordTypeConflict() {
 	current := []*endpoint.Endpoint{suite.fooA1Owner1}
 	previous := []*endpoint.Endpoint{}
@@ -1467,8 +1500,9 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateRecordTypeConflict() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "record type conflict, cannot update 'foo' with record type 'CNAME' when record already exists with record type 'A'")
 }
 
 // Should not merge targets of records with a shared dnsName, type and set identifier.
@@ -1490,8 +1524,9 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateSameOwnerWithSetIdentifie
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should not allow owned records to be updated by a plan with no owner
@@ -1512,8 +1547,33 @@ func (suite *PlanTestSuite) TestNoPlanOwnerARecordUpdate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "owner conflict, cannot update 'foo' with no owner when existing record is already owned")
+}
+
+// Should not allow unowned records to be updated by a plan with an owner
+func (suite *PlanTestSuite) TestPlanOwnerARecordUpdateNoOwner() {
+	current := []*endpoint.Endpoint{suite.fooA1OwnerNone}
+	desired := []*endpoint.Endpoint{suite.fooA1OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "owner conflict, cannot update 'foo' with owner when existing record is not owned")
 }
 
 // Should not merge targets of unowned records with a shared dnsName and type
@@ -1534,8 +1594,9 @@ func (suite *PlanTestSuite) TestNoOwnerARecordUpdate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should only delete records solely owned by the plan owner and update records with shared ownership to remove the plan owner.
@@ -1559,8 +1620,9 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordDelete() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 //CNAME Records
@@ -1584,8 +1646,9 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordCreate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should not merge targets of records with a shared dnsName, type and a set identifier.
@@ -1607,8 +1670,9 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordWithSetIdentifierCreate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should allow owned records to be updated from the creation of records with a shared dnsName and type by a plan with a different owner.
@@ -1634,8 +1698,9 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateDifferentOwner() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should allow owned records to be updated from the change to a record with a shared dnsName and type by a plan with the same owner.
@@ -1660,12 +1725,12 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateSameOwner() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should not allow the update of a record with a shared dnsName to a different record type (CNAME -> A) (CONFLICT).
-// ToDo This needs to expose the conflicting endpoints
 func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateRecordTypeConflict() {
 	current := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1}
 	previous := []*endpoint.Endpoint{}
@@ -1686,8 +1751,9 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateRecordTypeConflict() 
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "record type conflict, cannot update 'foo' with record type 'A' when record already exists with record type 'CNAME'")
 }
 
 // Should not merge targets of records with a shared dnsName, type and set identifier.
@@ -1711,8 +1777,9 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateSameOwnerWithSetIdent
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should not allow owned records to be updated by a plan with no owner
@@ -1733,8 +1800,33 @@ func (suite *PlanTestSuite) TestNoPlanOwnerCNAMERecordUpdate() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "owner conflict, cannot update 'foo' with no owner when existing record is already owned")
+}
+
+// Should not allow unowned records to be updated by a plan with an owner
+func (suite *PlanTestSuite) TestPlanOwnerCNAMERecordUpdateNoOwner() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1OwnerNone}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv1OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.EqualError(suite.T(), cp.ConflictError(), "owner conflict, cannot update 'foo' with owner when existing record is not owned")
 }
 
 // Should not merge targets of unowned records with a shared dnsName and type
@@ -1755,8 +1847,9 @@ func (suite *PlanTestSuite) TestNoPlanOwnerCNAMERecordUpdateNoOwner() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 // Should only delete records solely owned by the plan owner and update records with shared ownership to remove the plan owner.
@@ -1781,8 +1874,9 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordDelete() {
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
-	changes := p.Calculate().Changes
-	validateChanges(suite.T(), changes, expectedChanges)
+	cp := p.Calculate()
+	validateChanges(suite.T(), cp.Changes, expectedChanges)
+	assert.Nil(suite.T(), cp.ConflictError())
 }
 
 func TestPlan(t *testing.T) {

--- a/internal/external-dns/plan/plan_test.go
+++ b/internal/external-dns/plan/plan_test.go
@@ -55,6 +55,45 @@ type PlanTestSuite struct {
 	domainFilterFiltered2            *endpoint.Endpoint
 	domainFilterFiltered3            *endpoint.Endpoint
 	domainFilterExcluded             *endpoint.Endpoint
+	//A Records
+	fooA1OwnerNone *endpoint.Endpoint
+	fooA2OwnerNone *endpoint.Endpoint
+	barA3OwnerNone *endpoint.Endpoint
+	barA4OwnerNone *endpoint.Endpoint
+	fooA1Owner1    *endpoint.Endpoint
+	fooA2Owner1    *endpoint.Endpoint
+	fooA2Owner2    *endpoint.Endpoint
+	fooA12Owner12  *endpoint.Endpoint
+	barA3Owner1    *endpoint.Endpoint
+	barA3Owner2    *endpoint.Endpoint
+	barA4Owner1    *endpoint.Endpoint
+	barA4Owner2    *endpoint.Endpoint
+	//A Records with SetIdentifier
+	fooA1Owner1WithSetIdentifier1 *endpoint.Endpoint
+	fooA2Owner1WithSetIdentifier1 *endpoint.Endpoint
+	fooA2Owner1WithSetIdentifier2 *endpoint.Endpoint
+	fooA2Owner2WithSetIdentifier2 *endpoint.Endpoint
+	//CNAME Records
+	fooCNAMEv1OwnerNone *endpoint.Endpoint
+	fooCNAMEv2OwnerNone *endpoint.Endpoint
+	barCNAMEv3OwnerNone *endpoint.Endpoint
+	barCNAMEv4OwnerNone *endpoint.Endpoint
+	fooCNAMEv1Owner1    *endpoint.Endpoint
+	fooCNAMEv2Owner1    *endpoint.Endpoint
+	fooCNAMEv2Owner2    *endpoint.Endpoint
+	fooCNAMEv12Owner12  *endpoint.Endpoint
+	barCNAMEv3Owner1    *endpoint.Endpoint
+	barCNAMEv3Owner2    *endpoint.Endpoint
+	barCNAMEv4Owner1    *endpoint.Endpoint
+	barCNAMEv4Owner2    *endpoint.Endpoint
+	barCNAMEv34Owner2   *endpoint.Endpoint
+	barCNAMEv34Owner12  *endpoint.Endpoint
+	//CNAME Records with SetIdentifier
+	fooCNAMEv1Owner1WithSetIdentifier1 *endpoint.Endpoint
+	fooCNAMEv1Owner2WithSetIdentifier1 *endpoint.Endpoint
+	fooCNAMEv2Owner1WithSetIdentifier1 *endpoint.Endpoint
+	fooCNAMEv2Owner1WithSetIdentifier2 *endpoint.Endpoint
+	fooCNAMEv2Owner2WithSetIdentifier2 *endpoint.Endpoint
 }
 
 func (suite *PlanTestSuite) SetupTest() {
@@ -247,6 +286,268 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"1.1.1.1"},
 		RecordType: "A",
 	}
+	//Muti Owner
+	// A Records
+	suite.fooA1OwnerNone = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"1.1.1.1"},
+	}
+	suite.fooA2OwnerNone = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"2.2.2.2"},
+	}
+	suite.barA3OwnerNone = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"3.3.3.3"},
+	}
+	suite.barA4OwnerNone = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"4.4.4.4"},
+	}
+	suite.fooA1Owner1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"1.1.1.1"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.fooA2Owner1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"2.2.2.2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.fooA2Owner2 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"2.2.2.2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+	}
+	suite.fooA12Owner12 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"1.1.1.1", "2.2.2.2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1&&owner2",
+		},
+	}
+	suite.barA3Owner1 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"3.3.3.3"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.barA3Owner2 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"3.3.3.3"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+	}
+	suite.barA4Owner1 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"4.4.4.4"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.barA4Owner2 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"4.4.4.4"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+	}
+	// A Records with SetIdentifier
+	suite.fooA1Owner1WithSetIdentifier1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"1.1.1.1"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+		SetIdentifier: "1",
+	}
+	suite.fooA2Owner1WithSetIdentifier1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"2.2.2.2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+		SetIdentifier: "1",
+	}
+	suite.fooA2Owner1WithSetIdentifier2 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"2.2.2.2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+		SetIdentifier: "2",
+	}
+	suite.fooA2Owner2WithSetIdentifier2 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "A",
+		Targets:    endpoint.Targets{"2.2.2.2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+		SetIdentifier: "2",
+	}
+
+	// CNAME Records
+	suite.fooCNAMEv1OwnerNone = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v1"},
+	}
+	suite.fooCNAMEv2OwnerNone = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v2"},
+	}
+	suite.barCNAMEv3OwnerNone = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v3"},
+	}
+	suite.barCNAMEv4OwnerNone = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v4"},
+	}
+	suite.fooCNAMEv1Owner1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v1"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.fooCNAMEv2Owner1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.fooCNAMEv2Owner2 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+	}
+	suite.fooCNAMEv12Owner12 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v1", "v2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1&&owner2",
+		},
+	}
+	suite.barCNAMEv3Owner1 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v3"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.barCNAMEv3Owner2 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v3"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+	}
+	suite.barCNAMEv4Owner1 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v4"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+	}
+	suite.barCNAMEv4Owner2 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v4"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+	}
+	suite.barCNAMEv34Owner2 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v3", "v4"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+	}
+	suite.barCNAMEv34Owner12 = &endpoint.Endpoint{
+		DNSName:    "bar",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v3", "v4"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1&&owner2",
+		},
+	}
+	// CNAME Records with SetIdentifier
+	suite.fooCNAMEv1Owner1WithSetIdentifier1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v1"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+		SetIdentifier: "1",
+	}
+	suite.fooCNAMEv2Owner1WithSetIdentifier1 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+		SetIdentifier: "1",
+	}
+	suite.fooCNAMEv2Owner1WithSetIdentifier2 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAMEA",
+		Targets:    endpoint.Targets{"v2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner1",
+		},
+		SetIdentifier: "2",
+	}
+	suite.fooCNAMEv2Owner2WithSetIdentifier2 = &endpoint.Endpoint{
+		DNSName:    "foo",
+		RecordType: "CNAME",
+		Targets:    endpoint.Targets{"v2"},
+		Labels: map[string]string{
+			endpoint.OwnerLabelKey: "owner2",
+		},
+		SetIdentifier: "2",
+	}
 }
 
 func (suite *PlanTestSuite) TestSyncFirstRound() {
@@ -425,6 +726,7 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificAddition() {
 }
 
 func (suite *PlanTestSuite) TestSyncSecondRoundWithOwnerInherited() {
+	suite.T().Skip("Skipping incompatible test")
 	current := []*endpoint.Endpoint{suite.fooV1Cname}
 	desired := []*endpoint.Endpoint{suite.fooV2Cname}
 
@@ -484,6 +786,7 @@ func (suite *PlanTestSuite) TestIdempotency() {
 }
 
 func (suite *PlanTestSuite) TestRecordTypeChange() {
+	suite.T().Skip("Skipping incompatible test, plan does not allow record types to change")
 	current := []*endpoint.Endpoint{suite.fooV1Cname}
 	desired := []*endpoint.Endpoint{suite.fooA5}
 	expectedCreate := []*endpoint.Endpoint{suite.fooA5}
@@ -510,6 +813,7 @@ func (suite *PlanTestSuite) TestRecordTypeChange() {
 }
 
 func (suite *PlanTestSuite) TestExistingCNameWithDualStackDesired() {
+	suite.T().Skip("Skipping incompatible test, plan does not allow record types to change")
 	current := []*endpoint.Endpoint{suite.fooV1Cname}
 	desired := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
 	expectedCreate := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
@@ -536,6 +840,7 @@ func (suite *PlanTestSuite) TestExistingCNameWithDualStackDesired() {
 }
 
 func (suite *PlanTestSuite) TestExistingDualStackWithCNameDesired() {
+	suite.T().Skip("Skipping incompatible test, plan does not allow record types to change")
 	suite.fooA5.Labels[endpoint.OwnerLabelKey] = "nerf"
 	suite.fooAAAA.Labels[endpoint.OwnerLabelKey] = "nerf"
 	current := []*endpoint.Endpoint{suite.fooA5, suite.fooAAAA}
@@ -599,6 +904,7 @@ func (suite *PlanTestSuite) TestExistingOwnerNotMatchingDualStackDesired() {
 // caching issues. In this case since the desired records are not conflicting
 // the updates will end up with the conflict resolved.
 func (suite *PlanTestSuite) TestConflictingCurrentNonConflictingDesired() {
+	suite.T().Skip("Skipping incompatible test, plan does not allow record types to change")
 	suite.fooA5.Labels[endpoint.OwnerLabelKey] = suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]
 	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5}
 	desired := []*endpoint.Endpoint{suite.fooA5}
@@ -660,6 +966,7 @@ func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
 // This could be the result of multiple sources generating conflicting records types. In this case the conflict
 // resolver should prefer the A and AAAA record candidate and delete the other records.
 func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
+	suite.T().Skip("Skipping incompatible test, plan does not allow record types to change")
 	suite.fooV1Cname.Labels[endpoint.OwnerLabelKey] = "nerf"
 	current := []*endpoint.Endpoint{suite.fooV1Cname}
 	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5, suite.fooAAAA}
@@ -1013,6 +1320,7 @@ func (suite *PlanTestSuite) TestDualStackRecordsDelete() {
 }
 
 func (suite *PlanTestSuite) TestDualStackToSingleStack() {
+	suite.T().Skip("Skipping incompatible test, plan does not allow record types to change")
 	current := []*endpoint.Endpoint{suite.dsA, suite.dsAAAA}
 	desired := []*endpoint.Endpoint{suite.dsA}
 	expectedDelete := []*endpoint.Endpoint{suite.dsAAAA}
@@ -1028,6 +1336,448 @@ func (suite *PlanTestSuite) TestDualStackToSingleStack() {
 		Policies:       []Policy{&SyncPolicy{}},
 		Current:        current,
 		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Multiple Owner Tests
+
+//A Records
+
+// Should create record with plan owner.
+func (suite *PlanTestSuite) TestMultiOwnerARecordCreate() {
+	current := []*endpoint.Endpoint{}
+	desired := []*endpoint.Endpoint{suite.fooA1Owner1}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{suite.fooA1Owner1.DeepCopy()},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner1",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not merge targets of records with a shared dnsName, type and a set identifier.
+func (suite *PlanTestSuite) TestMultiOwnerARecordWithSetIdentifierCreate() {
+	current := []*endpoint.Endpoint{suite.fooA1Owner1WithSetIdentifier1}
+	desired := []*endpoint.Endpoint{suite.fooA2Owner2WithSetIdentifier2}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{suite.fooA2Owner2WithSetIdentifier2.DeepCopy()},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should allow owned records to be updated from the creation of records with a shared dnsName and type by a plan with a different owner.
+func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateCreate() {
+	current := []*endpoint.Endpoint{suite.fooA1Owner1, suite.barA3Owner2}
+	previous := []*endpoint.Endpoint{suite.barA3Owner2}
+	desired := []*endpoint.Endpoint{suite.fooA2OwnerNone, suite.barA3Owner2}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooA1Owner1.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooA12Owner12.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Previous:       previous,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should allow owned records to be updated from the change to a record with a shared dnsName and type by a plan with the same owner.
+// Should remove the previous target value
+// Should merge targets of records with a shared dnsName and type.
+func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateSameOwner() {
+	current := []*endpoint.Endpoint{suite.barA3Owner2}
+	previous := []*endpoint.Endpoint{suite.barA3Owner2}
+	desired := []*endpoint.Endpoint{suite.barA4OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.barA3Owner2.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.barA4Owner2.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Previous:       previous,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not allow the update of a record with a shared dnsName to a different record type (A -> CNAME) (CONFLICT).
+// ToDo This needs to expose the conflicting endpoints
+func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateRecordTypeConflict() {
+	current := []*endpoint.Endpoint{suite.fooA1Owner1}
+	previous := []*endpoint.Endpoint{}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv1OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Previous:       previous,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not merge targets of records with a shared dnsName, type and set identifier.
+func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateSameOwnerWithSetIdentifier() {
+	current := []*endpoint.Endpoint{suite.fooA1Owner1WithSetIdentifier1}
+	desired := []*endpoint.Endpoint{suite.fooA2Owner1WithSetIdentifier1}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooA1Owner1WithSetIdentifier1.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooA2Owner1WithSetIdentifier1.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner1",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not allow owned records to be updated by a plan with no owner
+func (suite *PlanTestSuite) TestNoPlanOwnerARecordUpdate() {
+	current := []*endpoint.Endpoint{suite.fooA1Owner1}
+	desired := []*endpoint.Endpoint{suite.fooA2OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not merge targets of unowned records with a shared dnsName and type
+func (suite *PlanTestSuite) TestNoOwnerARecordUpdate() {
+	current := []*endpoint.Endpoint{suite.fooA1OwnerNone}
+	desired := []*endpoint.Endpoint{suite.fooA2OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooA1OwnerNone.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooA2OwnerNone.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should only delete records solely owned by the plan owner and update records with shared ownership to remove the plan owner.
+func (suite *PlanTestSuite) TestMultiOwnerARecordDelete() {
+	current := []*endpoint.Endpoint{suite.barA3Owner1, suite.barA4Owner2, suite.fooA12Owner12}
+	previous := []*endpoint.Endpoint{suite.barA4Owner2, suite.fooA2Owner2}
+	desired := []*endpoint.Endpoint{}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooA12Owner12.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooA1Owner1.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{suite.barA4Owner2.DeepCopy()},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		Previous:       previous,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+//CNAME Records
+
+// Should create record with plan owner.
+func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordCreate() {
+	current := []*endpoint.Endpoint{}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{suite.fooCNAMEv1Owner1.DeepCopy()},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner1",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not merge targets of records with a shared dnsName, type and a set identifier.
+func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordWithSetIdentifierCreate() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1WithSetIdentifier1}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv2Owner2WithSetIdentifier2}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{suite.fooCNAMEv2Owner2WithSetIdentifier2.DeepCopy()},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should allow owned records to be updated from the creation of records with a shared dnsName and type by a plan with a different owner.
+// ToDo Whether we do the merge targets of CNAMES or not needs to be decided on per provider basis
+// This can create invalid CNAME records for AWS currently
+func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateDifferentOwner() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1, suite.barCNAMEv3Owner2}
+	previous := []*endpoint.Endpoint{suite.barCNAMEv3Owner2}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv2OwnerNone, suite.barCNAMEv3Owner2}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooCNAMEv1Owner1.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooCNAMEv12Owner12.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Previous:       previous,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should allow owned records to be updated from the change to a record with a shared dnsName and type by a plan with the same owner.
+// Should remove the previous target value
+func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateSameOwner() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1, suite.barCNAMEv3Owner2}
+	previous := []*endpoint.Endpoint{suite.barCNAMEv3Owner2}
+	desired := []*endpoint.Endpoint{suite.barCNAMEv4Owner2}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.barCNAMEv3Owner2.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.barCNAMEv4Owner2.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Previous:       previous,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not allow the update of a record with a shared dnsName to a different record type (CNAME -> A) (CONFLICT).
+// ToDo This needs to expose the conflicting endpoints
+func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateRecordTypeConflict() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1}
+	previous := []*endpoint.Endpoint{}
+	desired := []*endpoint.Endpoint{suite.fooA1OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Previous:       previous,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not merge targets of records with a shared dnsName, type and set identifier.
+func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateSameOwnerWithSetIdentifier() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1WithSetIdentifier1}
+	previous := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1WithSetIdentifier1}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv2Owner1WithSetIdentifier1}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooCNAMEv1Owner1WithSetIdentifier1.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooCNAMEv2Owner1WithSetIdentifier1.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner1",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Previous:       previous,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not allow owned records to be updated by a plan with no owner
+func (suite *PlanTestSuite) TestNoPlanOwnerCNAMERecordUpdate() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1Owner1}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv2OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
+		UpdateNew: []*endpoint.Endpoint{},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should not merge targets of unowned records with a shared dnsName and type
+func (suite *PlanTestSuite) TestNoPlanOwnerCNAMERecordUpdateNoOwner() {
+	current := []*endpoint.Endpoint{suite.fooCNAMEv1OwnerNone}
+	desired := []*endpoint.Endpoint{suite.fooCNAMEv2OwnerNone}
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooCNAMEv1OwnerNone.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooCNAMEv2OwnerNone.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{},
+	}
+
+	p := &Plan{
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
+	}
+
+	changes := p.Calculate().Changes
+	validateChanges(suite.T(), changes, expectedChanges)
+}
+
+// Should only delete records solely owned by the plan owner and update records with shared ownership to remove the plan owner.
+func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordDelete() {
+	current := []*endpoint.Endpoint{suite.barCNAMEv3Owner1, suite.barCNAMEv4Owner2, suite.fooCNAMEv12Owner12}
+	previous := []*endpoint.Endpoint{suite.barCNAMEv4Owner2, suite.fooCNAMEv2Owner2}
+	desired := []*endpoint.Endpoint{}
+
+	expectedChanges := &plan.Changes{
+		Create:    []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{suite.fooCNAMEv12Owner12.DeepCopy()},
+		UpdateNew: []*endpoint.Endpoint{suite.fooCNAMEv1Owner1.DeepCopy()},
+		Delete:    []*endpoint.Endpoint{suite.barCNAMEv4Owner2.DeepCopy()},
+	}
+
+	p := &Plan{
+		OwnerID:        "owner2",
+		Policies:       []Policy{&SyncPolicy{}},
+		Current:        current,
+		Desired:        desired,
+		Previous:       previous,
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1197,12 +1947,7 @@ func TestShouldUpdateProviderSpecific(tt *testing.T) {
 		},
 	} {
 		tt.Run(test.name, func(t *testing.T) {
-			plan := &Plan{
-				Current:        []*endpoint.Endpoint{test.current},
-				Desired:        []*endpoint.Endpoint{test.desired},
-				ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
-			}
-			b := plan.shouldUpdateProviderSpecific(test.desired, test.current)
+			b := shouldUpdateProviderSpecific(test.desired, test.current)
 			assert.Equal(t, test.shouldUpdate, b)
 		})
 	}

--- a/internal/external-dns/registry/txt.go
+++ b/internal/external-dns/registry/txt.go
@@ -246,9 +246,10 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 // for each created/deleted record it will also take into account TXT records for creation/deletion
 func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	filteredChanges := &plan.Changes{
-		Create:    changes.Create,
-		UpdateNew: endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.UpdateNew),
-		UpdateOld: endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.UpdateOld),
+		Create: changes.Create,
+		//ToDo Ideally we would still be able to ensure ownership on update
+		UpdateNew: changes.UpdateNew,
+		UpdateOld: changes.UpdateOld,
 		Delete:    endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.Delete),
 	}
 	for _, r := range filteredChanges.Create {

--- a/internal/external-dns/registry/txt_test.go
+++ b/internal/external-dns/registry/txt_test.go
@@ -841,9 +841,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
@@ -858,12 +856,8 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
 		},
-		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
-		},
-		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
-		},
+		UpdateNew: []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -1414,12 +1408,8 @@ func TestNewTXTScheme(t *testing.T) {
 		Delete: []*endpoint.Endpoint{
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
 		},
-		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
-		},
-		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
-		},
+		UpdateNew: []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{

--- a/internal/provider/aws/aws.go
+++ b/internal/provider/aws/aws.go
@@ -44,8 +44,8 @@ const (
 	providerSpecificGeolocationContinentCode = "aws/geolocation-continent-code"
 	awsBatchChangeSize                       = 1000
 	awsBatchChangeInterval                   = time.Second
-	awsEvaluateTargetHealth                  = true
-	awsPreferCNAME                           = false
+	awsEvaluateTargetHealth                  = false
+	awsPreferCNAME                           = true
 	awsZoneCacheDuration                     = 0 * time.Second
 )
 

--- a/test/e2e/multi_record_test.go
+++ b/test/e2e/multi_record_test.go
@@ -1,0 +1,756 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+)
+
+// Test Cases covering multiple DNSRecords updating a set of records in a zone
+var _ = Describe("Multi Record Test", func() {
+	// testID is a randomly generated identifier for the test
+	// it is used to name resources and/or namespaces so different
+	// tests can be run in parallel in the same cluster
+	var testID string
+	// testDomainName generated domain for this test e.g. t-e2e-12345.e2e.hcpapps.net
+	var testDomainName string
+	// testHostname generated hostname for this test e.g. t-gw-mgc-12345.t-e2e-12345.e2e.hcpapps.net
+	var testHostname string
+
+	var dnsRecord1 *v1alpha1.DNSRecord
+	var dnsRecord2 *v1alpha1.DNSRecord
+	var geoCode1 string
+	var geoCode2 string
+
+	BeforeEach(func(ctx SpecContext) {
+		testID = "t-multi-" + GenerateName()
+		testDomainName = strings.Join([]string{testSuiteID, testZoneDomainName}, ".")
+		testHostname = strings.Join([]string{testID, testDomainName}, ".")
+
+		if testDNSProvider == "gcp" {
+			geoCode1 = "us-east1"
+			geoCode2 = "europe-west1"
+		} else {
+			geoCode1 = "US"
+			geoCode2 = "EU"
+		}
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		if dnsRecord1 != nil {
+			err := k8sClient.Delete(ctx, dnsRecord1,
+				client.PropagationPolicy(metav1.DeletePropagationForeground))
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		}
+		if dnsRecord2 != nil {
+			err := k8sClient.Delete(ctx, dnsRecord2,
+				client.PropagationPolicy(metav1.DeletePropagationForeground))
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		}
+	})
+
+	Context("with ownerID", func() {
+		Context("simple", func() {
+			It("makes available a hostname that can be resolved", func(ctx SpecContext) {
+				By("creating two dns records")
+				testTargetIP1 := "127.0.0.1"
+				testTargetIP2 := "127.0.0.2"
+
+				dnsRecord1 = &v1alpha1.DNSRecord{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testID + "-1",
+						Namespace: testNamespace,
+					},
+					Spec: v1alpha1.DNSRecordSpec{
+						ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+							Name: testManagedZoneName,
+						},
+						Endpoints: []*externaldnsendpoint.Endpoint{
+							{
+								DNSName: testHostname,
+								Targets: []string{
+									testTargetIP1,
+								},
+								RecordType: "A",
+								RecordTTL:  60,
+							},
+						},
+						OwnerID: ptr.To("test-owner-1"),
+					},
+				}
+
+				dnsRecord2 = &v1alpha1.DNSRecord{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testID + "-2",
+						Namespace: testNamespace,
+					},
+					Spec: v1alpha1.DNSRecordSpec{
+						ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+							Name: testManagedZoneName,
+						},
+						Endpoints: []*externaldnsendpoint.Endpoint{
+							{
+								DNSName: testHostname,
+								Targets: []string{
+									testTargetIP2,
+								},
+								RecordType: "A",
+								RecordTTL:  60,
+							},
+						},
+						OwnerID: ptr.To("test-owner-2"),
+					},
+				}
+
+				By("creating dnsrecord " + dnsRecord1.Name)
+				err := k8sClient.Create(ctx, dnsRecord1)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("creating dnsrecord " + dnsRecord1.Name)
+				err = k8sClient.Create(ctx, dnsRecord2)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("checking the dns records becomes ready")
+				Eventually(func(g Gomega, ctx context.Context) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord1), dnsRecord1)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(dnsRecord1.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+					err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord2), dnsRecord2)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(dnsRecord2.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+				}, 1*time.Minute, 10*time.Second, ctx).Should(Succeed())
+
+				By("ensuring the authoritative nameserver resolves the hostname")
+				// speed up things by using the authoritative nameserver
+				authoritativeResolver := ResolverForDomainName(testZoneDomainName)
+				Eventually(func(g Gomega, ctx context.Context) {
+					ips, err := authoritativeResolver.LookupHost(ctx, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(ips).To(ConsistOf(testTargetIP1, testTargetIP2))
+				}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+
+				testProvider, err := providerForManagedZone(ctx, testManagedZone)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("ensuring zone records are created as expected")
+				Eventually(func(g Gomega, ctx context.Context) {
+					zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(zoneEndpoints).To(HaveLen(2))
+					g.Expect(zoneEndpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(testHostname),
+							"Targets":       ConsistOf(testTargetIP1, testTargetIP2),
+							"RecordType":    Equal("A"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-a-" + testHostname),
+							"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1&&test-owner-2\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						})),
+					))
+				}, 5*time.Second, 1*time.Second, ctx).Should(Succeed())
+
+				By("deleting dnsrecord " + dnsRecord2.Name)
+				err = k8sClient.Delete(ctx, dnsRecord2,
+					client.PropagationPolicy(metav1.DeletePropagationForeground))
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+				By("checking dnsrecord " + dnsRecord2.Name + " is removed")
+				Eventually(func(g Gomega, ctx context.Context) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord2), dnsRecord2)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, 10*time.Second, 1*time.Second, ctx).Should(Succeed())
+
+				By("ensuring the authoritative nameserver resolves the hostname")
+				Eventually(func(g Gomega, ctx context.Context) {
+					ips, err := authoritativeResolver.LookupHost(ctx, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(ips).To(ConsistOf(testTargetIP1))
+				}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+
+				By("ensuring zone records are updated as expected")
+				Eventually(func(g Gomega, ctx context.Context) {
+					zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(zoneEndpoints).To(HaveLen(2))
+					g.Expect(zoneEndpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(testHostname),
+							"Targets":       ConsistOf(testTargetIP1),
+							"RecordType":    Equal("A"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-a-" + testHostname),
+							"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						})),
+					))
+				}, 5*time.Second, 1*time.Second, ctx).Should(Succeed())
+
+				By("deleting dnsrecord " + dnsRecord1.Name)
+				err = k8sClient.Delete(ctx, dnsRecord1,
+					client.PropagationPolicy(metav1.DeletePropagationForeground))
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+				By("checking dnsrecord " + dnsRecord1.Name + " is removed")
+				Eventually(func(g Gomega, ctx context.Context) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord1), dnsRecord1)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, 10*time.Second, 1*time.Second, ctx).Should(Succeed())
+
+				By("ensuring zone records are all removed as expected")
+				Eventually(func(g Gomega, ctx context.Context) {
+					zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(zoneEndpoints).To(HaveLen(0))
+				}, 5*time.Second, 1*time.Second, ctx).Should(Succeed())
+			})
+		})
+
+		Context("loadbalanced", func() {
+			It("makes available a hostname that can be resolved", func(ctx SpecContext) {
+				By("creating two dns records")
+				klbHostName := "klb." + testHostname
+
+				testTargetIP1 := "127.0.0.1"
+				geo1KlbHostName := strings.ToLower(geoCode1) + "." + klbHostName
+				cluster1KlbHostName := "cluster1." + klbHostName
+
+				testTargetIP2 := "127.0.0.2"
+				geo2KlbHostName := strings.ToLower(geoCode2) + "." + klbHostName
+				cluster2KlbHostName := "cluster2." + klbHostName
+
+				dnsRecord1 = &v1alpha1.DNSRecord{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testID + "-1",
+						Namespace: testNamespace,
+					},
+					Spec: v1alpha1.DNSRecordSpec{
+						ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+							Name: testManagedZoneName,
+						},
+						Endpoints: []*externaldnsendpoint.Endpoint{
+							{
+								DNSName: cluster1KlbHostName,
+								Targets: []string{
+									testTargetIP1,
+								},
+								RecordType: "A",
+								RecordTTL:  60,
+							},
+							{
+								DNSName: testHostname,
+								Targets: []string{
+									klbHostName,
+								},
+								RecordType: "CNAME",
+								RecordTTL:  300,
+							},
+							{
+								DNSName: geo1KlbHostName,
+								Targets: []string{
+									cluster1KlbHostName,
+								},
+								RecordType:    "CNAME",
+								RecordTTL:     60,
+								SetIdentifier: cluster1KlbHostName,
+								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "200",
+									},
+								},
+							},
+							{
+								DNSName: klbHostName,
+								Targets: []string{
+									geo1KlbHostName,
+								},
+								RecordType:    "CNAME",
+								RecordTTL:     300,
+								SetIdentifier: geoCode1,
+								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+									{
+										Name:  "geo-code",
+										Value: geoCode1,
+									},
+								},
+							},
+							{
+								DNSName: klbHostName,
+								Targets: []string{
+									geo1KlbHostName,
+								},
+								RecordType:    "CNAME",
+								RecordTTL:     300,
+								SetIdentifier: "default",
+								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+									{
+										Name:  "geo-code",
+										Value: "*",
+									},
+								},
+							},
+						},
+						OwnerID: ptr.To("test-owner-1"),
+					},
+				}
+
+				dnsRecord2 = &v1alpha1.DNSRecord{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testID + "-2",
+						Namespace: testNamespace,
+					},
+					Spec: v1alpha1.DNSRecordSpec{
+						ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+							Name: testManagedZoneName,
+						},
+						Endpoints: []*externaldnsendpoint.Endpoint{
+							{
+								DNSName: cluster2KlbHostName,
+								Targets: []string{
+									testTargetIP2,
+								},
+								RecordType: "A",
+								RecordTTL:  60,
+							},
+							{
+								DNSName: testHostname,
+								Targets: []string{
+									klbHostName,
+								},
+								RecordType: "CNAME",
+								RecordTTL:  300,
+							},
+							{
+								DNSName: geo2KlbHostName,
+								Targets: []string{
+									cluster2KlbHostName,
+								},
+								RecordType:    "CNAME",
+								RecordTTL:     60,
+								SetIdentifier: cluster2KlbHostName,
+								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "200",
+									},
+								},
+							},
+							{
+								DNSName: klbHostName,
+								Targets: []string{
+									geo2KlbHostName,
+								},
+								RecordType:    "CNAME",
+								RecordTTL:     300,
+								SetIdentifier: geoCode2,
+								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+									{
+										Name:  "geo-code",
+										Value: geoCode2,
+									},
+								},
+							},
+							//Note this dnsRecord has no default geo ....
+						},
+						OwnerID: ptr.To("test-owner-2"),
+					},
+				}
+
+				By("creating dnsrecord " + dnsRecord1.Name)
+				err := k8sClient.Create(ctx, dnsRecord1)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("creating dnsrecord " + dnsRecord2.Name)
+				err = k8sClient.Create(ctx, dnsRecord2)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("checking the dns records become ready")
+				Eventually(func(g Gomega, ctx context.Context) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord1), dnsRecord1)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(dnsRecord1.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+					err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord2), dnsRecord2)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(dnsRecord2.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+				}, 5*time.Minute, 10*time.Second, ctx).Should(Succeed())
+
+				By("ensuring the authoritative nameserver resolves the hostname")
+				// speed up things by using the authoritative nameserver
+				authoritativeResolver := ResolverForDomainName(testZoneDomainName)
+				Eventually(func(g Gomega, ctx context.Context) {
+					ips, err := authoritativeResolver.LookupHost(ctx, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					GinkgoWriter.Printf("[debug] ips: %v\n", ips)
+					g.Expect(ips).To(Or(ContainElement(testTargetIP1), ContainElement(testTargetIP2)))
+				}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+
+				testProvider, err := providerForManagedZone(ctx, testManagedZone)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("ensuring zone records are created as expected")
+				zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
+				Expect(err).NotTo(HaveOccurred())
+				if testDNSProvider == "gcp" {
+					Expect(zoneEndpoints).To(HaveLen(12))
+					//Main Records
+					By("checking endpoint " + testHostname)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(testHostname),
+						"Targets":       ConsistOf(klbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					By("checking endpoint " + klbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(klbHostName),
+						"Targets":       ConsistOf(geo1KlbHostName, geo2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": ContainElements(
+							externaldnsendpoint.ProviderSpecificProperty{Name: "routingpolicy", Value: "geo"},
+							externaldnsendpoint.ProviderSpecificProperty{Name: geo1KlbHostName, Value: geoCode1},
+							externaldnsendpoint.ProviderSpecificProperty{Name: geo2KlbHostName, Value: geoCode2},
+						),
+					}))))
+					By("checking endpoint " + geo1KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(geo1KlbHostName),
+						"Targets":       ConsistOf(cluster1KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": ContainElements(
+							externaldnsendpoint.ProviderSpecificProperty{Name: "routingpolicy", Value: "weighted"},
+							externaldnsendpoint.ProviderSpecificProperty{Name: cluster1KlbHostName, Value: "200"},
+						),
+					}))))
+					By("checking endpoint " + geo2KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(geo2KlbHostName),
+						"Targets":       ConsistOf(cluster2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": ContainElements(
+							externaldnsendpoint.ProviderSpecificProperty{Name: "routingpolicy", Value: "weighted"},
+							externaldnsendpoint.ProviderSpecificProperty{Name: cluster2KlbHostName, Value: "200"},
+						),
+					}))))
+					By("checking endpoint " + cluster1KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(cluster1KlbHostName),
+						"Targets":       ConsistOf(testTargetIP1),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					}))))
+					By("checking endpoint " + cluster2KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(cluster2KlbHostName),
+						"Targets":       ConsistOf(testTargetIP2),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					}))))
+					//Txt Records
+					By("checking TXT owner endpoints")
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + testHostname),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1&&test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1&&test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geo1KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geo2KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-a-" + cluster2KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+				}
+				if testDNSProvider == "aws" {
+					Expect(zoneEndpoints).To(HaveLen(16))
+					//Main Records
+					By("checking endpoint " + testHostname)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(testHostname),
+						"Targets":       ConsistOf(klbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					By("checking endpoint " + klbHostName + " - " + geoCode1)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(klbHostName),
+						"Targets":       ConsistOf(geo1KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(geoCode1),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: "aws/geolocation-country-code", Value: "US"},
+						}),
+					}))))
+					By("checking endpoint " + klbHostName + " - " + geoCode2)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(klbHostName),
+						"Targets":       ConsistOf(geo2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(geoCode2),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: "aws/geolocation-continent-code", Value: "EU"},
+						}),
+					}))))
+					By("checking endpoint " + klbHostName + " - " + geoCode1)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(klbHostName),
+						"Targets":       ConsistOf(geo1KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal("default"),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: "aws/geolocation-country-code", Value: "*"},
+						}),
+					}))))
+					By("checking endpoint " + geo1KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(geo1KlbHostName),
+						"Targets":       ConsistOf(cluster1KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(cluster1KlbHostName),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: "aws/weight", Value: "200"},
+						}),
+					}))))
+					By("checking endpoint " + geo2KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(geo2KlbHostName),
+						"Targets":       ConsistOf(cluster2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(cluster2KlbHostName),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: "aws/weight", Value: "200"},
+						}),
+					}))))
+					By("checking endpoint " + cluster1KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(cluster1KlbHostName),
+						"Targets":       ConsistOf(testTargetIP1),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					}))))
+					By("checking endpoint " + cluster2KlbHostName)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(cluster2KlbHostName),
+						"Targets":       ConsistOf(testTargetIP2),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					}))))
+					//Txt Records
+					By("checking TXT owner endpoints")
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + testHostname),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1&&test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(geoCode1),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "aws/geolocation-country-code", Value: "US"},
+						}),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(geoCode2),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "aws/geolocation-continent-code", Value: "EU"},
+						}),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal("default"),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "aws/geolocation-country-code", Value: "*"},
+						}),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geo1KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(cluster1KlbHostName),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "aws/weight", Value: "200"},
+						}),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geo2KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(cluster2KlbHostName),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "aws/weight", Value: "200"},
+						}),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-1\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-a-" + cluster2KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=test-owner-2\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+				}
+
+				By("deleting dnsrecord " + dnsRecord2.Name)
+				err = k8sClient.Delete(ctx, dnsRecord2,
+					client.PropagationPolicy(metav1.DeletePropagationForeground))
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+				By("checking dnsrecord " + dnsRecord2.Name + " is removed")
+				Eventually(func(g Gomega, ctx context.Context) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord2), dnsRecord2)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, 10*time.Second, 1*time.Second, ctx).Should(Succeed())
+
+				By("ensuring the authoritative nameserver resolves the hostname")
+				Eventually(func(g Gomega, ctx context.Context) {
+					ips, err := authoritativeResolver.LookupHost(ctx, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					GinkgoWriter.Printf("[debug] ips: %v\n", ips)
+					g.Expect(ips).To(ConsistOf(testTargetIP1))
+				}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
+
+				By("ensuring zone records are updated as expected")
+				//ToDo mnairn Add more checks in here
+
+				By("deleting dnsrecord " + dnsRecord1.Name)
+				err = k8sClient.Delete(ctx, dnsRecord1,
+					client.PropagationPolicy(metav1.DeletePropagationForeground))
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+				By("checking dnsrecord " + dnsRecord1.Name + " is removed")
+				Eventually(func(g Gomega, ctx context.Context) {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord1), dnsRecord1)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, 10*time.Second, 1*time.Second, ctx).Should(Succeed())
+
+				By("ensuring zone records are all removed as expected")
+				Eventually(func(g Gomega, ctx context.Context) {
+					zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(zoneEndpoints).To(HaveLen(0))
+				}, 5*time.Second, 1*time.Second, ctx).Should(Succeed())
+
+			})
+		})
+	})
+
+})

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -19,7 +19,8 @@ import (
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
-var _ = Describe("Single Cluster Record Test", func() {
+// Test Cases covering a single DNSRecord updating a set of records in a zone
+var _ = Describe("Single Record Test", func() {
 	// testID is a randomly generated identifier for the test
 	// it is used to name resources and/or namespaces so different
 	// tests can be run in parallel in the same cluster

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/goombaio/namegenerator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -62,6 +64,9 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func(ctx SpecContext) {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	//Disable default External DNS logger
+	logrus.SetOutput(io.Discard)
 
 	err := setConfigFromEnvVars()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
closes #49 #85 

Initial work to modify the external-dns plan to work in the proposed way for distubuted dns.

Updates the plan to treat all endpoints passed to it (current/desired) as part of a single shared set of records. The calculation logic now takes into account other endpoints added to the plan when calculating the desired changes for any other endpoint also added.

The plan calculation logic is broken into two steps:

1. Calculate what endpoints will be created/updated and deleted based on the current and desired records passed to the plan. For each endpoint that will still exist if these changes were to be applied(create/update), a map of dnsNames and their owners is calculated.

2. Create the external-dns Changes for the endpoints calculated in step one. For all endpoints calculated to be an update the target values are re-calculated using the information gathered in step one about ownership of dnsNames. If we detect that a CNAME has a "managed" target value (it's in our owner map) we use the information known about who owns it to manipulate the desired targets values.