### PR TITLE
chore: Configure default logging (info/json)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go --zap-log-level=3 --provider inmemory,aws,google
+	go run ./cmd/main.go --zap-devel --provider inmemory,aws,google
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,9 +85,7 @@ func main() {
 		"The minimal timeout between calls to the DNS Provider"+
 			"Controls if we commit to the full reconcile loop")
 	flag.Var(&providers, "provider", "DNS Provider(s) to enable. Can be passed multiple times e.g. --provider aws --provider google, or as a comma separated list e.g. --provider aws,gcp")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/config/deploy/local/kustomization.yaml
+++ b/config/deploy/local/kustomization.yaml
@@ -11,6 +11,9 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --provider=aws,google,inmemory
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --zap-log-level=debug
     target:
       kind: Deployment
   - path: manager_config_patch.yaml


### PR DESCRIPTION
Sets the default log level to "info" and use json structured logs.  Sets the log level to debug for all local deployments and ony sets the devel option (--zap-devel) when using `make run`.