### PR TITLE
tests: Multi cluster e2e test support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,14 @@ local-setup: $(KIND) ## Setup local development kind cluster, dependencies and o
 	$(KUBECTL) get managedzones -A
 	@echo "local-setup: Complete!!"
 
+.PHONY: local-setup-multi
+local-setup-multi: CLUSTER_COUNT=1
+local-setup-multi: ## Setup multiple local development kind clusters
+	@n=1 ; while [[ $$n -le $(CLUSTER_COUNT) ]] ; do \
+		$(MAKE) -s local-setup KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME_PREFIX}-$$n;\
+		((n = n + 1)) ;\
+	done ;\
+
 .PHONY: local-cleanup
 local-cleanup: ## Delete local cluster
 	$(MAKE) kind-delete-cluster

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -3,7 +3,8 @@
 
 ## Targets to help install and use kind for development https://kind.sigs.k8s.io
 
-KIND_CLUSTER_NAME ?= kuadrant-dns-local
+KIND_CLUSTER_NAME_PREFIX ?= kuadrant-dns-local
+KIND_CLUSTER_NAME ?= $(KIND_CLUSTER_NAME_PREFIX)
 
 .PHONY: kind-create-cluster
 kind-create-cluster: kind ## Create the "kuadrant-dns-local" kind cluster.

--- a/test/e2e/helpers/common.go
+++ b/test/e2e/helpers/common.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/goombaio/namegenerator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -86,5 +87,6 @@ func ProviderForManagedZone(ctx context.Context, mz *v1alpha1.ManagedZone, c cli
 		ZoneTypeFilter: externaldnsprovider.NewZoneTypeFilter(""),
 		ZoneIDFilter:   externaldnsprovider.NewZoneIDFilter([]string{mz.Status.ID}),
 	}
-	return providerFactory.ProviderFor(ctx, mz, providerConfig)
+	//Disable provider logging in test output
+	return providerFactory.ProviderFor(logr.NewContext(ctx, logr.Discard()), mz, providerConfig)
 }

--- a/test/e2e/multi_instance/README.md
+++ b/test/e2e/multi_instance/README.md
@@ -10,7 +10,7 @@ Deploy the operator on a local kind cluster with X operator instances (DEPLOYMEN
 make local-setup DEPLOY=true DEPLOYMENT_SCOPE=namespace DEPLOYMENT_COUNT=2
 ```
 
-The above will create two dns operator deployments on the kind cluster, each configured to watch its own namespace, with the developmnet managedzones (Assuming you have configured them locally) created in each deployment namespace.
+The above will create two dns operator deployments on the kind cluster, each configured to watch its own namespace, with the development managedzones (Assuming you have configured them locally) created in each deployment namespace.
 
 DNS Operator Deployments:
 ```shell

--- a/test/e2e/multi_instance/multi_record_test.go
+++ b/test/e2e/multi_instance/multi_record_test.go
@@ -11,12 +11,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/provider"
 	. "github.com/kuadrant/dns-operator/test/e2e/helpers"
 )
 
