### PR TITLE
Add api to generate endpoints

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -175,8 +175,6 @@ const (
 
 	// NSRecordType is a name server record.
 	NSRecordType DNSRecordType = "NS"
-
-	DefaultGeo string = "default"
 )
 
 const WildcardPrefix = "*."

--- a/api/v1alpha1/dnsrecord_types_test.go
+++ b/api/v1alpha1/dnsrecord_types_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package v1alpha1
 
 import (

--- a/pkg/builder/endpoints.go
+++ b/pkg/builder/endpoints.go
@@ -1,0 +1,294 @@
+package builder
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	externaldns "sigs.k8s.io/external-dns/endpoint"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common/hash"
+)
+
+const (
+	IPAddressType       AddressType = "IPAddress"
+	HostnameAddressType AddressType = "Hostname"
+	// HostnameRegex checks for at least two groups of allowed for URLs characters separated by "."
+	HostnameRegex        = "^(?:[\\w\\-.~:\\/?#[\\]@!$&'()*+,;=]+)\\.(?:[\\w\\-.~:\\/?#[\\]@!$&'()*+,;=]+)$"
+	WildcardGeo   string = "*"
+
+	DefaultTTL      = 60
+	DefaultCnameTTL = 300
+	IDLength        = 6
+)
+
+// Target wraps a kubernetes ingress traffic resource e.g.Gateway, Ingress, Route etc.. but can wrap any resources
+// that has the desired geo and weight labels being applied, and can provide the required target addresses data.
+// This should be implemented as required for each type of ingress resource i.e. Gateway
+type Target interface {
+	metav1.Object
+	GetAddresses() []TargetAddress
+}
+
+// EndpointsBuilder builds an endpoints array.
+type EndpointsBuilder struct {
+	// target kubernetes resource that may have geo/weight labels applied and provides target addresses.
+	target Target
+
+	// hostname to be used for creation of endpoints. There could be multiple hostname values for a
+	// single target. This builder delegates burden of determining valid hostnames and managing
+	// an array of endpoints for each of hostname values to the consumer of this API
+	hostname string
+
+	// loadBalancing specification (Optional),
+	// If set the builder will create a loadbalanced set of endpoints for the target resource.
+	// If unset, the builder will create a simple set of endpoints for the target resource.
+	loadBalancing *LoadBalancing
+}
+
+type AddressType string
+
+type TargetAddress struct {
+	Type  AddressType
+	Value string
+}
+
+type LoadBalancing struct {
+	// Weight is the record weight to use when no other can be determined for a dns target cluster.
+	// The maximum value accepted is determined by the target dns provider.
+	Weight int
+
+	// Geo is the country/continent/region code to use when no other can be determined for a dns target cluster.
+	// The values accepted are determined by the target dns provider, please refer to the appropriate docs below.
+	//
+	// Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html
+	// Google: https://cloud.google.com/compute/docs/regions-zones
+	Geo string
+
+	// IsDefaultGeo specifies if this is the default geo for providers that support setting a default catch all geo endpoint such as Route53
+	IsDefaultGeo bool
+
+	// Id is a way to distinguish endpoints created for the same target
+	// with the same hostname for a different cluster
+	Id string
+}
+
+// NewEndpointsBuilder returns a new endpoints builder
+func NewEndpointsBuilder(target Target, hostname string) *EndpointsBuilder {
+	return &EndpointsBuilder{
+		target:   target,
+		hostname: hostname,
+	}
+}
+
+// WithLoadBalancing provides builder with necessary parameters to generate a load-balancing set of endpoints.
+// If not used, the builder will provide a simple set of endpoints
+func (builder *EndpointsBuilder) WithLoadBalancing(loadbalancing *LoadBalancing) *EndpointsBuilder {
+	builder.loadBalancing = loadbalancing
+	return builder
+}
+
+// WithLoadBalancingFor performs identically to WithLoadBalancing but without the need to parse params in LoadBalancing struct
+func (builder *EndpointsBuilder) WithLoadBalancingFor(id string, weight int, geo string, isDefaultGeo bool) *EndpointsBuilder {
+	return builder.WithLoadBalancing(&LoadBalancing{
+		Weight:       weight,
+		Geo:          geo,
+		IsDefaultGeo: isDefaultGeo,
+		Id:           id,
+	})
+}
+
+// Build returns a list of endpoints created based on the current configuration of the builder
+func (builder *EndpointsBuilder) Build() ([]*externaldns.Endpoint, error) {
+	if err := builder.Validate(); err != nil {
+		return nil, err
+	}
+
+	var endpoints []*externaldns.Endpoint
+
+	// no load-balancing provided, inferring simple strategy
+	if builder.loadBalancing == nil {
+		endpoints = builder.getSimpleEndpoints()
+	} else {
+		// load-balancing present, inferring load-balanced strategy
+		endpoints = builder.getLoadBalancedEndpoints()
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		return getSetID(endpoints[i]) < getSetID(endpoints[j])
+	})
+	return endpoints, nil
+}
+
+// Validate set of parameters passed inside the builder.
+// Does not ensure validity of values, but checks for a correct set of inputs.
+// e.g. will not check for invalid address type, but ensure they are not nil
+func (builder *EndpointsBuilder) Validate() error {
+	if matched, err := regexp.MatchString(HostnameRegex, builder.hostname); !matched {
+		// This only possible if HostnameRegex is modified.
+		// Leave it here as a precaution
+		if err != nil {
+			return fmt.Errorf("error parsing regexp to match hostname: %w", err)
+		}
+		return fmt.Errorf("invalid hostname")
+	}
+
+	if builder.target == nil {
+		return fmt.Errorf("must provide target")
+	}
+
+	if builder.target.GetAddresses() == nil {
+		return fmt.Errorf("must provide addresses")
+	}
+
+	// following only applicable for load-balancing strategy
+	if builder.loadBalancing != nil {
+		// Id must not be an empty string
+		if builder.loadBalancing.Id == "" {
+			return fmt.Errorf("ID is required")
+		}
+
+		// default weight and geo are required
+		if builder.loadBalancing.Weight < 0 {
+			return fmt.Errorf("invalid default weight")
+		}
+		if builder.loadBalancing.Geo == "" {
+			return fmt.Errorf("default geocode is required")
+		}
+	}
+	return nil
+}
+
+// getSimpleEndpoints returns the endpoints for the given GatewayTarget using the simple routing strategy
+func (builder *EndpointsBuilder) getSimpleEndpoints() []*externaldns.Endpoint {
+	var endpoints []*externaldns.Endpoint
+
+	ipValues, hostValues := targetsFromAddresses(builder.target.GetAddresses())
+
+	if len(ipValues) > 0 {
+		endpoint := createEndpoint(builder.hostname, ipValues, v1alpha1.ARecordType, "", DefaultTTL)
+		endpoints = append(endpoints, endpoint)
+	}
+
+	if len(hostValues) > 0 {
+		endpoint := createEndpoint(builder.hostname, hostValues, v1alpha1.CNAMERecordType, "", DefaultTTL)
+		endpoints = append(endpoints, endpoint)
+	}
+
+	return endpoints
+}
+
+// getLoadBalancedEndpoints returns the endpoints for the given Gateway using the loadbalanced routing strategy
+//
+// Builds an array of externaldns.Endpoint resources. The endpoints expected are calculated using the Gateway
+// and the Routing.
+//
+// A CNAME record is created for the target host (DNSRecord.name), pointing to a generated gateway lb host.
+// A CNAME record for the gateway lb host is created with appropriate Geo information from Gateway
+// A CNAME record for the geo specific host is created with weight information for that target added,
+// pointing to a target cluster hostname.
+// An A record for the target cluster hostname is created for any IP targets retrieved for that cluster.
+//
+// # Example
+//
+// shop.example.com CNAME lb-a1b2.shop.example.com
+// lb-a1b2.shop.example.com CNAME geolocation ireland ie.lb-a1b2.shop.example.com
+// lb-a1b2.shop.example.com geolocation default ie.lb-a1b2.shop.example.com (set by the default geo option)
+// ie.lb-a1b2.shop.example.com CNAME weighted 100 ab1.lb-a1b2.shop.example.com
+// ie.lb-a1b2.shop.example.com CNAME weighted 100 aws.lb.com
+// ab1.lb-a1b2.shop.example.com A 192.22.2.1 192.22.2.2
+func (builder *EndpointsBuilder) getLoadBalancedEndpoints() []*externaldns.Endpoint {
+	cnameHost := builder.hostname
+	if isWildCardHost(builder.hostname) {
+		cnameHost = strings.Replace(builder.hostname, "*.", "", -1)
+	}
+
+	var endpoint *externaldns.Endpoint
+	endpoints := make([]*externaldns.Endpoint, 0)
+
+	lbName := strings.ToLower(fmt.Sprintf("klb.%s", cnameHost))
+	geoCode := builder.loadBalancing.Geo
+	geoLbName := strings.ToLower(fmt.Sprintf("%s.%s", geoCode, lbName))
+
+	ipValues, hostValues := targetsFromAddresses(builder.target.GetAddresses())
+
+	if len(ipValues) > 0 {
+		aRecordLbName := strings.ToLower(fmt.Sprintf("%s-%s.%s", getShortCode(builder.loadBalancing.Id), getShortCode(fmt.Sprintf("%s-%s", builder.target.GetName(), builder.target.GetNamespace())), lbName))
+		endpoint = createEndpoint(aRecordLbName, ipValues, v1alpha1.ARecordType, "", DefaultTTL)
+		endpoints = append(endpoints, endpoint)
+		hostValues = append(hostValues, aRecordLbName)
+	}
+
+	for _, hostValue := range hostValues {
+		endpoint = createEndpoint(geoLbName, []string{hostValue}, v1alpha1.CNAMERecordType, hostValue, DefaultTTL)
+		endpoint.SetProviderSpecificProperty(v1alpha1.ProviderSpecificWeight, strconv.Itoa(int(builder.loadBalancing.Weight)))
+		endpoints = append(endpoints, endpoint)
+	}
+
+	// nothing to do
+	if len(endpoints) == 0 {
+		return endpoints
+	}
+
+	//Create lbName CNAME (lb-a1b2.shop.example.com -> <geoCode>.lb-a1b2.shop.example.com)
+	endpoint = createEndpoint(lbName, []string{geoLbName}, v1alpha1.CNAMERecordType, geoCode, DefaultCnameTTL)
+	endpoint.SetProviderSpecificProperty(v1alpha1.ProviderSpecificGeoCode, geoCode)
+	endpoints = append(endpoints, endpoint)
+
+	//Add a default geo (*) endpoint if the current geoCode is a default geo
+	if builder.loadBalancing.IsDefaultGeo {
+		endpoint = createEndpoint(lbName, []string{geoLbName}, v1alpha1.CNAMERecordType, "default", DefaultCnameTTL)
+		endpoint.SetProviderSpecificProperty(v1alpha1.ProviderSpecificGeoCode, WildcardGeo)
+		endpoints = append(endpoints, endpoint)
+	}
+
+	if len(endpoints) > 0 {
+		//Create gwListenerHost CNAME (shop.example.com -> lb-a1b2.shop.example.com)
+		endpoint = createEndpoint(builder.hostname, []string{lbName}, v1alpha1.CNAMERecordType, "", DefaultCnameTTL)
+		endpoints = append(endpoints, endpoint)
+	}
+
+	return endpoints
+}
+
+func createEndpoint(dnsName string, targets externaldns.Targets, recordType v1alpha1.DNSRecordType, setIdentifier string,
+	recordTTL externaldns.TTL) (endpoint *externaldns.Endpoint) {
+	return &externaldns.Endpoint{
+		DNSName:       dnsName,
+		Targets:       targets,
+		RecordType:    string(recordType),
+		SetIdentifier: setIdentifier,
+		RecordTTL:     recordTTL,
+	}
+}
+
+func getSetID(endpoint *externaldns.Endpoint) string {
+	return endpoint.DNSName + endpoint.SetIdentifier
+}
+
+func isWildCardHost(host string) bool {
+	return strings.HasPrefix(host, "*")
+}
+
+func getShortCode(name string) string {
+	return hash.ToBase36HashLen(name, IDLength)
+}
+
+func targetsFromAddresses(addresses []TargetAddress) ([]string, []string) {
+	var ipValues []string
+	var hostValues []string
+
+	for _, address := range addresses {
+		if address.Type == IPAddressType {
+			ipValues = append(ipValues, address.Value)
+		} else {
+			hostValues = append(hostValues, address.Value)
+		}
+	}
+
+	return ipValues, hostValues
+}

