### PR TITLE
Randomize duration bug

### DIFF
--- a/internal/common/helper.go
+++ b/internal/common/helper.go
@@ -9,6 +9,10 @@ import (
 // RandomizeDuration randomizes duration for a given variance.
 // variance is expected to be of a format 0.1 for 10%, 0.5 for 50% and so on
 func RandomizeDuration(variance float64, duration time.Duration) time.Duration {
+	// do not allow less than a second requeue
+	if duration.Milliseconds() < 1000 {
+		duration = time.Second * 1
+	}
 	// we won't go smaller than a second - using milliseconds to have a relatively big number to randomize
 	millisecond := float64(duration.Milliseconds())
 

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -47,11 +47,12 @@ const (
 	DNSRecordFinalizer        = "kuadrant.io/dns-record"
 	WriteCounterLimit         = 20
 	validationRequeueVariance = 0.5
+	DefaultValidationDuration = time.Second * 5
 )
 
 var (
 	defaultRequeueTime    time.Duration
-	validationRequeueTime = time.Millisecond * 5000
+	validationRequeueTime time.Duration
 	noRequeueDuration     = time.Duration(0)
 	validFor              time.Duration
 	reconcileStart                    = metav1.Time{}
@@ -75,7 +76,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	reconcileStart = metav1.Now()
 
 	// randomize validation reconcile delay
-	validationRequeueTime = common.RandomizeDuration(validationRequeueVariance, validationRequeueTime)
+	validationRequeueTime = common.RandomizeDuration(validationRequeueVariance, DefaultValidationDuration)
 
 	previous := &v1alpha1.DNSRecord{}
 	err := r.Client.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.Name}, previous)


### PR DESCRIPTION
prevent usage of `randomizeDuration()` for less than a second and address an issue when it would randomize itself into zero duration 