### PR TITLE
multi-arch image builds (linux/amd64 and linux/arm64)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -34,12 +34,18 @@ jobs:
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
 
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ env.IMG_TAGS }}
+          platforms: linux/amd64,linux/arm64
           dockerfiles: |
             ./Dockerfile
 
@@ -74,12 +80,18 @@ jobs:
       - name: Run make bundle
         run: make bundle IMG=${{ needs.build.outputs.build-image }}
 
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
+          platforms: linux/amd64,linux/arm64
           dockerfiles: |
             ./bundle.Dockerfile
 
@@ -111,12 +123,18 @@ jobs:
       - name: Run make catalog-build
         run: make catalog-build BUNDLE_IMG=${{ needs.build-bundle.outputs.bundle-image }}
 
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
+          platforms: linux/amd64,linux/arm64
           context: ./tmp/catalog
           dockerfiles: |
             ./tmp/catalog/index.Dockerfile


### PR DESCRIPTION
closes #127 

* Add linux/amd64 and linux/arm64 platforms to buildah builds of operator, bundle and catalog images.
* Add qemu dependency install to image build jobs.

Brings it in-line with other kuadrant image builds (kuadrant-operator, authorino-operator etc..)

Note: Warning messages appear in the logs "Failed to decode the keys ["machine"]", but it appears to be a known issue that can be ignored. https://github.com/redhat-actions/buildah-build/issues/101