@@ -36,6 +38,9 @@ var _ = Describe("Multi Record Test", func() {
 
 	var testRecords []*testDNSRecord
 
+	recordsReadyMaxDuration := time.Minute
+	recordsRemovedMaxDuration := time.Minute
+
 	BeforeEach(func(ctx SpecContext) {
 		testID = "t-multi-" + GenerateName()
 		testDomainName = strings.Join([]string{testSuiteID, testZoneDomainName}, ".")
@@ -54,7 +59,7 @@ var _ = Describe("Multi Record Test", func() {
 	AfterEach(func(ctx SpecContext) {
 		By("ensuring all dns records are deleted")
 		for _, tr := range testRecords {
-			err := k8sClient.Delete(ctx, tr.record,
+			err := tr.cluster.k8sClient.Delete(ctx, tr.record,
 				client.PropagationPolicy(metav1.DeletePropagationForeground))
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 		}
@@ -62,59 +67,61 @@ var _ = Describe("Multi Record Test", func() {
 		By("checking all dns records are removed")
 		Eventually(func(g Gomega, ctx context.Context) {
 			for _, tr := range testRecords {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+				err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
 				g.Expect(err).To(MatchError(ContainSubstring("not found")))
 			}
 		}, time.Minute, 10*time.Second, ctx).Should(Succeed())
 	})
 
 	Context("simple", func() {
-		It("makes available a hostname that can be resolved", func(ctx SpecContext) {
-			By("creating a simple dnsrecord in each managed zone")
-			for i, managedZone := range testManagedZones {
-				config := testConfig{
-					testTargetIP: fmt.Sprintf("127.0.0.%d", i+1),
-				}
-				record := &v1alpha1.DNSRecord{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testID,
-						Namespace: managedZone.Namespace,
-					},
-					Spec: v1alpha1.DNSRecordSpec{
-						RootHost: testHostname,
-						ManagedZoneRef: &v1alpha1.ManagedZoneReference{
-							Name: managedZone.Name,
+		It("creates and deletes distributed dns records", func(ctx SpecContext) {
+			By(fmt.Sprintf("creating %d simple dnsrecords accross %d clusters", len(testNamespaces)*len(testClusters), len(testClusters)))
+			for ci, tc := range testClusters {
+				for mi, mz := range tc.testManagedZones {
+					config := testConfig{
+						testTargetIP: fmt.Sprintf("127.0.%d.%d", ci+1, mi+1),
+					}
+					record := &v1alpha1.DNSRecord{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      testID,
+							Namespace: mz.Namespace,
 						},
-						Endpoints: []*externaldnsendpoint.Endpoint{
-							{
-								DNSName: testHostname,
-								Targets: []string{
-									config.testTargetIP,
-								},
-								RecordType: "A",
-								RecordTTL:  60,
+						Spec: v1alpha1.DNSRecordSpec{
+							RootHost: testHostname,
+							ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+								Name: mz.Name,
 							},
+							Endpoints: []*externaldnsendpoint.Endpoint{
+								{
+									DNSName: testHostname,
+									Targets: []string{
+										config.testTargetIP,
+									},
+									RecordType: "A",
+									RecordTTL:  60,
+								},
+							},
+							HealthCheck: nil,
 						},
-						HealthCheck: nil,
-					},
+					}
+
+					By(fmt.Sprintf("creating dns record [name: `%s`, namespace: `%s`, mz: `%s`, endpoint: [dnsname: `%s`, target: `%s`]] on cluster [name: `%s`]", record.Name, record.Namespace, mz.Name, testHostname, config.testTargetIP, tc.name))
+					err := tc.k8sClient.Create(ctx, record)
+					Expect(err).ToNot(HaveOccurred())
+
+					testRecords = append(testRecords, &testDNSRecord{
+						cluster:     &testClusters[ci],
+						managedZone: mz,
+						record:      record,
+						config:      config,
+					})
 				}
-
-				By(fmt.Sprintf("creating dns record [name: `%s`, namespace: `%s`, managedZone: `%s`, endpoint: [dnsname: `%s`, target: `%s`]]", record.Name, record.Namespace, managedZone.Name, testHostname, config.testTargetIP))
-				err := k8sClient.Create(ctx, record)
-				Expect(err).ToNot(HaveOccurred())
-
-				testRecords = append(testRecords, &testDNSRecord{
-					managedZone: managedZone,
-					record:      record,
-					config:      config,
-				})
 			}
-			Expect(testRecords).To(HaveLen(len(testManagedZones)))
 
-			By("checking all dns records become ready")
+			By(fmt.Sprintf("checking all dns records become ready within %s", recordsReadyMaxDuration))
 			Eventually(func(g Gomega, ctx context.Context) {
 				for _, tr := range testRecords {
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(tr.record.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
@@ -123,10 +130,10 @@ var _ = Describe("Multi Record Test", func() {
 						})),
 					)
 				}
-			}, time.Minute, 10*time.Second, ctx).Should(Succeed())
+			}, recordsReadyMaxDuration, 5*time.Second, ctx).Should(Succeed())
 
-			By("ensuring managedZone records are created as expected")
-			testProvider, err := ProviderForManagedZone(ctx, testRecords[0].managedZone, k8sClient)
+			By("checking provider zone records are created as expected")
+			testProvider, err := ProviderForManagedZone(ctx, testClusters[0].testManagedZones[0], testClusters[0].k8sClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
@@ -177,18 +184,18 @@ var _ = Describe("Multi Record Test", func() {
 			recordToDelete := testRecords[0]
 			lastRecord := len(testRecords) == 1
 			By(fmt.Sprintf("deleting dns record [name: `%s` namespace: `%s`]", recordToDelete.record.Name, recordToDelete.record.Namespace))
-			err = k8sClient.Delete(ctx, recordToDelete.record,
+			err = recordToDelete.cluster.k8sClient.Delete(ctx, recordToDelete.record,
 				client.PropagationPolicy(metav1.DeletePropagationForeground))
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 
-			By(fmt.Sprintf("checking dns record [name: `%s` namespace: `%s`] is removed", recordToDelete.record.Name, recordToDelete.record.Namespace))
+			By(fmt.Sprintf("checking dns record [name: `%s` namespace: `%s`] is removed within %s", recordToDelete.record.Name, recordToDelete.record.Namespace, recordsRemovedMaxDuration))
 			Eventually(func(g Gomega, ctx context.Context) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(recordToDelete.record), recordToDelete.record)
+				err := recordToDelete.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(recordToDelete.record), recordToDelete.record)
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(ContainSubstring("not found")))
-			}, 10*time.Second, 1*time.Second, ctx).Should(Succeed())
+			}, recordsRemovedMaxDuration, 5*time.Second, ctx).Should(Succeed())
 
-			By("ensuring zone records are updated as expected")
+			By("checking provider zone records are updated as expected")
 			Eventually(func(g Gomega, ctx context.Context) {
 				zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -214,131 +221,161 @@ var _ = Describe("Multi Record Test", func() {
 						})),
 					))
 				}
-			}, 5*time.Second, 1*time.Second, ctx).Should(Succeed())
+			}, 5*time.Second, time.Second, ctx).Should(Succeed())
+
+			By("deleting all remaining dns records")
+			for _, tr := range testRecords {
+				err := tr.cluster.k8sClient.Delete(ctx, tr.record,
+					client.PropagationPolicy(metav1.DeletePropagationForeground))
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+			}
+
+			By(fmt.Sprintf("checking all dns records are removed within %s", recordsRemovedMaxDuration))
+			Eventually(func(g Gomega, ctx context.Context) {
+				for _, tr := range testRecords {
+					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}
+			}, recordsRemovedMaxDuration, 5*time.Second, ctx).Should(Succeed())
+
+			By("checking provider zone records are all removed")
+			Eventually(func(g Gomega, ctx context.Context) {
+				zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(zoneEndpoints).To(HaveLen(0))
+			}, 5*time.Second, time.Second, ctx).Should(Succeed())
 
 		})
 
 	})
 
 	Context("loadbalanced", func() {
-		It("makes available a hostname that can be resolved", func(ctx SpecContext) {
-			testGeoRecords := map[string][]*testDNSRecord{}
+		It("creates and deletes distributed dns records", func(ctx SpecContext) {
+			testGeoRecords := map[string][]testDNSRecord{}
 
-			By("creating a loadbalanced dnsrecord in each managed zone")
-			for i, managedZone := range testManagedZones {
+			By(fmt.Sprintf("creating %d loadbalanced dnsrecords accross %d clusters", len(testNamespaces)*len(testClusters), len(testClusters)))
+			for ci, tc := range testClusters {
+				for mi, mz := range tc.testManagedZones {
 
-				var geoCode string
-				if i%2 == 0 {
-					geoCode = geoCode1
-				} else {
-					geoCode = geoCode2
-				}
+					var geoCode string
+					if (ci+mi)%2 == 0 {
+						geoCode = geoCode1
+					} else {
+						geoCode = geoCode2
+					}
 
-				klbHostName := "klb." + testHostname
-				geoKlbHostName := strings.ToLower(geoCode) + "." + klbHostName
-				defaultGeoKlbHostName := strings.ToLower(geoCode1) + "." + klbHostName
-				clusterKlbHostName := fmt.Sprintf("cluster%d.%s", i+1, klbHostName)
+					klbHostName := "klb." + testHostname
+					geoKlbHostName := strings.ToLower(geoCode) + "." + klbHostName
+					defaultGeoKlbHostName := strings.ToLower(geoCode1) + "." + klbHostName
+					clusterKlbHostName := fmt.Sprintf("cluster%d-%d.%s", ci+1, mi+1, klbHostName)
 
-				config := testConfig{
-					testTargetIP:       fmt.Sprintf("127.0.0.%d", i+1),
-					testGeoCode:        geoCode,
-					testDefaultGeoCode: geoCode1,
-				}
-
-				record := &v1alpha1.DNSRecord{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testID,
-						Namespace: managedZone.Namespace,
-					},
-					Spec: v1alpha1.DNSRecordSpec{
-						RootHost: testHostname,
-						ManagedZoneRef: &v1alpha1.ManagedZoneReference{
-							Name: managedZone.Name,
+					config := testConfig{
+						testTargetIP:       fmt.Sprintf("127.0.%d.%d", ci+1, mi+1),
+						testGeoCode:        geoCode,
+						testDefaultGeoCode: geoCode1,
+						hostnames: testHostnames{
+							klb:           klbHostName,
+							geoKlb:        geoKlbHostName,
+							defaultGeoKlb: defaultGeoKlbHostName,
+							clusterKlb:    clusterKlbHostName,
 						},
-						Endpoints: []*externaldnsendpoint.Endpoint{
-							{
-								DNSName: clusterKlbHostName,
-								Targets: []string{
-									config.testTargetIP,
-								},
-								RecordType: "A",
-								RecordTTL:  60,
-							},
-							{
-								DNSName: testHostname,
-								Targets: []string{
-									klbHostName,
-								},
-								RecordType: "CNAME",
-								RecordTTL:  300,
-							},
-							{
-								DNSName: geoKlbHostName,
-								Targets: []string{
-									clusterKlbHostName,
-								},
-								RecordType:    "CNAME",
-								RecordTTL:     60,
-								SetIdentifier: clusterKlbHostName,
-								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
-									{
-										Name:  "weight",
-										Value: "200",
-									},
-								},
-							},
-							{
-								DNSName: klbHostName,
-								Targets: []string{
-									geoKlbHostName,
-								},
-								RecordType:    "CNAME",
-								RecordTTL:     300,
-								SetIdentifier: config.testGeoCode,
-								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
-									{
-										Name:  "geo-code",
-										Value: config.testGeoCode,
-									},
-								},
-							},
-							{
-								DNSName: klbHostName,
-								Targets: []string{
-									defaultGeoKlbHostName,
-								},
-								RecordType:    "CNAME",
-								RecordTTL:     300,
-								SetIdentifier: "default",
-								ProviderSpecific: externaldnsendpoint.ProviderSpecific{
-									{
-										Name:  "geo-code",
-										Value: "*",
-									},
-								},
-							},
-						},
-						HealthCheck: nil,
-					},
-				}
+					}
 
-				By(fmt.Sprintf("creating dns record [name: `%s`, namespace: `%s`, managedZone: `%s`, endpoint: [dnsname: `%s`, target: `%s`, geoCode: `%s`]]", record.Name, record.Namespace, managedZone.Name, testHostname, config.testTargetIP, config.testGeoCode))
-				err := k8sClient.Create(ctx, record)
-				Expect(err).ToNot(HaveOccurred())
-				tr := &testDNSRecord{
-					managedZone: managedZone,
-					record:      record,
-					config:      config,
+					record := &v1alpha1.DNSRecord{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      testID,
+							Namespace: mz.Namespace,
+						},
+						Spec: v1alpha1.DNSRecordSpec{
+							RootHost: testHostname,
+							ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+								Name: mz.Name,
+							},
+							Endpoints: []*externaldnsendpoint.Endpoint{
+								{
+									DNSName: clusterKlbHostName,
+									Targets: []string{
+										config.testTargetIP,
+									},
+									RecordType: "A",
+									RecordTTL:  60,
+								},
+								{
+									DNSName: testHostname,
+									Targets: []string{
+										klbHostName,
+									},
+									RecordType: "CNAME",
+									RecordTTL:  300,
+								},
+								{
+									DNSName: geoKlbHostName,
+									Targets: []string{
+										clusterKlbHostName,
+									},
+									RecordType:    "CNAME",
+									RecordTTL:     60,
+									SetIdentifier: clusterKlbHostName,
+									ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+										{
+											Name:  "weight",
+											Value: "200",
+										},
+									},
+								},
+								{
+									DNSName: klbHostName,
+									Targets: []string{
+										geoKlbHostName,
+									},
+									RecordType:    "CNAME",
+									RecordTTL:     300,
+									SetIdentifier: config.testGeoCode,
+									ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+										{
+											Name:  "geo-code",
+											Value: config.testGeoCode,
+										},
+									},
+								},
+								{
+									DNSName: klbHostName,
+									Targets: []string{
+										defaultGeoKlbHostName,
+									},
+									RecordType:    "CNAME",
+									RecordTTL:     300,
+									SetIdentifier: "default",
+									ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+										{
+											Name:  "geo-code",
+											Value: "*",
+										},
+									},
+								},
+							},
+							HealthCheck: nil,
+						},
+					}
+
+					By(fmt.Sprintf("creating dns record [name: `%s`, namespace: `%s`, managedZone: `%s`, endpoint: [dnsname: `%s`, target: `%s`, geoCode: `%s`]] on cluster [name: `%s`]", record.Name, record.Namespace, mz.Name, testHostname, config.testTargetIP, config.testGeoCode, tc.name))
+					err := tc.k8sClient.Create(ctx, record)
+					Expect(err).ToNot(HaveOccurred())
+					tr := &testDNSRecord{
+						cluster:     &testClusters[ci],
+						managedZone: mz,
+						record:      record,
+						config:      config,
+					}
+					testRecords = append(testRecords, tr)
+					testGeoRecords[config.testGeoCode] = append(testGeoRecords[config.testGeoCode], *tr)
 				}
-				testRecords = append(testRecords, tr)
-				testGeoRecords[config.testGeoCode] = append(testGeoRecords[config.testGeoCode], tr)
 			}
-			Expect(testRecords).To(HaveLen(len(testManagedZones)))
 
-			By("checking all dns records become ready")
+			By(fmt.Sprintf("checking all dns records become ready within %s", recordsReadyMaxDuration))
 			Eventually(func(g Gomega, ctx context.Context) {
 				for _, tr := range testRecords {
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
 					g.Expect(err).NotTo(HaveOccurred())
 					g.Expect(tr.record.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
@@ -347,22 +384,294 @@ var _ = Describe("Multi Record Test", func() {
 						})),
 					)
 				}
-			}, time.Minute, 10*time.Second, ctx).Should(Succeed())
+			}, recordsReadyMaxDuration, 5*time.Second, ctx).Should(Succeed())
 
