### PR TITLE
feat: Add dns record delete validation

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -112,7 +112,9 @@ type DNSRecordStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// QueuedAt is a time when DNS record was received for the reconciliation
+	// QueuedAt is a time when DNS record was received for the reconciliation.
+	// During deletion QueuedAt is used to track the last time a change was detected when processing the delete request.
+	// Used for validation purposes to ensure the record is completely removed from the provider.
 	QueuedAt metav1.Time `json:"queuedAt,omitempty"`
 
 	// QueuedFor is a time when we expect a DNS record to be reconciled again

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2024-09-03T15:38:08Z"
+    createdAt: "2024-09-10T10:36:47Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -470,8 +470,10 @@ spec:
                   of this record.
                 type: string
               queuedAt:
-                description: QueuedAt is a time when DNS record was received for the
-                  reconciliation
+                description: |-
+                  QueuedAt is a time when DNS record was received for the reconciliation.
+                  During deletion QueuedAt is used to track the last time a change was detected when processing the delete request.
+                  Used for validation purposes to ensure the record is completely removed from the provider.
                 format: date-time
                 type: string
               queuedFor:

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -482,8 +482,10 @@ spec:
                   of this record.
                 type: string
               queuedAt:
-                description: QueuedAt is a time when DNS record was received for the
-                  reconciliation
+                description: |-
+                  QueuedAt is a time when DNS record was received for the reconciliation.
+                  During deletion QueuedAt is used to track the last time a change was detected when processing the delete request.
+                  Used for validation purposes to ensure the record is completely removed from the provider.
                 format: date-time
                 type: string
               queuedFor:

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -470,8 +470,10 @@ spec:
                   of this record.
                 type: string
               queuedAt:
-                description: QueuedAt is a time when DNS record was received for the
-                  reconciliation
+                description: |-
+                  QueuedAt is a time when DNS record was received for the reconciliation.
+                  During deletion QueuedAt is used to track the last time a change was detected when processing the delete request.
+                  Used for validation purposes to ensure the record is completely removed from the provider.
                 format: date-time
                 type: string
               queuedFor:

--- a/test/e2e/multi_record_test.go
+++ b/test/e2e/multi_record_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
@@ -40,8 +41,11 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 
 	var testRecords []*testDNSRecord
 
