### PR TITLE
bug: Sanitize provider error messages on zone lookup

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -199,7 +199,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		z, err := p.DNSZoneForHost(ctx, dnsRecord.Spec.RootHost)
 		if err != nil {
 			setDNSRecordCondition(dnsRecord, string(v1alpha1.ConditionTypeReady), metav1.ConditionFalse,
-				"DNSProviderError", fmt.Sprintf("Unable to find suitable zone in provider: %v", err))
+				"DNSProviderError", fmt.Sprintf("Unable to find suitable zone in provider: %v", provider.SanitizeError(err)))
 			return r.updateStatus(ctx, previous, dnsRecord, false, err)
 		}
 


### PR DESCRIPTION
fixes: #218  

Fixes an issue where if invalid credentials are used in the provider secret when looking for a suitable zone in the provider it would continually change the status on every reconcile. This is caused by the AWS provider adding a request id to the error which wasn't being removed in this case prior to update the record status.