-			By("ensuring managedZone records are created as expected")
-			testProvider, err := ProviderForManagedZone(ctx, testRecords[0].managedZone, k8sClient)
+			By("checking provider zone records are created as expected")
+			testProvider, err := ProviderForManagedZone(ctx, testClusters[0].testManagedZones[0], testClusters[0].k8sClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
 			Expect(err).NotTo(HaveOccurred())
-			var expectedLen int
+			var expectedEndpointsLen int
 			if testDNSProvider == "google" {
-				expectedLen = (2 + len(testGeoRecords) + len(testRecords)) * 2
-				Expect(zoneEndpoints).To(HaveLen(expectedLen))
+				expectedEndpointsLen = (2 + len(testGeoRecords) + len(testRecords)) * 2
+				Expect(zoneEndpoints).To(HaveLen(expectedEndpointsLen))
 			} else if testDNSProvider == "aws" {
-				expectedLen = (2 + len(testGeoRecords) + (len(testRecords) * 2)) * 2
-				Expect(zoneEndpoints).To(HaveLen(expectedLen))
+				expectedEndpointsLen = (2 + len(testGeoRecords) + (len(testRecords) * 2)) * 2
+				Expect(zoneEndpoints).To(HaveLen(expectedEndpointsLen))
 			}
+
+			var totalEndpointsChecked = 0
+			var allOwners = []string{}
+			var allOwnerMatcher = []types.GomegaMatcher{
+				ContainSubstring("heritage=external-dns,external-dns/owner="),
+			}
+			var geoOwners = map[string][]string{}
+			var geoKlbHostname = map[string]string{}
+			var geoOwnerMatcher = map[string][]types.GomegaMatcher{}
+			for i := range testRecords {
+				ownerID := testRecords[i].record.Status.OwnerID
+				allOwners = append(allOwners, ownerID)
+				allOwnerMatcher = append(allOwnerMatcher, ContainSubstring(ownerID))
+
+				geoCode := testRecords[i].config.testGeoCode
+				geoOwners[geoCode] = append(geoOwners[geoCode], ownerID)
+				geoKlbHostname[geoCode] = testRecords[i].config.hostnames.geoKlb
+				if _, ok := geoOwnerMatcher[geoCode]; !ok {
+					geoOwnerMatcher[geoCode] = []types.GomegaMatcher{
+						ContainSubstring("heritage=external-dns,external-dns/owner="),
+					}
+				}
+				geoOwnerMatcher[geoCode] = append(geoOwnerMatcher[geoCode], ContainSubstring(ownerID))
+			}
+
+			By("[Common] checking common endpoints")
+			// A CNAME record for testHostname should always exist and be owned by all endpoints
+			By("[Common] checking " + testHostname + " endpoint")
+			Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"DNSName":       Equal(testHostname),
+				"Targets":       ConsistOf(testRecords[0].config.hostnames.klb),
+				"RecordType":    Equal("CNAME"),
+				"SetIdentifier": Equal(""),
+				"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+			}))))
+			totalEndpointsChecked++
+			By("[Common] checking " + testHostname + " TXT owner endpoint")
+			Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"DNSName":       Equal("kuadrant-cname-" + testHostname),
+				"Targets":       ContainElement(And(allOwnerMatcher...)),
+				"RecordType":    Equal("TXT"),
+				"SetIdentifier": Equal(""),
+				"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+			}))))
+			totalEndpointsChecked++
+
+			By("[Geo] checking geo endpoints")
+			if testDNSProvider == "google" {
+				// A CNAME record for klbHostName should always exist, be owned by all endpoints and target all geo hostnames
+				klbHostName := testRecords[0].config.hostnames.klb
+
+				allKlbGeoHostnames := []string{}
+				gcpGeoProps := []externaldnsendpoint.ProviderSpecificProperty{
+					{Name: "routingpolicy", Value: "geo"},
+				}
+				for g, h := range geoKlbHostname {
+					allKlbGeoHostnames = append(allKlbGeoHostnames, h)
+					gcpGeoProps = append(gcpGeoProps, externaldnsendpoint.ProviderSpecificProperty{Name: h, Value: g})
+				}
+
+				By("[Geo] checking " + klbHostName + " endpoint")
+				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"DNSName":          Equal(klbHostName),
+					"Targets":          ConsistOf(allKlbGeoHostnames),
+					"RecordType":       Equal("CNAME"),
+					"SetIdentifier":    Equal(""),
+					"RecordTTL":        Equal(externaldnsendpoint.TTL(300)),
+					"ProviderSpecific": ContainElements(gcpGeoProps),
+				}))))
+				totalEndpointsChecked++
+				By("[Geo] checking " + klbHostName + " TXT owner endpoint")
+				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+					"Targets":       ContainElement(And(allOwnerMatcher...)),
+					"RecordType":    Equal("TXT"),
+					"SetIdentifier": Equal(""),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+				}))))
+				totalEndpointsChecked++
+			}
+			if testDNSProvider == "aws" {
+				// A CNAME record for klbHostName should exist for each geo and be owned by all endpoints in that geo
+				klbHostName := testRecords[0].config.hostnames.klb
+				for geoCode, geoRecords := range testGeoRecords {
+					geoKlbHostName := geoRecords[0].config.hostnames.geoKlb
+
+					By("[Geo] checking " + klbHostName + " -> " + geoCode + " -> " + geoKlbHostName + " - endpoint")
+
+					awsGeoCodeKey := "aws/geolocation-country-code"
+					if !provider.IsISO3166Alpha2Code(geoCode) {
+						awsGeoCodeKey = "aws/geolocation-continent-code"
+					}
+
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(klbHostName),
+						"Targets":       ConsistOf(geoKlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(geoCode),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: awsGeoCodeKey, Value: geoCode},
+						}),
+					}))))
+					totalEndpointsChecked++
+					By("[Geo] checking " + klbHostName + " -> " + geoCode + " - TXT owner endpoint")
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+						"Targets":       ContainElement(And(geoOwnerMatcher[geoCode]...)),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(geoCode),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: awsGeoCodeKey, Value: geoCode},
+						}),
+					}))))
+					totalEndpointsChecked++
+				}
+
+				defaultGeoKlbHostName := testRecords[0].config.hostnames.defaultGeoKlb
+				defaultGeoCode := testRecords[0].config.testDefaultGeoCode
+
+				By("[Geo] checking endpoint " + klbHostName + " -> default")
+				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"DNSName":       Equal(klbHostName),
+					"Targets":       ConsistOf(defaultGeoKlbHostName),
+					"RecordType":    Equal("CNAME"),
+					"SetIdentifier": Equal("default"),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+						{Name: "alias", Value: "false"},
+						{Name: "aws/geolocation-country-code", Value: "*"},
+					}),
+				}))))
+				totalEndpointsChecked++
+				By("[Geo] checking " + klbHostName + " -> default - TXT owner endpoint")
+				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+					"Targets":       ContainElement(And(geoOwnerMatcher[defaultGeoCode]...)),
+					"RecordType":    Equal("TXT"),
+					"SetIdentifier": Equal("default"),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+						{Name: "aws/geolocation-country-code", Value: "*"},
+					}),
+				}))))
+				totalEndpointsChecked++
+			}
+
+			By("[Weight] checking weighted endpoints")
+			if testDNSProvider == "google" {
+				// A weighted CNAME record should exist for each geo, be owned by all endpoints in that geo, and target the hostname of all clusters in that geo
+				for geoCode, geoRecords := range testGeoRecords {
+					geoKlbHostName := geoRecords[0].config.hostnames.geoKlb
+
+					allGeoClusterHostnames := []string{}
+					gcpWeightProps := []externaldnsendpoint.ProviderSpecificProperty{
+						{Name: "routingpolicy", Value: "weighted"},
+					}
+					for i := range geoRecords {
+						geoClusterHostname := geoRecords[i].config.hostnames.clusterKlb
+						allGeoClusterHostnames = append(allGeoClusterHostnames, geoClusterHostname)
+						gcpWeightProps = append(gcpWeightProps, externaldnsendpoint.ProviderSpecificProperty{Name: geoClusterHostname, Value: "200"})
+					}
+
+					By("[Weight] checking " + geoKlbHostName + " endpoint")
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":          Equal(geoKlbHostName),
+						"Targets":          ConsistOf(allGeoClusterHostnames),
+						"RecordType":       Equal("CNAME"),
+						"SetIdentifier":    Equal(""),
+						"RecordTTL":        Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": ContainElements(gcpWeightProps),
+					}))))
+					totalEndpointsChecked++
+					By("[Weight] checking " + geoKlbHostName + " TXT owner endpoint")
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geoKlbHostName),
+						"Targets":       ContainElement(And(geoOwnerMatcher[geoCode]...)),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					totalEndpointsChecked++
+				}
+			}
+			if testDNSProvider == "aws" {
+				// A weighted CNAME record should exist for each dns record in each geo and be owned only by that endpoint
+				for _, geoRecords := range testGeoRecords {
+					geoKlbHostName := geoRecords[0].config.hostnames.geoKlb
+					for i := range geoRecords {
+						clusterKlbHostName := geoRecords[i].config.hostnames.clusterKlb
+						ownerID := geoRecords[i].record.Status.OwnerID
+						By("[Weight] checking " + geoKlbHostName + " -> " + clusterKlbHostName + " - endpoint")
+						Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(geoKlbHostName),
+							"Targets":       ConsistOf(clusterKlbHostName),
+							"RecordType":    Equal("CNAME"),
+							"SetIdentifier": Equal(clusterKlbHostName),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+							"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+								{Name: "alias", Value: "false"},
+								{Name: "aws/weight", Value: "200"},
+							}),
+						}))))
+						totalEndpointsChecked++
+						By("[Weight] checking " + geoKlbHostName + " -> " + clusterKlbHostName + " -> " + ownerID + " TXT owner endpoint")
+						Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-cname-" + geoKlbHostName),
+							"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + ownerID + "\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal(clusterKlbHostName),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+							"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+								{Name: "aws/weight", Value: "200"},
+							}),
+						}))))
+						totalEndpointsChecked++
+					}
+				}
+			}
+
+			By("[Cluster] checking cluster endpoints")
+			// An A record with the cluster target IP should exist for each dns record and owned only by that endpoint
+			for i := range testRecords {
+				clusterKlbHostName := testRecords[i].config.hostnames.clusterKlb
+				clusterTargetIP := testRecords[i].config.testTargetIP
+				ownerID := testRecords[i].record.Status.OwnerID
+				By("[Cluster] checking " + clusterKlbHostName + " endpoint")
+				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"DNSName":       Equal(clusterKlbHostName),
+					"Targets":       ConsistOf(clusterTargetIP),
+					"RecordType":    Equal("A"),
+					"SetIdentifier": Equal(""),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+				}))))
+				totalEndpointsChecked++
+				By("[Cluster] checking " + clusterKlbHostName + " TXT owner endpoint")
+				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"DNSName":       Equal("kuadrant-a-" + clusterKlbHostName),
+					"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + ownerID + "\""),
+					"RecordType":    Equal("TXT"),
+					"SetIdentifier": Equal(""),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+				}))))
+				totalEndpointsChecked++
+			}
+
+			By("checking all endpoints were validated")
+			Expect(totalEndpointsChecked).To(Equal(expectedEndpointsLen))
+
+			By("deleting all remaining dns records")
+			for _, tr := range testRecords {
+				err := tr.cluster.k8sClient.Delete(ctx, tr.record,
+					client.PropagationPolicy(metav1.DeletePropagationForeground))
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+			}
+
+			By(fmt.Sprintf("checking all dns records are removed within %s", recordsRemovedMaxDuration))
+			Eventually(func(g Gomega, ctx context.Context) {
+				for _, tr := range testRecords {
+					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}
+			}, recordsRemovedMaxDuration, 5*time.Second, ctx).Should(Succeed())
+
+			By("checking provider zone records are all removed")
+			Eventually(func(g Gomega, ctx context.Context) {
+				zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(zoneEndpoints).To(HaveLen(0))
+			}, 5*time.Second, 1*time.Second, ctx).Should(Succeed())
 
 		})
 	})

