### PR TITLE
Helm charts

### DIFF
--- a/.github/workflows/delete-release-helm-chart.yaml
+++ b/.github/workflows/delete-release-helm-chart.yaml
@@ -1,0 +1,23 @@
+# Description: This workflow is used to communicate Kuadrant helm charts repo that a release has been deleted.
+
+name: Delete Release Helm Chart
+on:
+  release:
+    types:
+      - deleted
+jobs:
+  delete_chart_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Parse Tag
+        run: |
+          tag=${{ github.event.release.tag_name || inputs.operatorTag }}
+          echo "OPERATOR_VERSION=${tag#v}" >> $GITHUB_ENV
+      - name: Sync deleted Helm Chart with repository
+        run: |
+          make helm-sync-package-deleted \
+            VERSION=${{env.OPERATOR_VERSION}} \
+            HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -1,0 +1,52 @@
+# Description: This workflow is used to release the Helm chart to the GitHub repository. The chart manifests should be already
+# built with the target `helm-build` and the manifests changes already committed to the tag to be released.
+
+name: Release Helm Chart
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      operatorTag:
+          description: Operator bundle version tag
+          default: v0.0.0
+          type: string
+jobs:
+  chart_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+        fetch-depth: 0
+
+    - name: Package Helm Chart
+      run: |
+        make helm-package
+
+    - name: Parse Tag
+      run: |
+        tag=${{ github.event.release.tag_name || inputs.operatorTag }}
+        echo "OPERATOR_VERSION=${tag#v}" >> $GITHUB_ENV
+
+    - name: Upload package to GitHub Release
+      uses: svenstaro/upload-release-action@v2
+      id: upload-chart
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: dns-operator-${{ env.OPERATOR_VERSION }}.tgz
+        asset_name: chart-dns-operator-${{ env.OPERATOR_VERSION }}.tgz
+        tag: ${{ github.ref }}
+        overwrite: true
+
+    - name: Sync Helm Chart with repository
+      run: |
+        make helm-sync-package-created \
+          VERSION=${{env.OPERATOR_VERSION}} \
+          HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
+          BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,7 @@ ACT = $(LOCALBIN)/act
 YQ = $(LOCALBIN)/yq
 GINKGO ?= $(LOCALBIN)/ginkgo
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+HELM ?= $(LOCALBIN)/helm
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.1
@@ -303,6 +304,7 @@ ACT_VERSION = latest
 YQ_VERSION := v4.34.2
 GINKGO_VERSION ?= v2.13.2
 GOLANGCI_LINT_VERSION ?= v1.55.2
+HELM_VERSION = v3.15.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -360,6 +362,20 @@ $(ACT): $(LOCALBIN)
 yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
+
+.PHONY: helm
+helm: $(HELM) ## Download helm locally if necessary.
+$(HELM):
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(HELM)) ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	wget -O helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-$${OS}-$${ARCH}.tar.gz ;\
+	tar -zxvf helm.tar.gz ;\
+	mv $${OS}-$${ARCH}/helm $(HELM) ;\
+	chmod +x $(HELM) ;\
+	rm -rf $${OS}-$${ARCH} helm.tar.gz ;\
+	}
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary

--- a/charts/dns-operator/.helmignore
+++ b/charts/dns-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/dns-operator/Chart.yaml
+++ b/charts/dns-operator/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: dns-operator
+description: Kubernetes operator responsible for reconciling DNS Record and Managed Zone custom resources.
+home: https://kuadrant.io
+icon: https://raw.githubusercontent.com/Kuadrant/kuadrant.github.io/main/static/img/apple-touch-icon.png
+keywords:
+  - dns
+  - managed zone
+  - kubernetes
+  - kuadrant
+sources:
+  - https://github.com/Kuadrant/dns-operator/
+kubeVersion: ">=1.19.0-0"
+type: application
+# The version will be properly set when the chart is released matching the operator version
+version: "0.0.0"
+maintainers:
+  - email: mnairn@redhat.com
+    name: Michael Nairn
+  - email: cbrookes@redhat.com
+    name: Craig Brookes
+  - email: pbrookes@redhat.com
+    name: Phil Brookes
+  - email: didier@redhat.com
+    name: Didier Di Cesare

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -1,0 +1,965 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/part-of: dns-operator
+    control-plane: dns-operator-controller-manager
+  name: dns-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: dnsrecords.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: DNSRecord
+    listKind: DNSRecordList
+    plural: dnsrecords
+    singular: dnsrecord
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DNSRecord ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSRecord is the Schema for the dnsrecords API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSRecordSpec defines the desired state of DNSRecord
+            properties:
+              endpoints:
+                description: endpoints is a list of endpoints that will be published
+                  into the dns provider.
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                minItems: 1
+                type: array
+              healthCheck:
+                description: |-
+                  HealthCheckSpec configures health checks in the DNS provider.
+                  By default this health check will be applied to each unique DNS A Record for
+                  the listeners assigned to the target gateway
+                properties:
+                  endpoint:
+                    description: |-
+                      Endpoint is the path to append to the host to reach the expected health check.
+                      Must start with "?" or "/", contain only valid URL characters and end with alphanumeric char or "/". For example "/" or "/healthz" are common
+                    pattern: ^(?:\?|\/)[\w\-.~:\/?#\[\]@!$&'()*+,;=]+(?:[a-zA-Z0-9]|\/){1}$
+                    type: string
+                  failureThreshold:
+                    description: FailureThreshold is a limit of consecutive failures
+                      that must occur for a host to be considered unhealthy
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Failure threshold must be greater than 0
+                      rule: self > 0
+                  port:
+                    description: Port to connect to the host on. Must be either 80,
+                      443 or 1024-49151
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Only ports 80, 443, 1024-49151 are allowed
+                      rule: self in [80, 443] || (self >= 1024 && self <= 49151)
+                  protocol:
+                    description: Protocol to use when connecting to the host, valid
+                      values are "HTTP" or "HTTPS"
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Only HTTP or HTTPS protocols are allowed
+                      rule: self in ['HTTP','HTTPS']
+                type: object
+              managedZone:
+                description: managedZone is a reference to a ManagedZone instance
+                  to which this record will publish its endpoints.
+                properties:
+                  name:
+                    description: |-
+                      `name` is the name of the managed zone.
+                      Required
+                    type: string
+                required:
+                - name
+                type: object
+              ownerID:
+                description: |-
+                  ownerID is a unique string used to identify the owner of this record.
+                  If unset or set to an empty string the record UID will be used.
+                maxLength: 36
+                minLength: 6
+                type: string
+                x-kubernetes-validations:
+                - message: OwnerID is immutable
+                  rule: self == oldSelf
+              rootHost:
+                description: |-
+                  rootHost is the single root for all endpoints in a DNSRecord.
+                  it is expected all defined endpoints are children of or equal to this rootHost
+                  Must contain at least two groups of valid URL characters separated by a "."
+                maxLength: 255
+                minLength: 1
+                pattern: ^(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)\.(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)$
+                type: string
+            required:
+            - managedZone
+            - rootHost
+            type: object
+            x-kubernetes-validations:
+            - message: OwnerID can't be unset if it was previously set
+              rule: '!has(oldSelf.ownerID) || has(self.ownerID)'
+            - message: OwnerID can't be set if it was previously unset
+              rule: has(oldSelf.ownerID) || !has(self.ownerID)
+          status:
+            description: DNSRecordStatus defines the observed state of DNSRecord
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the record in the managed zone.
+
+
+                  If publishing the record fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoints:
+                description: |-
+                  endpoints are the last endpoints that were successfully published by the provider
+
+
+                  Provides a simple mechanism to store the current provider records in order to
+                  delete any that are no longer present in DNSRecordSpec.Endpoints
+
+
+                  Note: This will not be required if/when we switch to using external-dns since when
+                  running with a "sync" policy it will clean up unused records automatically.
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              healthCheck:
+                properties:
+                  conditions:
+                    items:
+                      description: "Condition contains details for one aspect of the
+                        current state of this API Resource.\n---\nThis struct is intended
+                        for direct use as an array at the field path .status.conditions.
+                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
+                        the observations of a foo's current state.\n\t    // Known
+                        .status.conditions.type are: \"Available\", \"Progressing\",
+                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
+                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                        \   // other fields\n\t}"
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: |-
+                            type of condition in CamelCase or in foo.example.com/CamelCase.
+                            ---
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                            useful (see .node.status.conditions), the ability to deconflict is important.
+                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  probes:
+                    items:
+                      properties:
+                        conditions:
+                          items:
+                            description: "Condition contains details for one aspect
+                              of the current state of this API Resource.\n---\nThis
+                              struct is intended for direct use as an array at the
+                              field path .status.conditions.  For example,\n\n\n\ttype
+                              FooStatus struct{\n\t    // Represents the observations
+                              of a foo's current state.\n\t    // Known .status.conditions.type
+                              are: \"Available\", \"Progressing\", and \"Degraded\"\n\t
+                              \   // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
+                              \   // +listType=map\n\t    // +listMapKey=type\n\t
+                              \   Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                              patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                              \   // other fields\n\t}"
+                            properties:
+                              lastTransitionTime:
+                                description: |-
+                                  lastTransitionTime is the last time the condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                format: date-time
+                                type: string
+                              message:
+                                description: |-
+                                  message is a human readable message indicating details about the transition.
+                                  This may be an empty string.
+                                maxLength: 32768
+                                type: string
+                              observedGeneration:
+                                description: |-
+                                  observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                  For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                  with respect to the current state of the instance.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              reason:
+                                description: |-
+                                  reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define expected values and meanings for this field,
+                                  and whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string.
+                                  This field may not be empty.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                type: string
+                              status:
+                                description: status of the condition, one of True,
+                                  False, Unknown.
+                                enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                                type: string
+                              type:
+                                description: |-
+                                  type of condition in CamelCase or in foo.example.com/CamelCase.
+                                  ---
+                                  Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                                  useful (see .node.status.conditions), the ability to deconflict is important.
+                                  The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        host:
+                          type: string
+                        id:
+                          type: string
+                        ipAddress:
+                          type: string
+                        synced:
+                          type: boolean
+                      required:
+                      - host
+                      - id
+                      - ipAddress
+                      type: object
+                    type: array
+                type: object
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  DNSRecord.  When the DNSRecord is updated, the controller updates the
+                  corresponding record in each managed zone.  If an update for a
+                  particular zone fails, that failure is recorded in the status
+                  condition for the zone so that the controller can determine that it
+                  needs to retry the update for that specific zone.
+                format: int64
+                type: integer
+              ownerID:
+                description: ownerID is a unique string used to identify the owner
+                  of this record.
+                type: string
+              queuedAt:
+                description: QueuedAt is a time when DNS record was received for the
+                  reconciliation
+                format: date-time
+                type: string
+              queuedFor:
+                description: QueuedFor is a time when we expect a DNS record to be
+                  reconciled again
+                format: date-time
+                type: string
+              validFor:
+                description: ValidFor indicates duration since the last reconciliation
+                  we consider data in the record to be valid
+                type: string
+              writeCounter:
+                description: |-
+                  WriteCounter represent a number of consecutive write attempts on the same generation of the record.
+                  It is being reset to 0 when the generation changes or there are no changes to write.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: managedzones.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: ManagedZone
+    listKind: ManagedZoneList
+    plural: managedzones
+    singular: managedzone
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Domain of this Managed Zone
+      jsonPath: .spec.domainName
+      name: Domain Name
+      type: string
+    - description: The ID assigned by this provider for this zone .
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Number of records in the provider zone.
+      jsonPath: .status.recordCount
+      name: Record Count
+      type: string
+    - description: The NameServers assigned by the provider for this zone.
+      jsonPath: .status.nameServers
+      name: NameServers
+      type: string
+    - description: Managed Zone ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedZone is the Schema for the managedzones API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedZoneSpec defines the desired state of ManagedZone
+            properties:
+              description:
+                description: description for this ManagedZone
+                type: string
+              dnsProviderSecretRef:
+                description: dnsProviderSecretRef reference to a secret containing
+                  credentials to access a dns provider.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              domainName:
+                description: domainName of this ManagedZone
+                pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
+                type: string
+              id:
+                description: id is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
+                type: string
+              parentManagedZone:
+                description: parentManagedZone reference to another managed zone that
+                  this managed zone belongs to.
+                properties:
+                  name:
+                    description: |-
+                      `name` is the name of the managed zone.
+                      Required
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - description
+            - dnsProviderSecretRef
+            - domainName
+            type: object
+          status:
+            description: ManagedZoneStatus defines the observed state of a Zone
+            properties:
+              conditions:
+                description: |-
+                  List of status conditions to indicate the status of a ManagedZone.
+                  Known condition types are `Ready`.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: The ID assigned by this provider for this zone (i.e.
+                  route53.HostedZone.ID)
+                type: string
+              nameServers:
+                description: The NameServers assigned by the provider for this zone
+                  (i.e. route53.DelegationSet.NameServers)
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recently observed generation
+                  of the ManagedZone.
+                format: int64
+                type: integer
+              recordCount:
+                description: The number of records in the provider zone
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-controller-manager
+  namespace: dns-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-leader-election-role
+  namespace: dns-operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dns-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - managedzones
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - managedzones/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - managedzones/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-leader-election-rolebinding
+  namespace: dns-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dns-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: dns-operator-controller-manager
+  namespace: dns-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dns-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: dns-operator-controller-manager
+  namespace: dns-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: dns-operator-controller-manager
+  name: dns-operator-controller-manager-metrics-service
+  namespace: dns-operator-system
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+  selector:
+    control-plane: dns-operator-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: dns-operator
+    control-plane: dns-operator-controller-manager
+  name: dns-operator-controller-manager
+  namespace: dns-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: dns-operator-controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: dns-operator-controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8080
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: WATCH_NAMESPACES
+          value: ""
+        image: quay.io/kuadrant/dns-operator:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: dns-operator-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/dns-operator/values.yaml
+++ b/charts/dns-operator/values.yaml
@@ -1,0 +1,1 @@
+# For its first iteration, this chart won't be configurable with helm settings

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../default

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,0 +1,61 @@
+##@ Helm Charts
+
+.PHONY: helm-build
+helm-build: yq manifests kustomize operator-sdk ## Build the helm chart from kustomize manifests
+	# Replace the controller image
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	# Build the helm chart templates from kustomize manifests
+	$(KUSTOMIZE) build config/helm > charts/dns-operator/templates/manifests.yaml
+	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i charts/dns-operator/Chart.yaml
+
+.PHONY: helm-install
+helm-install: $(HELM) ## Install the helm chart
+	# Install the helm chart in the cluster
+	$(HELM) install dns-operator charts/dns-operator
+
+.PHONY: helm-uninstall
+helm-uninstall: $(HELM) ## Uninstall the helm chart
+	# Uninstall the helm chart from the cluster
+	$(HELM) uninstall dns-operator
+
+.PHONY: helm-upgrade
+helm-upgrade: $(HELM) ## Upgrade the helm chart
+	# Upgrade the helm chart in the cluster
+	$(HELM) upgrade dns-operator charts/dns-operator
+
+.PHONY: helm-package
+helm-package: $(HELM) ## Package the helm chart
+	# Package the helm chart
+	$(HELM) package charts/dns-operator
+
+# GitHub Token with permissions to upload to the release assets
+HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>
+# GitHub Release Asset Browser Download URL, it can be find in the output of the uploaded asset
+BROWSER_DOWNLOAD_URL ?= <BROWSER-DOWNLOAD-URL>
+# Github repo name for the helm charts repository
+HELM_REPO_NAME ?= helm-charts
+ifeq (0.0.0,$(VERSION))
+CHART_VERSION = $(VERSION)-dev
+else
+CHART_VERSION = $(VERSION)
+endif
+
+.PHONY: helm-sync-package-created
+helm-sync-package-created: ## Sync the helm chart package to the helm-charts repo
+	curl -L \
+	  -X POST \
+	  -H "Accept: application/vnd.github+json" \
+	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
+	  -H "X-GitHub-Api-Version: 2022-11-28" \
+	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
+	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+
+.PHONY: helm-sync-package-deleted
+helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-charts repo
+	curl -L \
+	  -X POST \
+	  -H "Accept: application/vnd.github+json" \
+	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
+	  -H "X-GitHub-Api-Version: 2022-11-28" \
+	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
+	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)"}}'


### PR DESCRIPTION
This PR introduces a way to manage a DNS Operator [Helm Chart](https://helm.sh/). This is not meant to replace the way we are building and delivering our manifests (Kustomize, OLM) but to provide an alternative (complementary) way of delivering the operator.

This early implementation uses Kustomize to create the chart template, instead of creating and maintaining new ones with Helm, to later customize the Helm only settings with its `values.yaml`

**NOTES**

* This chart (and every other operator chart we package in the future: Limitador, Authorino, etc) bundles only the operator in the same fashion OLM does.
* The operator version matches the chart version
* This first release doesn't use helm templating, it provides only the manifests previously built by Kustomize.
* The sole repository for all our operator charts will be hosted in [Kuadrant/helm-charts](https://github.com/Kuadrant/helm-charts/).
* The "source of truth" (source code and releasing logic) will be provided in each operator repo, not in the helm charts repository above.
* The helm charts repository is [Kuadrant/helm-charts](https://github.com/Kuadrant/helm-charts/)
* Documentation will be provided once the repository and other operator charts are tested.
* The steps to try out the repository will be provided in the kuadrant helm charts repo.
* For the release of the package, it will be tested once merged with alpha pre releases.


**Verification Steps**

1. Create a local kind cluster
```sh
kind create cluster --name kuadrant-local
```

2. Deploy (install) the default (`latest`) DNS Operator chart
```sh
make helm-install
```

3. Verify the installed operator image:
```sh
kubectl get deployments/dns-operator-controller-manager -n dns-operator-system -o yaml | grep image:
```
it should return:
```sh
image: quay.io/kuadrant/dns-operator:latest
```

4. Build new manifests with specific version of the operator
```sh
make helm-build VERSION=0.4.0-alpha1
```

5. Upgrade the current installed operator to the freshly built one
```sh
make helm-upgrade
```

6. Check the installed operator image:
```sh
kubectl get deployments/dns-operator-controller-manager -n dns-operator-system -o yaml | grep image:
```

it should return:
```sh
image: quay.io/kuadrant/dns-operator:v0.4.0-alpha1
```

7. For uninstalling the chart:
```sh
make helm-uninstall
```
