### PR TITLE
fix: Ignore managed zone missing errors on deletion

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -90,7 +90,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	dnsRecord := previous.DeepCopy()
 
 	if dnsRecord.DeletionTimestamp != nil && !dnsRecord.DeletionTimestamp.IsZero() {
-		if err := r.ReconcileHealthChecks(ctx, dnsRecord); err != nil {
+		if err := r.ReconcileHealthChecks(ctx, dnsRecord); client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
 		requeueTime, err := r.deleteRecord(ctx, dnsRecord)


### PR DESCRIPTION
When we are deleting a DNSRecord we just ignore all errors relating to the ManagedZone being missing since there is nothing we can do about it, and we don't want the record staying around forever.

Check was missing for health checks
https://github.com/Kuadrant/dns-operator/pull/78