### PR TITLE
Update inmemory provider

### DIFF
--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
@@ -17,24 +18,32 @@ const (
 	TestRetryIntervalMedium = time.Millisecond * 250
 	RequeueDuration         = time.Second * 6
 	ValidityDuration        = time.Second * 3
-	defaultNS               = "default"
-	providerCredential      = "secretname"
 )
 
-func testBuildManagedZone(name, ns, domainName string) *kuadrantdnsv1alpha1.ManagedZone {
+func testBuildManagedZone(name, ns, domainName, secretName string) *kuadrantdnsv1alpha1.ManagedZone {
 	return &kuadrantdnsv1alpha1.ManagedZone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
 		Spec: kuadrantdnsv1alpha1.ManagedZoneSpec{
-			ID:          "1234",
 			DomainName:  domainName,
 			Description: domainName,
 			SecretRef: kuadrantdnsv1alpha1.ProviderRef{
-				Name: "secretname",
+				Name: secretName,
 			},
 		},
+	}
+}
+
+func testBuildInMemoryCredentialsSecret(name, ns string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{},
+		Type: "kuadrant.io/inmemory",
 	}
 }
 

--- a/internal/controller/managedzone_controller_test.go
+++ b/internal/controller/managedzone_controller_test.go
@@ -19,11 +19,13 @@ limitations under the License.
 package controller
 
 import (
-	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,62 +36,65 @@ import (
 
 var _ = Describe("ManagedZoneReconciler", func() {
 	Context("testing ManagedZone controller", func() {
+		var dnsProviderSecret *v1.Secret
 		var managedZone *v1alpha1.ManagedZone
-		var ctx context.Context
+		var testNamespace string
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			managedZone = &v1alpha1.ManagedZone{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "example.com",
-					Namespace: defaultNS,
-				},
-				Spec: v1alpha1.ManagedZoneSpec{
-					ID:         "example.com",
-					DomainName: "example.com",
-					SecretRef: v1alpha1.ProviderRef{
-						Name: providerCredential,
-					},
-				},
-			}
+			CreateNamespace(&testNamespace)
+
+			dnsProviderSecret = testBuildInMemoryCredentialsSecret("inmemory-credentials", testNamespace)
+			managedZone = testBuildManagedZone("mz-example-com", testNamespace, "example.com", dnsProviderSecret.Name)
+
+			Expect(k8sClient.Create(ctx, dnsProviderSecret)).To(Succeed())
 		})
 
 		AfterEach(func() {
 			// Clean up managedZones
 			mzList := &v1alpha1.ManagedZoneList{}
-			err := k8sClient.List(ctx, mzList, client.InNamespace(defaultNS))
+			err := k8sClient.List(ctx, mzList, client.InNamespace(testNamespace))
 			Expect(err).NotTo(HaveOccurred())
 			for _, mz := range mzList.Items {
 				err = k8sClient.Delete(ctx, &mz)
 				Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 			}
+
+			if dnsProviderSecret != nil {
+				err := k8sClient.Delete(ctx, dnsProviderSecret)
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+			}
 		})
 
 		It("should accept a managed zone for this controller and allow deletion", func() {
-			Expect(k8sClient.Create(ctx, managedZone)).To(BeNil())
+			Expect(k8sClient.Create(ctx, managedZone)).To(Succeed())
 
-			createdMZ := &v1alpha1.ManagedZone{}
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(managedZone), managedZone)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(managedZone.Status.Conditions).To(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":             Equal(metav1.ConditionTrue),
+						"ObservedGeneration": Equal(managedZone.Generation),
+					})),
+				)
+			}, TestTimeoutMedium, time.Second).Should(Succeed())
 
+			Expect(k8sClient.Delete(ctx, managedZone)).To(Succeed())
 			Eventually(func() error {
-				return k8sClient.Get(ctx, client.ObjectKey{Namespace: managedZone.Namespace, Name: managedZone.Name}, createdMZ)
-			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
-
-			Expect(k8sClient.Delete(ctx, managedZone)).To(BeNil())
-
-			Eventually(func() error {
-				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: managedZone.Namespace, Name: managedZone.Name}, createdMZ)
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(managedZone), managedZone)
 				if err != nil && !errors.IsNotFound(err) {
 					return err
 				}
 				return nil
-			}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+			}, TestTimeoutMedium, TestRetryIntervalMedium).Should(Succeed())
 		})
 
 		It("should reject a managed zone with an invalid domain name", func() {
 			invalidDomainNameManagedZone := &v1alpha1.ManagedZone{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid_domain",
-					Namespace: defaultNS,
+					Namespace: testNamespace,
 				},
 				Spec: v1alpha1.ManagedZoneSpec{
 					ID:         "invalid_domain",

--- a/internal/external-dns/provider/inmemory/inmemory.go
+++ b/internal/external-dns/provider/inmemory/inmemory.go
@@ -128,6 +128,11 @@ func (im *InMemoryProvider) DeleteZone(zone string) error {
 	return im.client.DeleteZone(zone)
 }
 
+// GetZone gets a Zone if present
+func (im *InMemoryProvider) GetZone(zone string) (Zone, error) {
+	return im.client.GetZone(zone)
+}
+
 // Zones returns filtered zones as specified by domain
 func (im *InMemoryProvider) Zones() map[string]string {
 	return im.filter.Zones(im.client.Zones())
@@ -298,6 +303,13 @@ func (c *InMemoryClient) DeleteZone(zone string) error {
 		return nil
 	}
 	return ErrZoneNotFound
+}
+
+func (c *InMemoryClient) GetZone(zone string) (Zone, error) {
+	if _, ok := c.zones[zone]; ok {
+		return c.zones[zone], nil
+	}
+	return nil, ErrZoneNotFound
 }
 
 func (c *InMemoryClient) ApplyChanges(ctx context.Context, zoneID string, changes *plan.Changes) error {


### PR DESCRIPTION
Update the inmemory provider to work more like aws and google providers when creating a managed zone. If an ID is specified in the spec it is expected that the zone should exist and return an error otherwise. Previously created managed zones should be retrieved using the ID in the status of the managed zone.

Update integration tests to use updated inmemory provider, ensure managedzone being created has no ID in the spec. Also updates the tests to load the provider via the factory instead of overriding the factory in the suite test.

Add a test that checks we get the expected provider error when trying to use a zone id that does not exist.