### PR TITLE
fix: flaky test (Test_resourceRecordSetFromEndpoint)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.21
 require (
 	github.com/aws/aws-sdk-go v1.44.311
 	github.com/go-logr/logr v1.3.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.1
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/linki/instrumented_http v0.3.0
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/rs/xid v1.5.0
 	github.com/sirupsen/logrus v1.9.3
@@ -50,7 +50,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20221212185716-aee1124e3a93 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
@@ -67,6 +66,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift/api v0.0.0-20230607130528-611114dca681 // indirect
 	github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/projectcontour/contour v1.25.2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect


### PR DESCRIPTION
fixes #95 

Ensure the RoutingPolicy Item arrays (geo or weighted) for resourceRecordSetFromEndpoint checks are sorted before checking for equality.

Replace the use of reflect.DeepEqual and equality.Semantic.DeepEqual in tests with github.com/google/go-cmp/cmp (cmp.Diff).

Produces easier to read errors when tests fail:

```
--- FAIL: Test_resourceRecordSetFromEndpoint (0.00s)
    --- FAIL: Test_resourceRecordSetFromEndpoint/test_A_record (0.00s)
        google_test.go:1039: resourceRecordSetFromEndpoint (-want +got):
            &dns.ResourceRecordSet{
              ... // 3 identical fields
              Rrdatas:          {"0.0.0.0"},
              SignatureRrdatas: nil,
            -  Ttl:              60,
            +  Ttl:              600,
              Type:             "A",
              ServerResponse:   {},
              ... // 2 identical fields
            }
```

Flake this PR fixes would have failed like this:

```
=== RUN   Test_resourceRecordSetFromEndpoint
=== RUN   Test_resourceRecordSetFromEndpoint/test_CNAME_with_geo_and_multiple_targets
    google_test.go:1055: resourceRecordSetFromEndpoint (-want +got):
          &dns.ResourceRecordSet{
          	Kind: "",
          	Name: "lb-4ej5le.unittest.google.hcpapps.net.",
          	RoutingPolicy: &dns.RRSetRoutingPolicy{
          		Geo: &dns.RRSetRoutingPolicyGeoPolicy{
          			EnableFencing: false,
          			Items: []*dns.RRSetRoutingPolicyGeoPolicyGeoPolicyItem{
          				&{
          					HealthCheckedTargets: nil,
          					Kind:                 "",
        - 					Location:             "europe-west1",
        + 					Location:             "us-east1",
        - 					Rrdatas:              []string{"europe-west1.lb-4ej5le.unittest.google.hcpapps.net."},
        + 					Rrdatas:              []string{"us-east1.lb-4ej5le.unittest.google.hcpapps.net."},
          					SignatureRrdatas:     nil,
          					ForceSendFields:      nil,
          					NullFields:           nil,
          				},
          				&{
          					HealthCheckedTargets: nil,
          					Kind:                 "",
        - 					Location:             "us-east1",
        + 					Location:             "europe-west1",
        - 					Rrdatas:              []string{"us-east1.lb-4ej5le.unittest.google.hcpapps.net."},
        + 					Rrdatas:              []string{"europe-west1.lb-4ej5le.unittest.google.hcpapps.net."},
          					SignatureRrdatas:     nil,
          					ForceSendFields:      nil,
          					NullFields:           nil,
          				},
          			},
          			Kind:            "",
          			ForceSendFields: nil,
          			NullFields:      nil,
          		},
          		Kind:          "",
          		PrimaryBackup: nil,
          		... // 3 identical fields
          	},
          	Rrdatas:          nil,
          	SignatureRrdatas: nil,
          	... // 5 identical fields
          }
--- FAIL: Test_resourceRecordSetFromEndpoint (0.00s)
    --- FAIL: Test_resourceRecordSetFromEndpoint/test_CNAME_with_geo_and_multiple_targets (0.00s)
```