### PR TITLE
REPO env used for helm targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.0
 
+# Repo in the container registry
+DEFAULT_REPO = dns-operator
+REPO ?= $(DEFAULT_REPO)
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -64,7 +64,7 @@ helm-sync-package-created: ## Sync the helm chart package to the helm-charts rep
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
 
 .PHONY: helm-sync-package-deleted
 helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-charts repo
@@ -74,4 +74,4 @@ helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-ch
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)"}}'
+	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)"}}'


### PR DESCRIPTION
This env var is placed in the Makefile in case it's used in other targets, following authorino, limitador and kuadrant convention.

This also fixes the synchronization with the helm charts repo, that currently is failing due a missing value:

```sh
Run make helm-sync-package-created \
curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: ***" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos//helm-charts/dispatches \
  -d '{"event_type":"chart-created","client_payload":{"chart":"","version":"0.4.0-alpha1", "browser_download_url": "https://github.com/Kuadrant/dns-operator/releases/download/v0.4.0-alpha1/chart-dns-operator-0.4.0-alpha1.tgz"}}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
[10](https://github.com/Kuadrant/dns-operator/actions/runs/10062522632/job/27815239069#step:6:11)0   324  100   103  100   221    883   1894 --:--:-- --:--:-- --:--:--  2769
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest",
  "status": "404"
}
```