--- a/test/e2e/multi_instance/suite_test.go
+++ b/test/e2e/multi_instance/suite_test.go
@@ -34,24 +34,34 @@ const (
 	// configuration environment variables
 	dnsManagedZoneName = "TEST_DNS_MANAGED_ZONE_NAME"
 	dnsNamespaces      = "TEST_DNS_NAMESPACES"
+	dnsClusterContexts = "TEST_DNS_CLUSTER_CONTEXTS"
 	deploymentCount    = "DEPLOYMENT_COUNT"
+	clusterCount       = "CLUSTER_COUNT"
 )
 
 var (
-	k8sClient client.Client
 	// testSuiteID is a randomly generated identifier for the test suite
 	testSuiteID string
 	// testZoneDomainName provided domain name for the testZoneID e.g. e2e.hcpapps.net
 	testZoneDomainName  string
 	testManagedZoneName string
 	testNamespaces      []string
+	testClusterContexts []string
 	testDNSProvider     string
-	testManagedZones    []*v1alpha1.ManagedZone
+	testClusters        []testCluster
 )
+
+// testCluster represents a cluster under test and contains a reference to a configured k8client and all it's managed zones.
+type testCluster struct {
+	name             string
+	testManagedZones []*v1alpha1.ManagedZone
+	k8sClient        client.Client
+}
 
 // testDNSRecord encapsulates a v1alpha1.DNSRecord created in a test case, the v1alpha1.ManagedZone it was created in and the config used to create it.
 // The testConfig is used when asserting the expected values set in the providers.
 type testDNSRecord struct {
+	cluster     *testCluster
 	managedZone *v1alpha1.ManagedZone
 	record      *v1alpha1.DNSRecord
 	config      testConfig
@@ -61,6 +71,14 @@ type testConfig struct {
 	testTargetIP       string
 	testGeoCode        string
 	testDefaultGeoCode string
+	hostnames          testHostnames
+}
+
+type testHostnames struct {
+	klb           string
+	geoKlb        string
+	defaultGeoKlb string
+	clusterKlb    string
 }
 
 func TestAPIs(t *testing.T) {
@@ -77,20 +95,13 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{},
-	).ClientConfig()
-	Expect(err).NotTo(HaveOccurred())
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	loadManagedZones(ctx)
+	loadClusters(ctx)
 	Expect(testDNSProvider).NotTo(BeEmpty())
 	Expect(testZoneDomainName).NotTo(BeEmpty())
-	Expect(testManagedZones).NotTo(BeEmpty())
+	Expect(testClusters).NotTo(BeEmpty())
+	for i := range testClusters {
+		Expect(testClusters[i].testManagedZones).NotTo(BeEmpty())
+	}
 
 	testSuiteID = "dns-op-e2e-multi-" + GenerateName()
 
@@ -110,19 +121,32 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 // dnsNamespaces=dns-operator deploymentCount=<unset> = dnsNamespaces=dns-operator
 // dnsNamespaces=dns-operator-1,dns-operator-2 deploymentCount=<unset> = dnsNamespaces=dns-operator-1,dns-operator-2
 // dnsNamespaces=dns-operator deploymentCount=1 = dnsNamespaces=dns-operator-1
-// dnsNamespaces=dns-operator deploymentCount=2 = dnsNamespaces=dns-operator-1,dns-operator-1
+// dnsNamespaces=dns-operator deploymentCount=2 = dnsNamespaces=dns-operator-1,dns-operator-2
 // dnsNamespaces=dns-operator-5,dns-operator-6 deploymentCount=1 = dnsNamespaces=dns-operator-5,dns-operator-6
+//
+// dnsClusterContexts test cluster contexts, comma seperated list (i.e. kind-kuadrant-dns-local-1,kind-kuadrant-dns-local-2),
+// if unset the current context is used and a single cluster is assumed.
+// clusterCount number of test clusters expected. Appends an index suffix to the dnsClusterContexts, only used if dnsClusterContexts is a single length array.
+//
+// Examples:
+// dnsClusterContexts=kind-kuadrant-dns-local clusterCount=<unset> = dnsClusterContexts=kind-kuadrant-dns-local
+// dnsClusterContexts=kind-kuadrant-dns-local-1,kind-kuadrant-dns-local-2 clusterCount=<unset> = dnsClusterContexts=kind-kuadrant-dns-local-1,kind-kuadrant-dns-local-2
+// dnsClusterContexts=kind-kuadrant-dns-local clusterCount=1 = dnsClusterContexts=kind-kuadrant-dns-local-1
+// dnsClusterContexts=kind-kuadrant-dns-local clusterCount=2 = dnsClusterContexts=kind-kuadrant-dns-local-1,kind-kuadrant-dns-local-2
+// dnsClusterContexts=my-cluster-1,my-cluster-2 clusterCount=1 = dnsClusterContexts=my-cluster-1,my-cluster-2
+
 func setConfigFromEnvVars() error {
 	// Load test suite configuration from the environment
 	if testManagedZoneName = os.Getenv(dnsManagedZoneName); testManagedZoneName == "" {
 		return fmt.Errorf("env variable '%s' must be set", dnsManagedZoneName)
 	}
 
-	namespaces := strings.Split(os.Getenv(dnsNamespaces), ",")
-	if len(namespaces) == 0 {
+	namespacesStr := os.Getenv(dnsNamespaces)
+	if namespacesStr == "" {
 		return fmt.Errorf("env variable '%s' must be set", dnsNamespaces)
 	}
 
+	namespaces := strings.Split(namespacesStr, ",")
 	if len(namespaces) == 1 {
 		if dcStr := os.Getenv(deploymentCount); dcStr != "" {
 			dc, err := strconv.Atoi(dcStr)
@@ -139,7 +163,58 @@ func setConfigFromEnvVars() error {
 		testNamespaces = namespaces
 	}
 
+	clusterContextsStr := os.Getenv(dnsClusterContexts)
+	if clusterContextsStr == "" {
+		testClusterContexts = []string{"current"}
+		return nil
+	}
+
+	clusterContexts := strings.Split(clusterContextsStr, ",")
+	if len(clusterContexts) == 1 {
+		if dcStr := os.Getenv(clusterCount); dcStr != "" {
+			dc, err := strconv.Atoi(dcStr)
+			if err != nil {
+				return fmt.Errorf("env variable '%s' must be an integar", clusterCount)
+			}
+			for i := 1; i <= dc; i++ {
+				testClusterContexts = append(testClusterContexts, fmt.Sprintf("%s-%d", clusterContexts[0], i))
+			}
+		} else {
+			testClusterContexts = clusterContexts
+		}
+	} else {
+		testClusterContexts = clusterContexts
+	}
+
 	return nil
+}
+
+// loadClusters iterates each of the configured test clusters, configures a k8s client, loads test managed zones and creates a `testCluster` resource.
+func loadClusters(ctx context.Context) {
+	for _, c := range testClusterContexts {
+		cfgOverrides := &clientcmd.ConfigOverrides{}
+		if c != "current" {
+			cfgOverrides = &clientcmd.ConfigOverrides{CurrentContext: c}
+		}
+		cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			cfgOverrides,
+		).ClientConfig()
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+
+		tc := &testCluster{
+			name:      c,
+			k8sClient: k8sClient,
+		}
+
+		loadManagedZones(ctx, tc)
+
+		//Append the cluster to the list of test clusters
+		testClusters = append(testClusters, *tc)
+	}
 }
 
 // loadManagedZones iterates each of the configured test namespaces, loads the expected managed zone (TEST_DNS_MANAGED_ZONE_NAME), and asserts the configuration of each is compatible.
@@ -147,12 +222,12 @@ func setConfigFromEnvVars() error {
 // If the managed zone does not exist in the namespace, an error is thrown.
 // If the managed zone has a different domain name from any previously loaded managed zones, an error is thrown.
 // If the managed zone has a different dns provider from any previously loaded managed zones, an error is thrown.
-func loadManagedZones(ctx context.Context) {
+func loadManagedZones(ctx context.Context, tc *testCluster) {
 	for _, n := range testNamespaces {
 		mz := &v1alpha1.ManagedZone{}
 
 		// Ensure managed zone exists and is ready
-		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: n, Name: testManagedZoneName}, mz)
+		err := tc.k8sClient.Get(ctx, client.ObjectKey{Namespace: n, Name: testManagedZoneName}, mz)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mz.Status.Conditions).To(
 			ContainElement(MatchFields(IgnoreExtras, Fields{
@@ -170,7 +245,7 @@ func loadManagedZones(ctx context.Context) {
 		}
 
 		s := &v1.Secret{}
-		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: n, Name: mz.Spec.SecretRef.Name}, s)
+		err = tc.k8sClient.Get(ctx, client.ObjectKey{Namespace: n, Name: mz.Spec.SecretRef.Name}, s)
 		Expect(err).NotTo(HaveOccurred())
 
 		p, err := provider.NameForProviderSecret(s)
@@ -184,6 +259,6 @@ func loadManagedZones(ctx context.Context) {
 		}
 
 		//Append the managed zone to the list of test zones
-		testManagedZones = append(testManagedZones, mz)
+		tc.testManagedZones = append(tc.testManagedZones, mz)
 	}
 }


### PR DESCRIPTION
closes #180

Adds a new `local-setup-multi` make target that can create multiple local kind clusters and updates the multi instance test suite to allow execution of tests across multiple clusters as well as namespaces.

Create 2 kind test clusters each with 2 namespaced deployments:
```
make local-setup-multi DEPLOY=true DEPLOYMENT_SCOPE=namespace DEPLOYMENT_COUNT=2 CLUSTER_COUNT=2
```

Run tests on 2 clusters each with 2 namespaced deployments:
```
make test-e2e-multi TEST_DNS_MANAGED_ZONE_NAME=dev-mz-aws TEST_DNS_NAMESPACES=dns-operator DEPLOYMENT_COUNT=2 TEST_DNS_CLUSTER_CONTEXTS=kind-kuadrant-dns-local CLUSTER_COUNT=2
```

Note: All clusters must have the same namespaces, and all namesapces must have the same managed zones.

Additional test suite updates:

* Add a check to make sure that all provider records are removed.
* Add validation of all provider endpoints.