### PR TITLE
add watch and ns config

### DIFF
--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -47,10 +47,10 @@ func testBuildInMemoryCredentialsSecret(name, ns string) *v1.Secret {
 	}
 }
 
-func getTestEndpoints() []*externaldnsendpoint.Endpoint {
+func getTestEndpoints(dnsName string) []*externaldnsendpoint.Endpoint {
 	return []*externaldnsendpoint.Endpoint{
 		{
-			DNSName: "foo.example.com",
+			DNSName: dnsName,
 			Targets: []string{
 				"127.0.0.1",
 			},


### PR DESCRIPTION
fixes #82 

- Add a watch on ManagedZones in the DNSRecord controller
- Add watch namespace env var to allow specifying which namespace to watch


**Verification**

- set ```WATCH_NAMESPACES=dnstest```
- start controller
- create zone in default ns (note it is not reconciled)
- create zone in dnstest (it is reconciled)
- create dnsrecord in dnstest (it is reconciled)
- add label to managedzone see dnsrecord is reconciled when MZ is updated