### PR TITLE
fix: CRD required validations

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -58,17 +58,20 @@ type HealthCheckStatusProbe struct {
 
 // DNSRecordSpec defines the desired state of DNSRecord
 type DNSRecordSpec struct {
-	// OwnerID is a unique string used to identify all endpoints created by this kuadrant
+	// ownerID is a unique string used to identify the owner of this record.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="OwnerID is immutable"
 	// +optional
 	OwnerID *string `json:"ownerID,omitempty"`
+
 	// rootHost is the single root for all endpoints in a DNSRecord.
-	//If rootHost is set, it is expected all defined endpoints are children 	of or equal to this rootHost
+	// If rootHost is set, it is expected all defined endpoints are children of or equal to this rootHost
 	// +optional
 	RootHost *string `json:"rootHost,omitempty"`
-	// +kubebuilder:validation:Required
-	// +required
-	ManagedZoneRef *ManagedZoneReference `json:"managedZone,omitempty"`
+
+	// managedZone is a reference to a ManagedZone instance to which this record will publish its endpoints.
+	ManagedZoneRef *ManagedZoneReference `json:"managedZone"`
+
+	// endpoints is a list of endpoints that will be published into the dns provider.
 	// +kubebuilder:validation:MinItems=1
 	// +optional
 	Endpoints []*externaldns.Endpoint `json:"endpoints,omitempty"`

--- a/api/v1alpha1/managedzone_types.go
+++ b/api/v1alpha1/managedzone_types.go
@@ -29,18 +29,22 @@ type ManagedZoneReference struct {
 
 // ManagedZoneSpec defines the desired state of ManagedZone
 type ManagedZoneSpec struct {
-	// ID is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
+	// id is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
 	// +optional
 	ID string `json:"id,omitempty"`
-	//Domain name of this ManagedZone
+
+	//domainName of this ManagedZone
 	// +kubebuilder:validation:Pattern=`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
 	DomainName string `json:"domainName"`
-	//Description for this ManagedZone
+
+	//description for this ManagedZone
 	Description string `json:"description"`
-	// Reference to another managed zone that this managed zone belongs to.
+
+	// parentManagedZone reference to another managed zone that this managed zone belongs to.
 	// +optional
 	ParentManagedZone *ManagedZoneReference `json:"parentManagedZone,omitempty"`
-	// +required
+
+	// dnsProviderSecretRef reference to a secret containing credentials to access a dns provider.
 	SecretRef ProviderRef `json:"dnsProviderSecretRef"`
 }
 
@@ -53,17 +57,20 @@ type ManagedZoneStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// observedGeneration is the most recently observed generation of the
-	// ManagedZone.
+	// observedGeneration is the most recently observed generation of the ManagedZone.
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// The ID assigned by this provider for this zone (i.e. route53.HostedZone.ID)
+	// +optional
 	ID string `json:"id,omitempty"`
 
 	// The number of records in the provider zone
+	// +optional
 	RecordCount int64 `json:"recordCount,omitempty"`
 
 	// The NameServers assigned by the provider for this zone (i.e. route53.DelegationSet.NameServers)
+	// +optional
 	NameServers []*string `json:"nameServers,omitempty"`
 }
 

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 type ProviderRef struct {
-	//+required
 	Name string `json:"name"`
 }
 

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2024-04-17T03:35:09Z"
+    createdAt: "2024-04-24T14:36:53Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -40,6 +40,8 @@ spec:
             description: DNSRecordSpec defines the desired state of DNSRecord
             properties:
               endpoints:
+                description: endpoints is a list of endpoints that will be published
+                  into the dns provider.
                 items:
                   description: Endpoint is a high-level way of a connection between
                     a service and an IP
@@ -100,7 +102,8 @@ spec:
                     type: string
                 type: object
               managedZone:
-                description: ManagedZoneReference holds a reference to a ManagedZone
+                description: managedZone is a reference to a ManagedZone instance
+                  to which this record will publish its endpoints.
                 properties:
                   name:
                     description: '`name` is the name of the managed zone. Required'
@@ -109,17 +112,19 @@ spec:
                 - name
                 type: object
               ownerID:
-                description: OwnerID is a unique string used to identify all endpoints
-                  created by this kuadrant
+                description: ownerID is a unique string used to identify the owner
+                  of this record.
                 type: string
                 x-kubernetes-validations:
                 - message: OwnerID is immutable
                   rule: self == oldSelf
               rootHost:
-                description: "rootHost is the single root for all endpoints in a DNSRecord.
+                description: rootHost is the single root for all endpoints in a DNSRecord.
                   If rootHost is set, it is expected all defined endpoints are children
-                  \tof or equal to this rootHost"
+                  of or equal to this rootHost
                 type: string
+            required:
+            - managedZone
             type: object
           status:
             description: DNSRecordStatus defines the observed state of DNSRecord

--- a/bundle/manifests/kuadrant.io_managedzones.yaml
+++ b/bundle/manifests/kuadrant.io_managedzones.yaml
@@ -56,9 +56,11 @@ spec:
             description: ManagedZoneSpec defines the desired state of ManagedZone
             properties:
               description:
-                description: Description for this ManagedZone
+                description: description for this ManagedZone
                 type: string
               dnsProviderSecretRef:
+                description: dnsProviderSecretRef reference to a secret containing
+                  credentials to access a dns provider.
                 properties:
                   name:
                     type: string
@@ -66,15 +68,15 @@ spec:
                 - name
                 type: object
               domainName:
-                description: Domain name of this ManagedZone
+                description: domainName of this ManagedZone
                 pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
                 type: string
               id:
-                description: ID is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
+                description: id is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
                 type: string
               parentManagedZone:
-                description: Reference to another managed zone that this managed zone
-                  belongs to.
+                description: parentManagedZone reference to another managed zone that
+                  this managed zone belongs to.
                 properties:
                   name:
                     description: '`name` is the name of the managed zone. Required'

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -40,6 +40,8 @@ spec:
             description: DNSRecordSpec defines the desired state of DNSRecord
             properties:
               endpoints:
+                description: endpoints is a list of endpoints that will be published
+                  into the dns provider.
                 items:
                   description: Endpoint is a high-level way of a connection between
                     a service and an IP
@@ -100,7 +102,8 @@ spec:
                     type: string
                 type: object
               managedZone:
-                description: ManagedZoneReference holds a reference to a ManagedZone
+                description: managedZone is a reference to a ManagedZone instance
+                  to which this record will publish its endpoints.
                 properties:
                   name:
                     description: '`name` is the name of the managed zone. Required'
@@ -109,17 +112,19 @@ spec:
                 - name
                 type: object
               ownerID:
-                description: OwnerID is a unique string used to identify all endpoints
-                  created by this kuadrant
+                description: ownerID is a unique string used to identify the owner
+                  of this record.
                 type: string
                 x-kubernetes-validations:
                 - message: OwnerID is immutable
                   rule: self == oldSelf
               rootHost:
-                description: "rootHost is the single root for all endpoints in a DNSRecord.
+                description: rootHost is the single root for all endpoints in a DNSRecord.
                   If rootHost is set, it is expected all defined endpoints are children
-                  \tof or equal to this rootHost"
+                  of or equal to this rootHost
                 type: string
+            required:
+            - managedZone
             type: object
           status:
             description: DNSRecordStatus defines the observed state of DNSRecord

--- a/config/crd/bases/kuadrant.io_managedzones.yaml
+++ b/config/crd/bases/kuadrant.io_managedzones.yaml
@@ -56,9 +56,11 @@ spec:
             description: ManagedZoneSpec defines the desired state of ManagedZone
             properties:
               description:
-                description: Description for this ManagedZone
+                description: description for this ManagedZone
                 type: string
               dnsProviderSecretRef:
+                description: dnsProviderSecretRef reference to a secret containing
+                  credentials to access a dns provider.
                 properties:
                   name:
                     type: string
@@ -66,15 +68,15 @@ spec:
                 - name
                 type: object
               domainName:
-                description: Domain name of this ManagedZone
+                description: domainName of this ManagedZone
                 pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
                 type: string
               id:
-                description: ID is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
+                description: id is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
                 type: string
               parentManagedZone:
-                description: Reference to another managed zone that this managed zone
-                  belongs to.
+                description: parentManagedZone reference to another managed zone that
+                  this managed zone belongs to.
                 properties:
                   name:
                     description: '`name` is the name of the managed zone. Required'


### PR DESCRIPTION
The validations to ensure required fields were marked as required were incorrect.

Any fields that are not explicitly marked with `+optional` and do not have `omitempty` are considered required.