### PR TITLE
fix: Validate MZ id and domainName on create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/linki/instrumented_http v0.3.0
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/rs/xid v1.5.0
 	github.com/sirupsen/logrus v1.9.3
@@ -67,6 +66,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift/api v0.0.0-20230607130528-611114dca681 // indirect
 	github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/projectcontour/contour v1.25.2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/internal/provider/google/google.go
+++ b/internal/provider/google/google.go
@@ -688,6 +688,7 @@ func (p *GoogleDNSProvider) toManagedZoneOutput(mz *dnsv1.ManagedZone) (provider
 		nameservers = append(nameservers, &mz.NameServers[i])
 	}
 	managedZoneOutput.ID = zoneID
+	managedZoneOutput.DNSName = strings.ToLower(strings.TrimSuffix(mz.DnsName, "."))
 	managedZoneOutput.NameServers = nameservers
 
 	currentRecords, err := p.getResourceRecordSets(p.ctx, zoneID)

--- a/internal/provider/inmemory/inmemory.go
+++ b/internal/provider/inmemory/inmemory.go
@@ -53,19 +53,27 @@ func (i InMemoryDNSProvider) EnsureManagedZone(mz *v1alpha1.ManagedZone) (provid
 	}
 
 	if zoneID != "" {
-		_, err := i.GetZone(zoneID)
+		z, err := i.GetZone(zoneID)
+		if err != nil {
+			return provider.ManagedZoneOutput{}, err
+		}
 		return provider.ManagedZoneOutput{
 			ID:          zoneID,
+			DNSName:     zoneID,
 			NameServers: nil,
-			RecordCount: 0,
-		}, err
+			RecordCount: int64(len(z)),
+		}, nil
 	}
 	err := i.CreateZone(mz.Spec.DomainName)
+	if err != nil {
+		return provider.ManagedZoneOutput{}, err
+	}
 	return provider.ManagedZoneOutput{
 		ID:          mz.Spec.DomainName,
+		DNSName:     mz.Spec.DomainName,
 		NameServers: nil,
 		RecordCount: 0,
-	}, err
+	}, nil
 }
 
 func (i InMemoryDNSProvider) DeleteManagedZone(managedZone *v1alpha1.ManagedZone) error {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -49,6 +49,7 @@ type ProviderSpecificLabels struct {
 
 type ManagedZoneOutput struct {
 	ID          string
+	DNSName     string
 	NameServers []*string
 	RecordCount int64
 }


### PR DESCRIPTION
fixes #122 

Add managed zone validation step to ensure that when we are creating a managed zone with an ID that the corresponding domainName matches what is in the provider.

Related: 

* https://github.com/Kuadrant/dns-operator/pull/134