--- a/pkg/builder/endpoints_test.go
+++ b/pkg/builder/endpoints_test.go
@@ -1,0 +1,394 @@
+//go:build unit
+
+package builder
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+const (
+	ipAddressOne = "127.0.0.1"
+	ipAddressTwo = "127.0.0.2"
+	testHostname = "pat.the.cat"
+)
+
+var (
+	testHost          string
+	testTarget        TestTargetImpl
+	testLoadbalancing *LoadBalancing
+
+	testName      = "TestName"
+	testNamespace = "TestNamespace"
+
+	domain     = "example.com"
+	idHash     = "2q5hyv"
+	targetHash = "a8xcra"
+	geo        = "IE"
+	weight     = 120
+	id         = "fbf71c44-6b37-4962-ace6-801912e769be"
+)
+
+type TestTargetImpl struct {
+	metav1.Object
+	addresses []TargetAddress
+}
+
+func (t TestTargetImpl) GetAddresses() []TargetAddress {
+	return t.addresses
+}
+
+var _ = Describe("DnsrecordEndpoints", func() {
+	BeforeEach(func() {
+		// reset
+		testTarget = TestTargetImpl{
+			Object: &metav1.ObjectMeta{
+				Name:      testName,
+				Namespace: testNamespace,
+			},
+		}
+
+		testLoadbalancing = &LoadBalancing{}
+	})
+	Context("Success scenarios", func() {
+		Context("Simple routing Strategy", func() {
+			BeforeEach(func() {
+				testTarget.addresses = []TargetAddress{
+					{
+						Type:  IPAddressType,
+						Value: ipAddressOne,
+					},
+					{
+						Type:  IPAddressType,
+						Value: ipAddressTwo,
+					},
+				}
+			})
+			It("Should generate endpoint", func() {
+				testHost = HostOne(domain)
+				endpoints, err := NewEndpointsBuilder(testTarget, testHost).Build()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(endpoints).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(HostOne(domain)),
+						"Targets":       ContainElements(ipAddressOne, ipAddressTwo),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(endpoint.TTL(60)),
+					})),
+				))
+			})
+			It("Should generate wildcard endpoint", func() {
+				TestListener := HostWildcard(domain)
+				endpoints, err := NewEndpointsBuilder(testTarget, TestListener).Build()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(endpoints).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(HostWildcard(domain)),
+						"Targets":       ContainElements(ipAddressOne, ipAddressTwo),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(endpoint.TTL(60)),
+					})),
+				))
+			})
+			It("Should generate hostname endpoint", func() {
+				testTarget.addresses = []TargetAddress{{Type: HostnameAddressType, Value: testHostname}}
+				testHost = HostOne(domain)
+				endpoints, err := NewEndpointsBuilder(testTarget, testHost).Build()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(endpoints).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(HostOne(domain)),
+						"Targets":       ContainElement(testHostname),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(endpoint.TTL(60)),
+					})),
+				))
+
+			})
+		})
+		Context("Load-balanced routing strategy", func() {
+			BeforeEach(func() {
+				testTarget.addresses = []TargetAddress{
+					{
+						Type:  IPAddressType,
+						Value: ipAddressOne,
+					},
+					{
+						Type:  IPAddressType,
+						Value: ipAddressTwo,
+					},
+				}
+				testLoadbalancing = &LoadBalancing{
+					Weight:       weight,
+					Geo:          geo,
+					IsDefaultGeo: true,
+					Id:           id,
+				}
+			})
+
+			Context("With default geo", func() {
+				It("Should generate endpoints", func() {
+					testHost = HostOne(domain)
+					endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+						WithLoadBalancing(testLoadbalancing).
+						Build()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(EndpointsTraversable(endpoints, HostOne(domain), []string{ipAddressOne, ipAddressTwo})).To(BeTrue())
+					Expect(endpoints).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(idHash + "-" + targetHash + "." + "klb.test." + domain),
+							"Targets":       ConsistOf(ipAddressOne, ipAddressTwo),
+							"RecordType":    Equal("A"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("ie.klb.test." + domain),
+							"Targets":          ConsistOf(idHash + "-" + targetHash + "." + "klb.test." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal(idHash + "-" + targetHash + "." + "klb.test." + domain),
+							"RecordTTL":        Equal(endpoint.TTL(60)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "weight", Value: "120"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("klb.test." + domain),
+							"Targets":          ConsistOf("ie.klb.test." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal(geo),
+							"RecordTTL":        Equal(endpoint.TTL(300)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "geo-code", Value: geo}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("klb.test." + domain),
+							"Targets":          ConsistOf("ie.klb.test." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal("default"),
+							"RecordTTL":        Equal(endpoint.TTL(300)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(HostOne(domain)),
+							"Targets":       ConsistOf("klb.test." + domain),
+							"RecordType":    Equal("CNAME"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(300)),
+						})),
+					))
+
+				})
+				It("Should generate wildcard endpoints", func() {
+					testHost = HostWildcard(domain)
+					endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+						WithLoadBalancing(testLoadbalancing).
+						Build()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(EndpointsTraversable(endpoints, HostWildcard(domain), []string{ipAddressOne, ipAddressTwo})).To(BeTrue())
+					Expect(endpoints).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(idHash + "-" + targetHash + "." + "klb." + domain),
+							"Targets":       ConsistOf(ipAddressOne, ipAddressTwo),
+							"RecordType":    Equal("A"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("ie.klb." + domain),
+							"Targets":          ConsistOf(idHash + "-" + targetHash + "." + "klb." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal(idHash + "-" + targetHash + "." + "klb." + domain),
+							"RecordTTL":        Equal(endpoint.TTL(60)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "weight", Value: "120"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("klb." + domain),
+							"Targets":          ConsistOf("ie.klb." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal("default"),
+							"RecordTTL":        Equal(endpoint.TTL(300)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("klb." + domain),
+							"Targets":          ConsistOf("ie.klb." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal(geo),
+							"RecordTTL":        Equal(endpoint.TTL(300)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "geo-code", Value: geo}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(HostWildcard(domain)),
+							"Targets":       ConsistOf("klb." + domain),
+							"RecordType":    Equal("CNAME"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(300)),
+						})),
+					))
+				})
+			})
+
+			Context("With non-default geo", func() {
+				BeforeEach(func() {
+					testLoadbalancing.IsDefaultGeo = false
+					testLoadbalancing.Geo = "CAD"
+				})
+				It("Should generate endpoints", func() {
+					testHost = HostOne(domain)
+					endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+						WithLoadBalancing(testLoadbalancing).
+						Build()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(EndpointsTraversable(endpoints, HostOne(domain), []string{ipAddressOne, ipAddressTwo})).To(BeTrue())
+					Expect(endpoints).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(idHash + "-" + targetHash + "." + "klb.test." + domain),
+							"Targets":       ConsistOf(ipAddressOne, ipAddressTwo),
+							"RecordType":    Equal("A"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("cad.klb.test." + domain),
+							"Targets":          ConsistOf(idHash + "-" + targetHash + "." + "klb.test." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal(idHash + "-" + targetHash + "." + "klb.test." + domain),
+							"RecordTTL":        Equal(endpoint.TTL(60)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "weight", Value: "120"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("klb.test." + domain),
+							"Targets":          ConsistOf("cad.klb.test." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal("CAD"),
+							"RecordTTL":        Equal(endpoint.TTL(300)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "geo-code", Value: "CAD"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(HostOne(domain)),
+							"Targets":       ConsistOf("klb.test." + domain),
+							"RecordType":    Equal("CNAME"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(300)),
+						})),
+					))
+
+				})
+				It("Should generate wildcard endpoints", func() {
+					testHost = HostWildcard(domain)
+					endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+						WithLoadBalancing(testLoadbalancing).
+						Build()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(EndpointsTraversable(endpoints, HostWildcard(domain), []string{ipAddressOne, ipAddressTwo})).To(BeTrue())
+					Expect(endpoints).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(idHash + "-" + targetHash + "." + "klb." + domain),
+							"Targets":       ConsistOf(ipAddressOne, ipAddressTwo),
+							"RecordType":    Equal("A"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("cad.klb." + domain),
+							"Targets":          ConsistOf(idHash + "-" + targetHash + "." + "klb." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal(idHash + "-" + targetHash + "." + "klb." + domain),
+							"RecordTTL":        Equal(endpoint.TTL(60)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "weight", Value: "120"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":          Equal("klb." + domain),
+							"Targets":          ConsistOf("cad.klb." + domain),
+							"RecordType":       Equal("CNAME"),
+							"SetIdentifier":    Equal("CAD"),
+							"RecordTTL":        Equal(endpoint.TTL(300)),
+							"ProviderSpecific": Equal(endpoint.ProviderSpecific{{Name: "geo-code", Value: "CAD"}}),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal(HostWildcard(domain)),
+							"Targets":       ConsistOf("klb." + domain),
+							"RecordType":    Equal("CNAME"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(endpoint.TTL(300)),
+						})),
+					))
+				})
+			})
+
+		})
+	})
+
+	Context("Failure scenarios", func() {
+		BeforeEach(func() {
+			// create valid set of inputs for lb strategy
+			testTarget.addresses = []TargetAddress{
+				{
+					Type:  IPAddressType,
+					Value: ipAddressOne,
+				},
+				{
+					Type:  IPAddressType,
+					Value: ipAddressTwo,
+				},
+			}
+			testHost = HostOne(domain)
+		})
+
+		It("Should return no endpoints if missing addresses", func() {
+			testTarget.addresses = []TargetAddress{}
+			endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+				WithLoadBalancingFor(id, weight, geo, true).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoints).To(BeEmpty())
+		})
+		Context("Should validate builder correctly", func() {
+			It("Should not allow invalid hostname", func() {
+				endpoints, err := NewEndpointsBuilder(testTarget, "cat").Build()
+				Expect(endpoints).To(BeNil())
+				Expect(err.Error()).To(ContainSubstring("invalid hostname"))
+			})
+			It("Should not allow nil target", func() {
+				endpoints, err := NewEndpointsBuilder(nil, testHost).Build()
+				Expect(endpoints).To(BeNil())
+				Expect(err.Error()).To(ContainSubstring("must provide target"))
+			})
+			It("Should not allow for nil addresses", func() {
+				testTarget.addresses = nil
+				endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+					WithLoadBalancingFor(id, weight, geo, true).
+					Build()
+				Expect(endpoints).To(BeNil())
+				Expect(err.Error()).To(ContainSubstring("must provide addresses"))
+			})
+			It("Should not allow for empty id", func() {
+				endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+					WithLoadBalancingFor("", weight, geo, true).
+					Build()
+				Expect(endpoints).To(BeNil())
+				Expect(err.Error()).To(ContainSubstring("ID is required"))
+			})
+			It("Should not allow for invalid default weight", func() {
+				endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+					WithLoadBalancingFor(id, -1, geo, true).
+					Build()
+				Expect(endpoints).To(BeNil())
+				Expect(err.Error()).To(ContainSubstring("invalid default weight"))
+			})
+			It("Should not allow for invalid default geo", func() {
+				endpoints, err := NewEndpointsBuilder(testTarget, testHost).
+					WithLoadBalancingFor(id, weight, "", true).
+					Build()
+				Expect(endpoints).To(BeNil())
+				Expect(err.Error()).To(ContainSubstring("default geocode is required"))
+			})
+		})
+
+	})
+})

