### PR TITLE
Add verify generate and gomod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,38 @@ jobs:
       - name: Run make verify-imports
         run: |
           make verify-imports
+  verify-generate:
+    name: Verify generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
+          cache: false
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Verify generate command
+        run: |
+          make verify-generate
+
+  verify-go-mod:
+    name: Verify go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
+          cache: false
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Verify generate command
+        run: |
+          make verify-go-mod
+
   unit_test_suite:
     name: Unit Test Suite
     runs-on: ubuntu-latest

--- a/make/verify.mk
+++ b/make/verify.mk
@@ -4,7 +4,7 @@
 ## Targets to verify actions that generate/modify code have been executed and output committed
 
 .PHONY: verify-all
-verify-all: verify-code verify-bundle verify-imports verify-manifests
+verify-all: verify-code verify-bundle verify-imports verify-manifests verify-generate verify-go-mod
 
 .PHONY: verify-code
 verify-code: vet ## Verify code formatting
@@ -23,3 +23,12 @@ verify-bundle: bundle ## Verify bundle update.
 .PHONY: verify-imports
 verify-imports: ## Verify go imports are sorted and grouped correctly.
 	hack/verify-imports.sh
+
+.PHONY: verify-generate
+verify-generate: generate ## Verify generate update.
+	git diff --exit-code ./api ./internal/controller
+
+.PHONY: verify-go-mod
+verify-go-mod: ## Verify go.mod matches source code
+	go mod tidy
+	git diff --exit-code ./go.mod


### PR DESCRIPTION
[Add verify generate and go.mod make targets](https://github.com/Kuadrant/dns-operator/pull/126/commits/9877b7de4626d747ff1b085cd250ded82ef8d0c7)

Add new make targets to verify that `make generate` and `go mod tidy` have been executed against the current code and the results committed.
Add verify-generate and verify-go-mod jobs to CI github workflow.
