### PR TITLE
Root host target checks

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -299,11 +299,12 @@ func (r *DNSRecordReconciler) getDNSProvider(ctx context.Context, dnsRecord *v1a
 
 func (r *DNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord *v1alpha1.DNSRecord, managedZone *v1alpha1.ManagedZone, isDelete bool) (time.Duration, error) {
 	logger := log.FromContext(ctx)
-	filterDomain, _ := strings.CutPrefix(managedZone.Spec.DomainName, v1alpha1.WildcardPrefix)
+	zoneDomainName, _ := strings.CutPrefix(managedZone.Spec.DomainName, v1alpha1.WildcardPrefix)
+	var rootDomainName string
 	if dnsRecord.Spec.RootHost != nil {
-		filterDomain, _ = strings.CutPrefix(*dnsRecord.Spec.RootHost, v1alpha1.WildcardPrefix)
+		rootDomainName, _ = strings.CutPrefix(*dnsRecord.Spec.RootHost, v1alpha1.WildcardPrefix)
 	}
-	rootDomainFilter := externaldnsendpoint.NewDomainFilter([]string{filterDomain})
+	zoneDomainFilter := externaldnsendpoint.NewDomainFilter([]string{zoneDomainName})
 
 	dnsProvider, err := r.getDNSProvider(ctx, dnsRecord)
 	if err != nil {
@@ -353,15 +354,15 @@ func (r *DNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord *v1alp
 	logger.V(3).Info("applyChanges", "statusEndpoints", statusEndpoints)
 
 	plan := &externaldnsplan.Plan{
-		Policies: []externaldnsplan.Policy{policy},
-		Current:  zoneEndpoints,
-		Desired:  specEndpoints,
-		Previous: statusEndpoints,
-		//Note: We can't just filter domains by `managedZone.Spec.DomainName` it needs to be the exact root domain for this particular record
-		DomainFilter:   externaldnsendpoint.MatchAllDomainFilters{&rootDomainFilter},
+		Policies:       []externaldnsplan.Policy{policy},
+		Current:        zoneEndpoints,
+		Desired:        specEndpoints,
+		Previous:       statusEndpoints,
+		DomainFilter:   externaldnsendpoint.MatchAllDomainFilters{&zoneDomainFilter},
 		ManagedRecords: managedDNSRecordTypes,
 		ExcludeRecords: excludeDNSRecordTypes,
 		OwnerID:        registry.OwnerID(),
+		RootHost:       &rootDomainName,
 	}
 
 	plan = plan.Calculate()

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -367,7 +367,7 @@ func (r *DNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord *v1alp
 
 	plan = plan.Calculate()
 
-	if err = plan.ConflictError(); err != nil {
+	if err = plan.Error(); err != nil {
 		return noRequeueDuration, err
 	}
 


### PR DESCRIPTION
closes #86 

Add step in the plan to verify the targets of all CNAME records being created or updated. If the target is calculated to be a subdomain of the plans root host, it must exist in the zone or will exist after the changes are applied.

Makes use of the plans DomainFilters since this is already used to filter down to relevant records and allows us to use the same logic to check for matches in dnsName values or targets. Plan was updated to ensure that a DomainFilter is always set for the RootHost if one is specified.

