### PR TITLE
chore: Immutable RootHost field on DNSRecord

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -81,6 +81,7 @@ type DNSRecordSpec struct {
 	// rootHost is the single root for all endpoints in a DNSRecord.
 	// it is expected all defined endpoints are children of or equal to this rootHost
 	// Must contain at least two groups of valid URL characters separated by a "."
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="RootHost is immutable"
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:Pattern=`^(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)\.(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)$`

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2024-08-13T17:16:20Z"
+    createdAt: "2024-09-03T15:38:08Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -154,6 +154,9 @@ spec:
                 minLength: 1
                 pattern: ^(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)\.(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)$
                 type: string
+                x-kubernetes-validations:
+                - message: RootHost is immutable
+                  rule: self == oldSelf
             required:
             - providerRef
             - rootHost

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -166,6 +166,9 @@ spec:
                 minLength: 1
                 pattern: ^(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)\.(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)$
                 type: string
+                x-kubernetes-validations:
+                - message: RootHost is immutable
+                  rule: self == oldSelf
             required:
             - providerRef
             - rootHost

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -154,6 +154,9 @@ spec:
                 minLength: 1
                 pattern: ^(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)\.(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)$
                 type: string
+                x-kubernetes-validations:
+                - message: RootHost is immutable
+                  rule: self == oldSelf
             required:
             - providerRef
             - rootHost


### PR DESCRIPTION
The dnsrecord controller does not currently handle changes to the rootHost so is now marked as immutable to prevent it from being changed and causing odd behaviour.

In the case where you want to change the host, a new record should be created and the old one removed to ensure proper cleanup of resources in the provider.

part of: https://github.com/Kuadrant/kuadrant-operator/issues/794