### PR TITLE
Add inmemory provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,8 @@ test-unit: manifests generate fmt vet ## Run unit tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -tags=unit -coverprofile cover-unit.out
 
 .PHONY: test-integration
-test-integration: manifests generate fmt vet envtest ## Run integration tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./internal/controller... -tags=integration -coverprofile cover-integration.out
+test-integration: manifests generate fmt vet envtest ginkgo ## Run integration tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -tags=integration ./internal/controller -coverprofile cover-integration.out
 
 .PHONY: test-e2e
 test-e2e: ginkgo

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kuadrant/dns-operator/internal/provider"
 	_ "github.com/kuadrant/dns-operator/internal/provider/aws"
 	_ "github.com/kuadrant/dns-operator/internal/provider/google"
+	_ "github.com/kuadrant/dns-operator/internal/provider/inmemory"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	TestTimeoutMedium       = time.Second * 10
+	TestTimeoutMedium       = time.Second * 15
 	TestTimeoutLong         = time.Second * 30
 	TestRetryIntervalMedium = time.Millisecond * 250
 	RequeueDuration         = time.Second * 6

--- a/internal/external-dns/plan/plan.go
+++ b/internal/external-dns/plan/plan.go
@@ -286,7 +286,7 @@ func (p *Plan) Calculate() *Plan {
 					candidate := t.resolver.ResolveUpdate(records.current, records.candidates)
 					current := records.current.DeepCopy()
 					owners := []string{}
-					if endpointOwner, hasOwner := current.Labels[endpoint.OwnerLabelKey]; hasOwner {
+					if endpointOwner, hasOwner := current.Labels[endpoint.OwnerLabelKey]; hasOwner && endpointOwner != "" {
 						if p.OwnerID == "" {
 							// Only allow owned records to be updated by other owned records
 							errs = append(errs, fmt.Errorf("%w, cannot update endpoint '%s' with no owner when existing endpoint is already owned", ErrOwnerConflict, candidate.DNSName))

--- a/internal/external-dns/provider/inmemory/inmemory.go
+++ b/internal/external-dns/provider/inmemory/inmemory.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+var (
+	// ErrZoneAlreadyExists error returned when zone cannot be created when it already exists
+	ErrZoneAlreadyExists = errors.New("specified zone already exists")
+	// ErrZoneNotFound error returned when specified zone does not exists
+	ErrZoneNotFound = errors.New("specified zone not found")
+	// ErrRecordAlreadyExists when create request is sent but record already exists
+	ErrRecordAlreadyExists = errors.New("record already exists")
+	// ErrRecordNotFound when update/delete request is sent but record not found
+	ErrRecordNotFound = errors.New("record not found")
+	// ErrDuplicateRecordFound when record is repeated in create/update/delete
+	ErrDuplicateRecordFound = errors.New("invalid batch request")
+)
+
+// InMemoryProvider - dns provider only used for testing purposes
+// initialized as dns provider with no records
+type InMemoryProvider struct {
+	provider.BaseProvider
+	domain         endpoint.DomainFilter
+	client         *inMemoryClient
+	filter         *filter
+	OnApplyChanges func(ctx context.Context, changes *plan.Changes)
+	OnRecords      func()
+}
+
+// InMemoryOption allows to extend in-memory provider
+type InMemoryOption func(*InMemoryProvider)
+
+// InMemoryWithLogging injects logging when ApplyChanges is called
+func InMemoryWithLogging() InMemoryOption {
+	return func(p *InMemoryProvider) {
+		p.OnApplyChanges = func(ctx context.Context, changes *plan.Changes) {
+			for _, v := range changes.Create {
+				log.Infof("CREATE: %v", v)
+			}
+			for _, v := range changes.UpdateOld {
+				log.Infof("UPDATE (old): %v", v)
+			}
+			for _, v := range changes.UpdateNew {
+				log.Infof("UPDATE (new): %v", v)
+			}
+			for _, v := range changes.Delete {
+				log.Infof("DELETE: %v", v)
+			}
+		}
+	}
+}
+
+// InMemoryWithDomain modifies the domain on which dns zones are filtered
+func InMemoryWithDomain(domainFilter endpoint.DomainFilter) InMemoryOption {
+	return func(p *InMemoryProvider) {
+		p.domain = domainFilter
+	}
+}
+
+// InMemoryInitZones pre-seeds the InMemoryProvider with given zones
+func InMemoryInitZones(zones []string) InMemoryOption {
+	return func(p *InMemoryProvider) {
+		for _, z := range zones {
+			if err := p.CreateZone(z); err != nil {
+				log.Warnf("Unable to initialize zones for inmemory provider")
+			}
+		}
+	}
+}
+
+// NewInMemoryProvider returns InMemoryProvider DNS provider interface implementation
+func NewInMemoryProvider(opts ...InMemoryOption) *InMemoryProvider {
+	im := &InMemoryProvider{
+		filter:         &filter{},
+		OnApplyChanges: func(ctx context.Context, changes *plan.Changes) {},
+		OnRecords:      func() {},
+		domain:         endpoint.NewDomainFilter([]string{""}),
+		client:         newInMemoryClient(),
+	}
+
+	for _, opt := range opts {
+		opt(im)
+	}
+
+	return im
+}
+
+// CreateZone adds new zone if not present
+func (im *InMemoryProvider) CreateZone(newZone string) error {
+	return im.client.CreateZone(newZone)
+}
+
+// Zones returns filtered zones as specified by domain
+func (im *InMemoryProvider) Zones() map[string]string {
+	return im.filter.Zones(im.client.Zones())
+}
+
+// Records returns the list of endpoints
+func (im *InMemoryProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	defer im.OnRecords()
+
+	endpoints := make([]*endpoint.Endpoint, 0)
+
+	for zoneID := range im.Zones() {
+		records, err := im.client.Records(zoneID)
+		if err != nil {
+			return nil, err
+		}
+
+		endpoints = append(endpoints, copyEndpoints(records)...)
+	}
+
+	return endpoints, nil
+}
+
+// ApplyChanges simply modifies records in memory
+// error checking occurs before any modifications are made, i.e. batch processing
+// create record - record should not exist
+// update/delete record - record should exist
+// create/update/delete lists should not have overlapping records
+func (im *InMemoryProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	defer im.OnApplyChanges(ctx, changes)
+
+	perZoneChanges := map[string]*plan.Changes{}
+
+	zones := im.Zones()
+	for zoneID := range zones {
+		perZoneChanges[zoneID] = &plan.Changes{}
+	}
+
+	for _, ep := range changes.Create {
+		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
+		perZoneChanges[zoneID].Create = append(perZoneChanges[zoneID].Create, ep)
+	}
+	for _, ep := range changes.UpdateNew {
+		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
+		perZoneChanges[zoneID].UpdateNew = append(perZoneChanges[zoneID].UpdateNew, ep)
+	}
+	for _, ep := range changes.UpdateOld {
+		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
+		perZoneChanges[zoneID].UpdateOld = append(perZoneChanges[zoneID].UpdateOld, ep)
+	}
+	for _, ep := range changes.Delete {
+		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
+		perZoneChanges[zoneID].Delete = append(perZoneChanges[zoneID].Delete, ep)
+	}
+
+	for zoneID := range perZoneChanges {
+		change := &plan.Changes{
+			Create:    perZoneChanges[zoneID].Create,
+			UpdateNew: perZoneChanges[zoneID].UpdateNew,
+			UpdateOld: perZoneChanges[zoneID].UpdateOld,
+			Delete:    perZoneChanges[zoneID].Delete,
+		}
+		err := im.client.ApplyChanges(ctx, zoneID, change)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+	records := make([]*endpoint.Endpoint, 0, len(endpoints))
+	for _, ep := range endpoints {
+		newEp := endpoint.NewEndpointWithTTL(ep.DNSName, ep.RecordType, ep.RecordTTL, ep.Targets...).WithSetIdentifier(ep.SetIdentifier)
+		newEp.Labels = endpoint.NewLabels()
+		for k, v := range ep.Labels {
+			newEp.Labels[k] = v
+		}
+		newEp.ProviderSpecific = append(endpoint.ProviderSpecific(nil), ep.ProviderSpecific...)
+		records = append(records, newEp)
+	}
+	return records
+}
+
+type filter struct {
+	domain string
+}
+
+// Zones filters map[zoneID]zoneName for names having f.domain as suffix
+func (f *filter) Zones(zones map[string]string) map[string]string {
+	result := map[string]string{}
+	for zoneID, zoneName := range zones {
+		if strings.HasSuffix(zoneName, f.domain) {
+			result[zoneID] = zoneName
+		}
+	}
+	return result
+}
+
+// EndpointZoneID determines zoneID for endpoint from map[zoneID]zoneName by taking longest suffix zoneName match in endpoint DNSName
+// returns empty string if no match found
+func (f *filter) EndpointZoneID(endpoint *endpoint.Endpoint, zones map[string]string) (zoneID string) {
+	var matchZoneID, matchZoneName string
+	for zoneID, zoneName := range zones {
+		if strings.HasSuffix(endpoint.DNSName, zoneName) && len(zoneName) > len(matchZoneName) {
+			matchZoneName = zoneName
+			matchZoneID = zoneID
+		}
+	}
+	return matchZoneID
+}
+
+type zone map[endpoint.EndpointKey]*endpoint.Endpoint
+
+type inMemoryClient struct {
+	zones map[string]zone
+}
+
+func newInMemoryClient() *inMemoryClient {
+	return &inMemoryClient{map[string]zone{}}
+}
+
+func (c *inMemoryClient) Records(zone string) ([]*endpoint.Endpoint, error) {
+	if _, ok := c.zones[zone]; !ok {
+		return nil, ErrZoneNotFound
+	}
+
+	var records []*endpoint.Endpoint
+	for _, rec := range c.zones[zone] {
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+func (c *inMemoryClient) Zones() map[string]string {
+	zones := map[string]string{}
+	for zone := range c.zones {
+		zones[zone] = zone
+	}
+	return zones
+}
+
+func (c *inMemoryClient) CreateZone(zone string) error {
+	if _, ok := c.zones[zone]; ok {
+		return ErrZoneAlreadyExists
+	}
+	c.zones[zone] = map[endpoint.EndpointKey]*endpoint.Endpoint{}
+
+	return nil
+}
+
+func (c *inMemoryClient) ApplyChanges(ctx context.Context, zoneID string, changes *plan.Changes) error {
+	if err := c.validateChangeBatch(zoneID, changes); err != nil {
+		return err
+	}
+	for _, newEndpoint := range changes.Create {
+		c.zones[zoneID][newEndpoint.Key()] = newEndpoint
+	}
+	for _, updateEndpoint := range changes.UpdateNew {
+		c.zones[zoneID][updateEndpoint.Key()] = updateEndpoint
+	}
+	for _, deleteEndpoint := range changes.Delete {
+		delete(c.zones[zoneID], deleteEndpoint.Key())
+	}
+	return nil
+}
+
+func (c *inMemoryClient) updateMesh(mesh sets.Set[endpoint.EndpointKey], record *endpoint.Endpoint) error {
+	if mesh.Has(record.Key()) {
+		return ErrDuplicateRecordFound
+	}
+	mesh.Insert(record.Key())
+	return nil
+}
+
+// validateChangeBatch validates that the changes passed to InMemory DNS provider is valid
+func (c *inMemoryClient) validateChangeBatch(zone string, changes *plan.Changes) error {
+	curZone, ok := c.zones[zone]
+	if !ok {
+		return ErrZoneNotFound
+	}
+	mesh := sets.New[endpoint.EndpointKey]()
+	for _, newEndpoint := range changes.Create {
+		if _, exists := curZone[newEndpoint.Key()]; exists {
+			return ErrRecordAlreadyExists
+		}
+		if err := c.updateMesh(mesh, newEndpoint); err != nil {
+			return err
+		}
+	}
+	for _, updateEndpoint := range changes.UpdateNew {
+		if _, exists := curZone[updateEndpoint.Key()]; !exists {
+			return ErrRecordNotFound
+		}
+		if err := c.updateMesh(mesh, updateEndpoint); err != nil {
+			return err
+		}
+	}
+	for _, updateOldEndpoint := range changes.UpdateOld {
+		if rec, exists := curZone[updateOldEndpoint.Key()]; !exists || rec.Targets[0] != updateOldEndpoint.Targets[0] {
+			return ErrRecordNotFound
+		}
+	}
+	for _, deleteEndpoint := range changes.Delete {
+		if rec, exists := curZone[deleteEndpoint.Key()]; !exists || rec.Targets[0] != deleteEndpoint.Targets[0] {
+			return ErrRecordNotFound
+		}
+		if err := c.updateMesh(mesh, deleteEndpoint); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/external-dns/provider/inmemory/inmemory_test.go
+++ b/internal/external-dns/provider/inmemory/inmemory_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 	"sigs.k8s.io/external-dns/provider"
@@ -44,28 +45,28 @@ func testInMemoryRecords(t *testing.T) {
 		title       string
 		zone        string
 		expectError bool
-		init        map[string]zone
+		init        map[string]Zone
 		expected    []*endpoint.Endpoint
 	}{
 		{
-			title:       "no records, no zone",
+			title:       "no records, no Zone",
 			zone:        "",
-			init:        map[string]zone{},
+			init:        map[string]Zone{},
 			expectError: false,
 		},
 		{
-			title: "records, wrong zone",
+			title: "records, wrong Zone",
 			zone:  "net",
-			init: map[string]zone{
+			init: map[string]Zone{
 				"org": {},
 				"com": {},
 			},
 			expectError: false,
 		},
 		{
-			title: "records, zone with records",
+			title: "records, Zone with records",
 			zone:  "org",
-			init: map[string]zone{
+			init: map[string]Zone{
 				"org": makeZone(
 					"example.org", "8.8.8.8", endpoint.RecordTypeA,
 					"example.org", "", endpoint.RecordTypeTXT,
@@ -94,7 +95,7 @@ func testInMemoryRecords(t *testing.T) {
 		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
-			c := newInMemoryClient()
+			c := NewInMemoryClient()
 			c.zones = ti.init
 			im := NewInMemoryProvider()
 			im.client = c
@@ -113,7 +114,7 @@ func testInMemoryRecords(t *testing.T) {
 }
 
 func testInMemoryValidateChangeBatch(t *testing.T) {
-	init := map[string]zone{
+	init := map[string]Zone{
 		"org": makeZone(
 			"example.org", "8.8.8.8", endpoint.RecordTypeA,
 			"example.org", "", endpoint.RecordTypeTXT,
@@ -126,7 +127,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 		title       string
 		expectError bool
 		errorType   error
-		init        map[string]zone
+		init        map[string]Zone
 		changes     *plan.Changes
 		zone        string
 	}{
@@ -134,7 +135,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			title:       "no zones, no update",
 			expectError: true,
 			zone:        "",
-			init:        map[string]zone{},
+			init:        map[string]Zone{},
 			changes: &plan.Changes{
 				Create:    []*endpoint.Endpoint{},
 				UpdateNew: []*endpoint.Endpoint{},
@@ -157,7 +158,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrZoneNotFound,
 		},
 		{
-			title:       "zones, update, wrong zone",
+			title:       "zones, update, wrong Zone",
 			expectError: true,
 			zone:        "test",
 			init:        init,
@@ -170,7 +171,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrZoneNotFound,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - already exists",
+			title:       "zones, update, right Zone, invalid batch - already exists",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -189,7 +190,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrRecordAlreadyExists,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - record not found for update",
+			title:       "zones, update, right Zone, invalid batch - record not found for update",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -214,7 +215,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrRecordNotFound,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - record not found for update",
+			title:       "zones, update, right Zone, invalid batch - record not found for update",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -239,7 +240,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrRecordNotFound,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - duplicated create",
+			title:       "zones, update, right Zone, invalid batch - duplicated create",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -263,7 +264,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrDuplicateRecordFound,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - duplicated update/delete",
+			title:       "zones, update, right Zone, invalid batch - duplicated update/delete",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -288,7 +289,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrDuplicateRecordFound,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - duplicated update",
+			title:       "zones, update, right Zone, invalid batch - duplicated update",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -312,7 +313,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrDuplicateRecordFound,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - wrong update old",
+			title:       "zones, update, right Zone, invalid batch - wrong update old",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -331,7 +332,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrRecordNotFound,
 		},
 		{
-			title:       "zones, update, right zone, invalid batch - wrong delete",
+			title:       "zones, update, right Zone, invalid batch - wrong delete",
 			expectError: true,
 			zone:        "org",
 			init:        init,
@@ -350,7 +351,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			errorType: ErrRecordNotFound,
 		},
 		{
-			title:       "zones, update, right zone, valid batch - delete",
+			title:       "zones, update, right Zone, valid batch - delete",
 			expectError: false,
 			zone:        "org",
 			init:        init,
@@ -368,7 +369,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			},
 		},
 		{
-			title:       "zones, update, right zone, valid batch - update and create",
+			title:       "zones, update, right Zone, valid batch - update and create",
 			expectError: false,
 			zone:        "org",
 			init:        init,
@@ -399,7 +400,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
-			c := &inMemoryClient{}
+			c := &InMemoryClient{}
 			c.zones = ti.init
 			ichanges := &plan.Changes{
 				Create:    ti.changes.Create,
@@ -417,8 +418,8 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 	}
 }
 
-func getInitData() map[string]zone {
-	return map[string]zone{
+func getInitData() map[string]Zone {
+	return map[string]Zone{
 		"org": makeZone("example.org", "8.8.8.8", endpoint.RecordTypeA,
 			"example.org", "", endpoint.RecordTypeTXT,
 			"foo.org", "4.4.4.4", endpoint.RecordTypeCNAME,
@@ -432,12 +433,12 @@ func testInMemoryApplyChanges(t *testing.T) {
 	for _, ti := range []struct {
 		title              string
 		expectError        bool
-		init               map[string]zone
+		init               map[string]Zone
 		changes            *plan.Changes
-		expectedZonesState map[string]zone
+		expectedZonesState map[string]Zone
 	}{
 		{
-			title:       "unmatched zone, should be ignored in the apply step",
+			title:       "unmatched Zone, should be ignored in the apply step",
 			expectError: false,
 			changes: &plan.Changes{
 				Create: []*endpoint.Endpoint{{
@@ -474,7 +475,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 			},
 		},
 		{
-			title:       "zones, update, right zone, valid batch - delete",
+			title:       "zones, update, right Zone, valid batch - delete",
 			expectError: false,
 			changes: &plan.Changes{
 				Create:    []*endpoint.Endpoint{},
@@ -488,7 +489,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 					},
 				},
 			},
-			expectedZonesState: map[string]zone{
+			expectedZonesState: map[string]Zone{
 				"org": makeZone("example.org", "8.8.8.8", endpoint.RecordTypeA,
 					"example.org", "", endpoint.RecordTypeTXT,
 					"foo.org", "4.4.4.4", endpoint.RecordTypeCNAME,
@@ -497,7 +498,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 			},
 		},
 		{
-			title:       "zones, update, right zone, valid batch - update, create, delete",
+			title:       "zones, update, right Zone, valid batch - update, create, delete",
 			expectError: false,
 			changes: &plan.Changes{
 				Create: []*endpoint.Endpoint{
@@ -533,7 +534,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 					},
 				},
 			},
-			expectedZonesState: map[string]zone{
+			expectedZonesState: map[string]Zone{
 				"org": makeZone(
 					"example.org", "", endpoint.RecordTypeTXT,
 					"foo.org", "4.4.4.4", endpoint.RecordTypeCNAME,
@@ -546,7 +547,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			im := NewInMemoryProvider()
-			c := &inMemoryClient{}
+			c := &InMemoryClient{}
 			c.zones = getInitData()
 			im.client = c
 
@@ -568,9 +569,9 @@ func testNewInMemoryProvider(t *testing.T) {
 
 func testInMemoryCreateZone(t *testing.T) {
 	im := NewInMemoryProvider()
-	err := im.CreateZone("zone")
+	err := im.CreateZone("Zone")
 	assert.NoError(t, err)
-	err = im.CreateZone("zone")
+	err = im.CreateZone("Zone")
 	assert.EqualError(t, err, ErrZoneAlreadyExists.Error())
 }
 

--- a/internal/external-dns/provider/inmemory/inmemory_test.go
+++ b/internal/external-dns/provider/inmemory/inmemory_test.go
@@ -1,0 +1,589 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+	"sigs.k8s.io/external-dns/provider"
+
+	"github.com/kuadrant/dns-operator/internal/external-dns/testutils"
+)
+
+var _ provider.Provider = &InMemoryProvider{}
+
+func TestInMemoryProvider(t *testing.T) {
+	t.Run("Records", testInMemoryRecords)
+	t.Run("validateChangeBatch", testInMemoryValidateChangeBatch)
+	t.Run("ApplyChanges", testInMemoryApplyChanges)
+	t.Run("NewInMemoryProvider", testNewInMemoryProvider)
+	t.Run("CreateZone", testInMemoryCreateZone)
+}
+
+func testInMemoryRecords(t *testing.T) {
+	for _, ti := range []struct {
+		title       string
+		zone        string
+		expectError bool
+		init        map[string]zone
+		expected    []*endpoint.Endpoint
+	}{
+		{
+			title:       "no records, no zone",
+			zone:        "",
+			init:        map[string]zone{},
+			expectError: false,
+		},
+		{
+			title: "records, wrong zone",
+			zone:  "net",
+			init: map[string]zone{
+				"org": {},
+				"com": {},
+			},
+			expectError: false,
+		},
+		{
+			title: "records, zone with records",
+			zone:  "org",
+			init: map[string]zone{
+				"org": makeZone(
+					"example.org", "8.8.8.8", endpoint.RecordTypeA,
+					"example.org", "", endpoint.RecordTypeTXT,
+					"foo.org", "4.4.4.4", endpoint.RecordTypeCNAME,
+				),
+				"com": makeZone("example.com", "4.4.4.4", endpoint.RecordTypeCNAME),
+			},
+			expectError: false,
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "example.org",
+					RecordType: endpoint.RecordTypeTXT,
+					Targets:    endpoint.Targets{""},
+				},
+				{
+					DNSName:    "foo.org",
+					Targets:    endpoint.Targets{"4.4.4.4"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+			},
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			c := newInMemoryClient()
+			c.zones = ti.init
+			im := NewInMemoryProvider()
+			im.client = c
+			f := filter{domain: ti.zone}
+			im.filter = &f
+			records, err := im.Records(context.Background())
+			if ti.expectError {
+				assert.Nil(t, records)
+				assert.EqualError(t, err, ErrZoneNotFound.Error())
+			} else {
+				require.NoError(t, err)
+				assert.True(t, testutils.SameEndpoints(ti.expected, records), "Endpoints not the same: Expected: %+v Records: %+v", ti.expected, records)
+			}
+		})
+	}
+}
+
+func testInMemoryValidateChangeBatch(t *testing.T) {
+	init := map[string]zone{
+		"org": makeZone(
+			"example.org", "8.8.8.8", endpoint.RecordTypeA,
+			"example.org", "", endpoint.RecordTypeTXT,
+			"foo.org", "bar.org", endpoint.RecordTypeCNAME,
+			"foo.bar.org", "5.5.5.5", endpoint.RecordTypeA,
+		),
+		"com": makeZone("example.com", "another-example.com", endpoint.RecordTypeCNAME),
+	}
+	for _, ti := range []struct {
+		title       string
+		expectError bool
+		errorType   error
+		init        map[string]zone
+		changes     *plan.Changes
+		zone        string
+	}{
+		{
+			title:       "no zones, no update",
+			expectError: true,
+			zone:        "",
+			init:        map[string]zone{},
+			changes: &plan.Changes{
+				Create:    []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrZoneNotFound,
+		},
+		{
+			title:       "zones, no update",
+			expectError: true,
+			zone:        "",
+			init:        init,
+			changes: &plan.Changes{
+				Create:    []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrZoneNotFound,
+		},
+		{
+			title:       "zones, update, wrong zone",
+			expectError: true,
+			zone:        "test",
+			init:        init,
+			changes: &plan.Changes{
+				Create:    []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrZoneNotFound,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - already exists",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrRecordAlreadyExists,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - record not found for update",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.org",
+						Targets:    endpoint.Targets{"4.4.4.4"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateNew: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.org",
+						Targets:    endpoint.Targets{"4.4.4.4"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrRecordNotFound,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - record not found for update",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.org",
+						Targets:    endpoint.Targets{"4.4.4.4"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateNew: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.org",
+						Targets:    endpoint.Targets{"4.4.4.4"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrRecordNotFound,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - duplicated create",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.org",
+						Targets:    endpoint.Targets{"4.4.4.4"},
+						RecordType: endpoint.RecordTypeA,
+					},
+					{
+						DNSName:    "foo.org",
+						Targets:    endpoint.Targets{"4.4.4.4"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrDuplicateRecordFound,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - duplicated update/delete",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+			},
+			errorType: ErrDuplicateRecordFound,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - duplicated update",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			errorType: ErrDuplicateRecordFound,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - wrong update old",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create:    []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{
+					{
+						DNSName:    "new.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				Delete: []*endpoint.Endpoint{},
+			},
+			errorType: ErrRecordNotFound,
+		},
+		{
+			title:       "zones, update, right zone, invalid batch - wrong delete",
+			expectError: true,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create:    []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "new.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+			},
+			errorType: ErrRecordNotFound,
+		},
+		{
+			title:       "zones, update, right zone, valid batch - delete",
+			expectError: false,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create:    []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.org",
+						Targets:    endpoint.Targets{"5.5.5.5"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+			},
+		},
+		{
+			title:       "zones, update, right zone, valid batch - update and create",
+			expectError: false,
+			zone:        "org",
+			init:        init,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.new.org",
+						Targets:    endpoint.Targets{"4.8.8.9"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateNew: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.org",
+						Targets:    endpoint.Targets{"4.8.8.4"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateOld: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.org",
+						Targets:    endpoint.Targets{"5.5.5.5"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				Delete: []*endpoint.Endpoint{},
+			},
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			c := &inMemoryClient{}
+			c.zones = ti.init
+			ichanges := &plan.Changes{
+				Create:    ti.changes.Create,
+				UpdateNew: ti.changes.UpdateNew,
+				UpdateOld: ti.changes.UpdateOld,
+				Delete:    ti.changes.Delete,
+			}
+			err := c.validateChangeBatch(ti.zone, ichanges)
+			if ti.expectError {
+				assert.EqualError(t, err, ti.errorType.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func getInitData() map[string]zone {
+	return map[string]zone{
+		"org": makeZone("example.org", "8.8.8.8", endpoint.RecordTypeA,
+			"example.org", "", endpoint.RecordTypeTXT,
+			"foo.org", "4.4.4.4", endpoint.RecordTypeCNAME,
+			"foo.bar.org", "5.5.5.5", endpoint.RecordTypeA,
+		),
+		"com": makeZone("example.com", "4.4.4.4", endpoint.RecordTypeCNAME),
+	}
+}
+
+func testInMemoryApplyChanges(t *testing.T) {
+	for _, ti := range []struct {
+		title              string
+		expectError        bool
+		init               map[string]zone
+		changes            *plan.Changes
+		expectedZonesState map[string]zone
+	}{
+		{
+			title:       "unmatched zone, should be ignored in the apply step",
+			expectError: false,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{{
+					DNSName:    "example.de",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				}},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+			expectedZonesState: getInitData(),
+		},
+		{
+			title:       "expect error",
+			expectError: true,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+			},
+		},
+		{
+			title:       "zones, update, right zone, valid batch - delete",
+			expectError: false,
+			changes: &plan.Changes{
+				Create:    []*endpoint.Endpoint{},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.org",
+						Targets:    endpoint.Targets{"5.5.5.5"},
+						RecordType: endpoint.RecordTypeA,
+					},
+				},
+			},
+			expectedZonesState: map[string]zone{
+				"org": makeZone("example.org", "8.8.8.8", endpoint.RecordTypeA,
+					"example.org", "", endpoint.RecordTypeTXT,
+					"foo.org", "4.4.4.4", endpoint.RecordTypeCNAME,
+				),
+				"com": makeZone("example.com", "4.4.4.4", endpoint.RecordTypeCNAME),
+			},
+		},
+		{
+			title:       "zones, update, right zone, valid batch - update, create, delete",
+			expectError: false,
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.new.org",
+						Targets:    endpoint.Targets{"4.8.8.9"},
+						RecordType: endpoint.RecordTypeA,
+						Labels:     endpoint.NewLabels(),
+					},
+				},
+				UpdateNew: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.org",
+						Targets:    endpoint.Targets{"4.8.8.4"},
+						RecordType: endpoint.RecordTypeA,
+						Labels:     endpoint.NewLabels(),
+					},
+				},
+				UpdateOld: []*endpoint.Endpoint{
+					{
+						DNSName:    "foo.bar.org",
+						Targets:    endpoint.Targets{"5.5.5.5"},
+						RecordType: endpoint.RecordTypeA,
+						Labels:     endpoint.NewLabels(),
+					},
+				},
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "example.org",
+						Targets:    endpoint.Targets{"8.8.8.8"},
+						RecordType: endpoint.RecordTypeA,
+						Labels:     endpoint.NewLabels(),
+					},
+				},
+			},
+			expectedZonesState: map[string]zone{
+				"org": makeZone(
+					"example.org", "", endpoint.RecordTypeTXT,
+					"foo.org", "4.4.4.4", endpoint.RecordTypeCNAME,
+					"foo.bar.org", "4.8.8.4", endpoint.RecordTypeA,
+					"foo.bar.new.org", "4.8.8.9", endpoint.RecordTypeA,
+				),
+				"com": makeZone("example.com", "4.4.4.4", endpoint.RecordTypeCNAME),
+			},
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			im := NewInMemoryProvider()
+			c := &inMemoryClient{}
+			c.zones = getInitData()
+			im.client = c
+
+			err := im.ApplyChanges(context.Background(), ti.changes)
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, ti.expectedZonesState, c.zones)
+			}
+		})
+	}
+}
+
+func testNewInMemoryProvider(t *testing.T) {
+	cfg := NewInMemoryProvider()
+	assert.NotNil(t, cfg.client)
+}
+
+func testInMemoryCreateZone(t *testing.T) {
+	im := NewInMemoryProvider()
+	err := im.CreateZone("zone")
+	assert.NoError(t, err)
+	err = im.CreateZone("zone")
+	assert.EqualError(t, err, ErrZoneAlreadyExists.Error())
+}
+
+func makeZone(s ...string) map[endpoint.EndpointKey]*endpoint.Endpoint {
+	if len(s)%3 != 0 {
+		panic("makeZone arguments must be multiple of 3")
+	}
+
+	output := map[endpoint.EndpointKey]*endpoint.Endpoint{}
+	for i := 0; i < len(s); i += 3 {
+		ep := endpoint.NewEndpoint(s[i], s[i+2], s[i+1])
+		output[ep.Key()] = ep
+	}
+
+	return output
+}

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -82,6 +82,8 @@ func nameForProviderSecret(secret *v1.Secret) (string, error) {
 		return "aws", nil
 	case "kuadrant.io/gcp":
 		return "google", nil
+	case "kuadrant.io/inmemory":
+		return "inmemory", nil
 	}
 	return "", errUnsupportedProvider
 }

--- a/internal/provider/inmemory/inmemory.go
+++ b/internal/provider/inmemory/inmemory.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/external-dns/provider/inmemory"
+	"github.com/kuadrant/dns-operator/internal/provider"
+)
+
+type InMemoryDNSProvider struct {
+	*inmemory.InMemoryProvider
+	ctx context.Context
+}
+
+var client *inmemory.InMemoryClient
+
+var _ provider.Provider = &InMemoryDNSProvider{}
+
+func NewProviderFromSecret(ctx context.Context, _ *v1.Secret, c provider.Config) (provider.Provider, error) {
+	inmemoryProvider := inmemory.NewInMemoryProvider(inmemory.InMemoryWithClient(client), inmemory.InMemoryWithDomain(c.DomainFilter), inmemory.InMemoryWithLogging())
+	p := &InMemoryDNSProvider{
+		InMemoryProvider: inmemoryProvider,
+		ctx:              ctx,
+	}
+	return p, nil
+}
+
+func (i InMemoryDNSProvider) EnsureManagedZone(managedZone *v1alpha1.ManagedZone) (provider.ManagedZoneOutput, error) {
+	_ = i.CreateZone(managedZone.Spec.DomainName)
+	return provider.ManagedZoneOutput{
+		ID:          managedZone.Spec.DomainName,
+		NameServers: nil,
+		RecordCount: 0,
+	}, nil
+}
+
+func (i InMemoryDNSProvider) DeleteManagedZone(managedZone *v1alpha1.ManagedZone) error {
+	return i.DeleteZone(managedZone.Spec.DomainName)
+}
+
+func (i InMemoryDNSProvider) HealthCheckReconciler() provider.HealthCheckReconciler {
+	return &provider.FakeHealthCheckReconciler{}
+}
+
+func (i InMemoryDNSProvider) ProviderSpecific() provider.ProviderSpecificLabels {
+	return provider.ProviderSpecificLabels{}
+}
+
+// Register this Provider with the provider factory
+func init() {
+	client = inmemory.NewInMemoryClient()
+	provider.RegisterProvider("inmemory", NewProviderFromSecret)
+}


### PR DESCRIPTION
Adds a new provider `inmemory` for testing purposes which wraps the external dns `inmemory` provider
https://github.com/kubernetes-sigs/external-dns/tree/master/provider/inmemory. Also adds the inmemory provider to the provider factory allowing it to be used via the creation of a ManagedZone.

```
apiVersion: v1
kind: Secret
metadata:
  name: inmemory-credentials
type: kuadrant.io/inmemory
data: {}
---
apiVersion: kuadrant.io/v1alpha1
kind: ManagedZone
metadata:
  name: example.com
spec:
  domainName: example.com
  description: "example.com managed domain"
  dnsProviderSecretRef:
    name: inmemory-credentials
```

The external-dns provider has been modified slightly to work for some of our testing scenarios.

* Add delete zone (Removes the key from the zones map)
* Exposes the client so we can change it when loading a new provider instance. Allows us to share the same zone map for all providers loaded via the factory.

Update integration test suite to use the `inmemory` provider. Each test case must now create and cleanup all dnsrecords it requires for testing.

Related follow up tasks:

* https://github.com/Kuadrant/dns-operator/issues/105