### PR TITLE
fix: default operator img tag to latest

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,6 +7,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/dns-operator
-  newTag: remove_managed_zone_api
-
-#ToDo mnairn: Revert tag before merge
+  newTag: latest


### PR DESCRIPTION
Should have been reverted before merging https://github.com/Kuadrant/dns-operator/pull/203