### PR TITLE
Update logging

### DIFF
--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -301,6 +301,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			g.Expect(err).To(MatchError(ContainSubstring("not found")))
 		}, 5*time.Second, time.Second, ctx).Should(Succeed())
 	})
+
 	It("should have ready condition with status true", func() {
 		Expect(k8sClient.Create(ctx, dnsRecord)).To(Succeed())
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
closes #117 

PR has two changes: 
- Rework logging to ensure logs make sense regardless of the logging level and provide needed information for debugging. 
- Document the logging and provide an example of querying logs locally. 