### PR TITLE
ci: Update olm bundle/helm chart verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,21 @@ jobs:
       - name: Run make verify-bundle
         run: |
           make verify-bundle
+  verify-helm-build:
+    name: Verify helm build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.21.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
+          cache: false
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run make helm-build
+        run: |
+          make verify-helm-build
   verify-imports:
     name: Verify imports
     runs-on: ubuntu-latest

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,25 +1,9 @@
 ##@ Helm Charts
 
-# TODO: If this is found useful, consider adding it to the main Makefile
-# Semantic versioning (i.e. Major.Minor.Patch)
-is_semantic_version = $(shell [[ $(1) =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]] && echo "true")
-
-
-# OPERATOR_IMG defines the dns-operator image with version tag.
-# If the version is not semantic, will use the default one
-bundle_is_semantic := $(call is_semantic_version,$(VERSION))
-ifeq (0.0.0,$(VERSION))
-OPERATOR_IMG = $(IMAGE_TAG_BASE):latest
-else ifeq ($(bundle_is_semantic),true)
-OPERATOR_IMG = $(IMAGE_TAG_BASE):v$(VERSION)
-else
-OPERATOR_IMG ?= $(DEFAULT_IMAGE_TAG)
-endif
-
 .PHONY: helm-build
 helm-build: yq manifests kustomize operator-sdk ## Build the helm chart from kustomize manifests
-	# Replace the controller image
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMG)
+	# Replace the controller image (Should remain consistent with what `make bundle` does)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Build the helm chart templates from kustomize manifests
 	$(KUSTOMIZE) build config/helm > charts/dns-operator/templates/manifests.yaml
 	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i charts/dns-operator/Chart.yaml

--- a/make/verify.mk
+++ b/make/verify.mk
@@ -17,8 +17,13 @@ verify-manifests: manifests ## Verify manifests update.
 
 .PHONY: verify-bundle
 verify-bundle: bundle ## Verify bundle update.
-	git diff --exit-code ./bundle
-	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle)" ]
+	git diff --exit-code ./bundle ./config
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle ./config)" ]
+
+.PHONY: verify-helm-build
+verify-helm-build: helm-build ## Verify helm build update.
+	git diff --exit-code ./charts ./config
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./charts ./config)" ]
 
 .PHONY: verify-imports
 verify-imports: ## Verify go imports are sorted and grouped correctly.


### PR DESCRIPTION
* Update verify-bundle to check config directory as it also modifies the contents of the manager kustomization.
* Add verify-helm-build to check the results of `make helm-build` are committed.
* Update helm-build to be consistent with `make bundle` in what image will be set in the manager kustomization.