### PR TITLE
fix: Handle wildcard rootHost values

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -301,7 +301,7 @@ func (r *DNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord *v1alp
 	logger := log.FromContext(ctx)
 	filterDomain, _ := strings.CutPrefix(managedZone.Spec.DomainName, v1alpha1.WildcardPrefix)
 	if dnsRecord.Spec.RootHost != nil {
-		filterDomain = *dnsRecord.Spec.RootHost
+		filterDomain, _ = strings.CutPrefix(*dnsRecord.Spec.RootHost, v1alpha1.WildcardPrefix)
 	}
 	rootDomainFilter := externaldnsendpoint.NewDomainFilter([]string{filterDomain})
 


### PR DESCRIPTION
closes #88 

Fixes an issue where if you specify a wildcard rootHost value e.g. *.example.com the plan would incorrectly filter out changes for valid dnsNames e.g. foo.example.com, and only create exactly matching dnsNames e.g. *.example.com.