### PR TITLE
Scope provider zone lookup to a single id

### DIFF
--- a/internal/external-dns/provider/aws/zones.go
+++ b/internal/external-dns/provider/aws/zones.go
@@ -1,0 +1,166 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/provider"
+)
+
+type zonesListCache struct {
+	age      time.Time
+	duration time.Duration
+	zones    map[string]*route53.HostedZone
+}
+
+type ZonesAPI interface {
+	GetZones(ctx context.Context) (map[string]*route53.HostedZone, error)
+}
+
+type ZonesAPIListAndFilter struct {
+	client Route53API
+	// only consider hosted zones managing domains ending in this suffix
+	domainFilter endpoint.DomainFilter
+	// filter hosted zones by id
+	zoneIDFilter provider.ZoneIDFilter
+	// filter hosted zones by type (e.g. private or public)
+	zoneTypeFilter provider.ZoneTypeFilter
+	// filter hosted zones by tags
+	zoneTagFilter provider.ZoneTagFilter
+	zonesCache    *zonesListCache
+}
+
+var _ ZonesAPI = &ZonesAPIListAndFilter{}
+
+func NewZonesAPIListAndFilter(awsConfig AWSConfig, client Route53API) *ZonesAPIListAndFilter {
+	return &ZonesAPIListAndFilter{
+		client:         client,
+		domainFilter:   awsConfig.DomainFilter,
+		zoneIDFilter:   awsConfig.ZoneIDFilter,
+		zoneTypeFilter: awsConfig.ZoneTypeFilter,
+		zoneTagFilter:  awsConfig.ZoneTagFilter,
+		zonesCache:     &zonesListCache{duration: awsConfig.ZoneCacheDuration},
+	}
+}
+
+// Zones returns the list of hosted zones.
+func (p ZonesAPIListAndFilter) GetZones(ctx context.Context) (map[string]*route53.HostedZone, error) {
+	if p.zonesCache.zones != nil && time.Since(p.zonesCache.age) < p.zonesCache.duration {
+		log.Debug("Using cached zones list")
+		return p.zonesCache.zones, nil
+	}
+	log.Debug("Refreshing zones list cache")
+
+	zones := make(map[string]*route53.HostedZone)
+
+	var tagErr error
+	f := func(resp *route53.ListHostedZonesOutput, lastPage bool) (shouldContinue bool) {
+		for _, zone := range resp.HostedZones {
+			if !p.zoneIDFilter.Match(aws.StringValue(zone.Id)) {
+				continue
+			}
+
+			if !p.zoneTypeFilter.Match(zone) {
+				continue
+			}
+
+			if !p.domainFilter.Match(aws.StringValue(zone.Name)) {
+				continue
+			}
+
+			// Only fetch tags if a tag filter was specified
+			if !p.zoneTagFilter.IsEmpty() {
+				tags, err := p.tagsForZone(ctx, *zone.Id)
+				if err != nil {
+					tagErr = err
+					return false
+				}
+				if !p.zoneTagFilter.Match(tags) {
+					continue
+				}
+			}
+
+			zones[aws.StringValue(zone.Id)] = zone
+		}
+
+		return true
+	}
+
+	err := p.client.ListHostedZonesPagesWithContext(ctx, &route53.ListHostedZonesInput{}, f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list hosted zones, %w", err)
+	}
+	if tagErr != nil {
+		return nil, fmt.Errorf("failed to list zones tags, %w", tagErr)
+	}
+
+	for _, zone := range zones {
+		log.Debugf("Considering zone: %s (domain: %s)", aws.StringValue(zone.Id), aws.StringValue(zone.Name))
+	}
+
+	if p.zonesCache.duration > time.Duration(0) {
+		p.zonesCache.zones = zones
+		p.zonesCache.age = time.Now()
+	}
+
+	return zones, nil
+}
+
+func (p *ZonesAPIListAndFilter) tagsForZone(ctx context.Context, zoneID string) (map[string]string, error) {
+	response, err := p.client.ListTagsForResourceWithContext(ctx, &route53.ListTagsForResourceInput{
+		ResourceType: aws.String("hostedzone"),
+		ResourceId:   aws.String(zoneID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags for zone %s, %w", zoneID, err)
+	}
+	tagMap := map[string]string{}
+	for _, tag := range response.ResourceTagSet.Tags {
+		tagMap[*tag.Key] = *tag.Value
+	}
+	return tagMap, nil
+}
+
+type ZonesAPISingleByID struct {
+	client Route53API
+	// filter hosted zones by id
+	zoneIDFilter provider.ZoneIDFilter
+}
+
+var _ ZonesAPI = &ZonesAPISingleByID{}
+
+func NewZonesAPISingleByID(awsConfig AWSConfig, client Route53API) *ZonesAPISingleByID {
+	return &ZonesAPISingleByID{
+		client:       client,
+		zoneIDFilter: awsConfig.ZoneIDFilter,
+	}
+}
+
+func (p ZonesAPISingleByID) GetZones(ctx context.Context) (map[string]*route53.HostedZone, error) {
+	if !p.zoneIDFilter.IsConfigured() && len(p.zoneIDFilter.ZoneIDs) != 1 {
+		return nil, fmt.Errorf("invalid zone id filter configuration %s", p.zoneIDFilter)
+	}
+	zoneID := p.zoneIDFilter.ZoneIDs[0]
+
+	getResp, err := p.client.GetHostedZoneWithContext(ctx, &route53.GetHostedZoneInput{
+		Id: &zoneID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hosted zone %s, %w", zoneID, err)
+	}
+	if getResp.HostedZone == nil {
+		return nil, fmt.Errorf("aws zone issue. No hosted zone info in response")
+	}
+
+	zone := getResp.HostedZone
+	zones := make(map[string]*route53.HostedZone)
+	zones[aws.StringValue(zone.Id)] = zone
+
+	return zones, nil
+}

--- a/internal/external-dns/provider/inmemory/inmemory.go
+++ b/internal/external-dns/provider/inmemory/inmemory.go
@@ -134,8 +134,8 @@ func (im *InMemoryProvider) GetZone(zone string) (Zone, error) {
 }
 
 // Zones returns filtered zones as specified by domain
-func (im *InMemoryProvider) Zones() map[string]string {
-	return im.filter.Zones(im.client.Zones())
+func (im *InMemoryProvider) Zones() (map[string]string, error) {
+	return im.filter.Zones(im.client.Zones()), nil
 }
 
 // Records returns the list of endpoints
@@ -144,7 +144,11 @@ func (im *InMemoryProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 
 	endpoints := make([]*endpoint.Endpoint, 0)
 
-	for zoneID := range im.Zones() {
+	zones, err := im.Zones()
+	if err != nil {
+		return nil, err
+	}
+	for zoneID := range zones {
 		records, err := im.client.Records(zoneID)
 		if err != nil {
 			return nil, err
@@ -166,7 +170,10 @@ func (im *InMemoryProvider) ApplyChanges(ctx context.Context, changes *plan.Chan
 
 	perZoneChanges := map[string]*plan.Changes{}
 
-	zones := im.Zones()
+	zones, err := im.Zones()
+	if err != nil {
+		return err
+	}
 	for zoneID := range zones {
 		perZoneChanges[zoneID] = &plan.Changes{}
 	}

--- a/internal/external-dns/provider/inmemory/inmemory_test.go
+++ b/internal/external-dns/provider/inmemory/inmemory_test.go
@@ -52,7 +52,7 @@ func testInMemoryRecords(t *testing.T) {
 			title:       "no records, no Zone",
 			zone:        "",
 			init:        map[string]Zone{},
-			expectError: false,
+			expectError: true,
 		},
 		{
 			title: "records, wrong Zone",
@@ -61,7 +61,7 @@ func testInMemoryRecords(t *testing.T) {
 				"org": {},
 				"com": {},
 			},
-			expectError: false,
+			expectError: true,
 		},
 		{
 			title: "records, Zone with records",
@@ -101,6 +101,7 @@ func testInMemoryRecords(t *testing.T) {
 			im.client = c
 			f := filter{domain: ti.zone}
 			im.filter = &f
+			im.zoneIDFilter = provider.ZoneIDFilter{ZoneIDs: []string{ti.zone}}
 			records, err := im.Records(context.Background())
 			if ti.expectError {
 				assert.Nil(t, records)
@@ -550,6 +551,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 			c := &InMemoryClient{}
 			c.zones = getInitData()
 			im.client = c
+			im.zoneIDFilter = provider.ZoneIDFilter{ZoneIDs: []string{"org"}}
 
 			err := im.ApplyChanges(context.Background(), ti.changes)
 			if ti.expectError {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -40,6 +41,13 @@ type Config struct {
 	ZoneTypeFilter externaldnsprovider.ZoneTypeFilter
 	// only consider hosted zones ending with this zone id
 	ZoneIDFilter externaldnsprovider.ZoneIDFilter
+}
+
+func (c Config) GetZoneID() (string, error) {
+	if !c.ZoneIDFilter.IsConfigured() && len(c.ZoneIDFilter.ZoneIDs) != 1 {
+		return "", fmt.Errorf("invalid zone id filter configuration %s", c.ZoneIDFilter)
+	}
+	return c.ZoneIDFilter.ZoneIDs[0], nil
 }
 
 type ProviderSpecificLabels struct {


### PR DESCRIPTION
Update all dns providers to only look for a single known zone when retrieving the list of zones that records need to be updated in. This logic still makes use of the external-dns filters, but ensures that a single non-empty string is set, and each provider overrides the default provider zone lookup logic to get the one specific zone required.

The external-dns Zones logic is written from the POV that we could be updating any zone on any reconciliation. This isn't the case for our controller where we will always be reconciling for a single known zone id on any given reconcile. The listing and filtering of all zones in the external dns provider was inefficient and increasing the likelihood of issues with updates/deletes etc.. in the wrong zone.