-	recordsReadyMaxDuration := time.Minute
-	recordsRemovedMaxDuration := 90 * time.Second
+	// Max durations that we would ever expect a record to be become ready or deleted.
+	// Note: These are extreme max durations, and it would not be expected under normal scenarios that creating or
+	// deleting a record would take this long.
+	recordsReadyMaxDuration := 2 * time.Minute
+	recordsRemovedMaxDuration := 2 * time.Minute
 
 	BeforeEach(func(ctx SpecContext) {
 		testID = "t-multi-" + GenerateName()
@@ -129,7 +133,10 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			By(fmt.Sprintf("checking all dns records become ready within %s", recordsReadyMaxDuration))
 			var allOwners = []string{}
 			var allTargetIps = []string{}
+			checkStarted := time.Now()
 			Eventually(func(g Gomega, ctx context.Context) {
+				allOwners = []string{}
+				allTargetIps = []string{}
 				for _, tr := range testRecords {
 					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
 					g.Expect(err).NotTo(HaveOccurred())
@@ -146,6 +153,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				}
 				g.Expect(len(allOwners)).To(Equal(len(testRecords)))
 			}, recordsReadyMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] all records became ready in %v\n", time.Since(checkStarted))
 
 			By("checking provider zone records are created as expected")
 			testProvider, err := ProviderForDNSRecord(ctx, testRecords[0].record, testClusters[0].k8sClient)
@@ -155,10 +163,16 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(zoneEndpoints).To(HaveLen(2))
 
-			By("checking each record has all owners present")
-			for _, tr := range testRecords {
-				Expect(tr.record.Status.DomainOwners).To(ConsistOf(allOwners))
-			}
+			By(fmt.Sprintf("checking each record has all(%v) domain owners present within %s", len(allOwners), recordsReadyMaxDuration))
+			checkStarted = time.Now()
+			Eventually(func(g Gomega, ctx context.Context) {
+				for _, tr := range testRecords {
+					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(tr.record.Status.DomainOwners).To(ConsistOf(allOwners))
+				}
+			}, recordsReadyMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] all records updated in %v\n", time.Since(checkStarted))
 
 			By("checking all target ips are present")
 			Expect(zoneEndpoints).To(ContainElements(
@@ -218,11 +232,13 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 
 			By(fmt.Sprintf("checking dns record [name: `%s` namespace: `%s`] is removed within %s", recordToDelete.record.Name, recordToDelete.record.Namespace, recordsRemovedMaxDuration))
+			checkStarted = time.Now()
 			Eventually(func(g Gomega, ctx context.Context) {
 				err := recordToDelete.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(recordToDelete.record), recordToDelete.record)
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(ContainSubstring("not found")))
 			}, recordsRemovedMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] record removed in %v\n", time.Since(checkStarted))
 
 			By("checking provider zone records are updated as expected")
 			Eventually(func(g Gomega, ctx context.Context) {
@@ -252,6 +268,26 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				}
 			}, 5*time.Second, time.Second, ctx).Should(Succeed())
 
+			//Remove deleted record owner from owners list
+			allOwners = slices.DeleteFunc(allOwners, func(id string) bool {
+				return id == recordToDelete.record.Status.OwnerID
+			})
+			//Remove deleted record from testRecords list
+			testRecords = slices.DeleteFunc(testRecords, func(tr *testDNSRecord) bool {
+				return tr.record.Status.OwnerID == recordToDelete.record.Status.OwnerID
+			})
+
+			By(fmt.Sprintf("checking remaining records have all(%v) domain owners updated within %s", len(allOwners), recordsReadyMaxDuration))
+			checkStarted = time.Now()
+			Eventually(func(g Gomega, ctx context.Context) {
+				for _, tr := range testRecords {
+					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(tr.record.Status.DomainOwners).To(ConsistOf(allOwners))
+				}
+			}, recordsReadyMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] records updated in %v\n", time.Since(checkStarted))
+
 			By("deleting all remaining dns records")
 			for _, tr := range testRecords {
 				err := tr.cluster.k8sClient.Delete(ctx, tr.record,
@@ -260,12 +296,14 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			}
 
 			By(fmt.Sprintf("checking all dns records are removed within %s", recordsRemovedMaxDuration))
+			checkStarted = time.Now()
 			Eventually(func(g Gomega, ctx context.Context) {
 				for _, tr := range testRecords {
 					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
 					g.Expect(err).To(MatchError(ContainSubstring("not found")))
 				}
 			}, recordsRemovedMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] all records removed in %v\n", time.Since(checkStarted))
 
 			By("checking provider zone records are all removed")
 			Eventually(func(g Gomega, ctx context.Context) {
@@ -279,8 +317,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 	})
 
 	Context("loadbalanced", func() {
-		It("makes available a hostname that can be resolved", func(ctx SpecContext) {
-			By("creating two dns records")
+		It("creates and deletes distributed dns records", func(ctx SpecContext) {
 			testGeoRecords := map[string][]testDNSRecord{}
 
 			By(fmt.Sprintf("creating %d loadbalanced dnsrecords accross %d clusters", len(testNamespaces)*len(testClusters), len(testClusters)))
@@ -404,7 +441,9 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 
 			By(fmt.Sprintf("checking all dns records become ready within %s", recordsReadyMaxDuration))
 			var allOwners = []string{}
+			checkStarted := time.Now()
 			Eventually(func(g Gomega, ctx context.Context) {
+				allOwners = []string{}
 				for _, tr := range testRecords {
 					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
 					g.Expect(err).NotTo(HaveOccurred())
@@ -419,6 +458,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				}
 				g.Expect(len(allOwners)).To(Equal(len(testRecords)))
 			}, recordsReadyMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] all records became ready in %v\n", time.Since(checkStarted))
 
 			By("checking provider zone records are created as expected")
 			testProvider, err := ProviderForDNSRecord(ctx, testRecords[0].record, testClusters[0].k8sClient)
@@ -438,6 +478,17 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				Expect(zoneEndpoints).To(HaveLen(expectedEndpointsLen))
 			}
 
+			By(fmt.Sprintf("checking each record has all(%v) domain owners present within %s", len(allOwners), recordsReadyMaxDuration))
+			checkStarted = time.Now()
+			Eventually(func(g Gomega, ctx context.Context) {
+				for _, tr := range testRecords {
+					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(tr.record.Status.DomainOwners).To(ConsistOf(allOwners))
+				}
+			}, recordsReadyMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] all records updated in %v\n", time.Since(checkStarted))
+
 			var totalEndpointsChecked = 0
 
 			var allOwnerMatcher = []types.GomegaMatcher{
@@ -450,7 +501,6 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				underTest := testRecords[i]
 				ownerID := underTest.record.Status.OwnerID
 				allOwnerMatcher = append(allOwnerMatcher, ContainSubstring(ownerID))
-				Expect(underTest.record.Status.DomainOwners).To(ConsistOf(allOwners))
 				geoCode := testRecords[i].config.testGeoCode
 				geoOwners[geoCode] = append(geoOwners[geoCode], ownerID)
 				geoKlbHostname[geoCode] = testRecords[i].config.hostnames.geoKlb
@@ -771,12 +821,14 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			}
 
 			By(fmt.Sprintf("checking all dns records are removed within %s", recordsRemovedMaxDuration))
+			checkStarted = time.Now()
 			Eventually(func(g Gomega, ctx context.Context) {
 				for _, tr := range testRecords {
 					err := tr.cluster.k8sClient.Get(ctx, client.ObjectKeyFromObject(tr.record), tr.record)
 					g.Expect(err).To(MatchError(ContainSubstring("not found")))
 				}
 			}, recordsRemovedMaxDuration, 5*time.Second, ctx).Should(Succeed())
+			GinkgoWriter.Printf("[debug] all records removed in %v\n", time.Since(checkStarted))
 
 			By("checking provider zone records are all removed")
 			Eventually(func(g Gomega, ctx context.Context) {

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -55,9 +55,16 @@ var _ = Describe("Single Record Test", func() {
 
 	AfterEach(func(ctx SpecContext) {
 		if dnsRecord != nil {
+			By("ensuring dns record is deleted")
 			err := k8sClient.Delete(ctx, dnsRecord,
 				client.PropagationPolicy(metav1.DeletePropagationForeground))
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+			By("checking dns record is removed")
+			Eventually(func(g Gomega, ctx context.Context) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+				g.Expect(err).To(MatchError(ContainSubstring("not found")))
+			}, TestTimeoutLong, time.Second, ctx).Should(Succeed())
 		}
 	})
 


### PR DESCRIPTION
closes #181

[fix e2e multi record test issues](https://github.com/Kuadrant/dns-operator/commit/cf6c6bc65f10f6f3096c8e3c0d92912885ba9bd9)

* Fix an issue with the domain owners checks when multiple instances are being used, allOwners was being appended with multiple duplicates.
* Add additional checks to ensure all remaining records are eventually updated with the correct domain owners.
* Add logging of time taken around dnsrecord create/update/delete checks.

[feat: Add dns record delete validation](https://github.com/Kuadrant/dns-operator/commit/dfb7260bf57d508b8662cfbce505ba7a85c0fe63)

Adds validation around the deletion of DNSRecord resources to reduce the chances of unexpected records being left in the external dns provider (AWS Routes53 etc..) after the record has been garbage collected. It now takes into account the possibly that multiple records could be manipulating the same zone record set simultaneously which can happen if
a significant number of DNSRecord resources were contributing to the same rootHost record set in the provider and were all deleted at roughly the same time.

The deletion logic was changed to always run validation checks, at random intervals, for an amount of time (currently 15 seconds) after the last time a change was detected. A change here can either be that it had to update the provider itself or that some status on the record was changed, the most important one being `Status.DomainOwners`. If either of these changes occur the delete validation loop of 15 seconds is restarted and will only move on to remove the finalizer once it reaches the 15 seconds duration without any changes having been made.

Note: Some providers, such as google, handle this better as they require the API requests to know the current state of the record you are updating/deleting before it will be accepted. Others such as AWS(Route53) unfortunately do not meaning that some things one record just deleted, may get added back by another depending on when it last queried the providers zone records.

**_Validation_**

**Terminal 1:**
Setup local env with multiple instances and watch all dnsrecords: 
```
make local-setup DEPLOY=true DEPLOYMENT_SCOPE=namespace DEPLOYMENT_COUNT=20
kubectl get dnsrecord -w -o json -A | jq '.metadata.namespace + ":" + .metadata.name + " = deletedAt: " + (.metadata.deletionTimestamp | tostring) + " queuedAt: " + (.status.queuedAt | tostring) + " domainOwners: " + (.status.domainOwners | tostring)'
```

**Terminal 2:**
Tail all operator logs: 
```
kubectl stern -l control-plane=dns-operator-controller-manager --all-namespaces
```

**Terminal 3:**
Run multi record e2e with 20 instances (AWS)
```
make test-e2e-multi TEST_DNS_ZONE_DOMAIN_NAME=<your aws domain> TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-aws TEST_DNS_NAMESPACES=dns-operator DEPLOYMENT_COUNT=20
```
Run multi record e2e with 20 instances (GCP)
```
make test-e2e-multi TEST_DNS_ZONE_DOMAIN_NAME=<your google domain> TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-gcp TEST_DNS_NAMESPACES=dns-operator DEPLOYMENT_COUNT=20
```