--- a/pkg/builder/suite_test.go
+++ b/pkg/builder/suite_test.go
@@ -1,0 +1,63 @@
+//go:build unit
+
+package builder
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "API suite")
+}
+
+// misc
+func HostWildcard(domain string) string {
+	return fmt.Sprintf("*.%s", domain)
+}
+
+func HostOne(domain string) string {
+	return fmt.Sprintf("%s.%s", "test", domain)
+}
+
+func HostTwo(domain string) string {
+	return fmt.Sprintf("%s.%s", "other.test", domain)
+}
+
+// EndpointsTraversable consumes an array of endpoints and returns a boolean
+// indicating presence of that path from host to all destinations
+// this function DOES NOT report a presence of an endpoint with one of destinations DNSNames
+func EndpointsTraversable(endpoints []*endpoint.Endpoint, host string, destinations []string) bool {
+	allDestinationsFound := len(destinations) > 0
+	for _, destination := range destinations {
+		allTargetsFound := false
+		for _, ep := range endpoints {
+			// the host exists as a DNSName on an endpoint
+			if ep.DNSName == host {
+				// we found destination in the targets of the endpoint.
+				if slices.Contains(ep.Targets, destination) {
+					return true
+				}
+				// destination is not found on the endpoint. Use target as a host and check for existence of Endpoints with such a DNSName
+				for _, target := range ep.Targets {
+					// if at least one returns as true allTargetsFound will be locked in true
+					// this means that at least one of the targets on the endpoint leads to the destination
+					allTargetsFound = allTargetsFound || EndpointsTraversable(endpoints, target, []string{destination})
+				}
+			}
+		}
+		// we must match all destinations
+		allDestinationsFound = allDestinationsFound && allTargetsFound
+	}
+	// there are no destinations to look for: len(destinations) == 0 locks allDestinationsFound into false
+	// or every destination was matched to a target on the endpoint
+	return allDestinationsFound
+}


### PR DESCRIPTION
Moving logic that generates endpoints from the `kuadrant-operator` repo to the DNS-operator. 
Also transfer applicable test cases and extend them a bit to cover a few edge cases since it is a unit testing and it is cheap. 
There is a bump in the GO version - gatewayAPI requires it. It is debatable if we should be using Gateways in our API. An alternative would be to use addresses and labels in our "custom" struct and have a parser on the `kuadrant-operator` side. Just like there is a `Routing` struct to avoid policy usage. 