### PR TITLE
Add related endpoints to DNSRecord status

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -141,6 +141,9 @@ type DNSRecordStatus struct {
 	// endpoints are the last endpoints that were successfully published to the provider zone
 	Endpoints []*externaldns.Endpoint `json:"endpoints,omitempty"`
 
+	// ZoneEndpoints are all the endpoints for the DNSRecordSpec.RootHost that are present in the provider
+	ZoneEndpoints []*externaldns.Endpoint `json:"relatedEndpoints,omitempty"`
+
 	HealthCheck *HealthCheckStatus `json:"healthCheck,omitempty"`
 
 	// ownerID is a unique string used to identify the owner of this record.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -188,6 +188,17 @@ func (in *DNSRecordStatus) DeepCopyInto(out *DNSRecordStatus) {
 			}
 		}
 	}
+	if in.ZoneEndpoints != nil {
+		in, out := &in.ZoneEndpoints, &out.ZoneEndpoints
+		*out = make([]*endpoint.Endpoint, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(endpoint.Endpoint)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.HealthCheck != nil {
 		in, out := &in.HealthCheck, &out.HealthCheck
 		*out = new(HealthCheckStatus)

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -493,6 +493,53 @@ spec:
                   reconciliation
                 format: date-time
                 type: string
+              relatedEndpoints:
+                description: ZoneEndpoints are all the endpoints for the DNSRecordSpec.RootHost
+                  that are present in the provider
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
               validFor:
                 description: ValidFor indicates duration since the last reconciliation
                   we consider data in the record to be valid

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -505,6 +505,53 @@ spec:
                   reconciliation
                 format: date-time
                 type: string
+              relatedEndpoints:
+                description: ZoneEndpoints are all the endpoints for the DNSRecordSpec.RootHost
+                  that are present in the provider
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
               validFor:
                 description: ValidFor indicates duration since the last reconciliation
                   we consider data in the record to be valid

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -493,6 +493,53 @@ spec:
                   reconciliation
                 format: date-time
                 type: string
+              relatedEndpoints:
+                description: ZoneEndpoints are all the endpoints for the DNSRecordSpec.RootHost
+                  that are present in the provider
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
               validFor:
                 description: ValidFor indicates duration since the last reconciliation
                   we consider data in the record to be valid

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -504,6 +504,11 @@ func (r *DNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord *v1alp
 		return false, fmt.Errorf("adjusting statusEndpoints: %w", err)
 	}
 
+	// add related endpoints to the record
+	dnsRecord.Status.ZoneEndpoints = mergeZoneEndpoints(
+		dnsRecord.Status.ZoneEndpoints,
+		filterEndpoints(rootDomainName, zoneEndpoints))
+
 	//Note: All endpoint lists should be in the same provider specific format at this point
 	logger.V(1).Info("applyChanges", "zoneEndpoints", zoneEndpoints,
 		"specEndpoints", specEndpoints, "statusEndpoints", statusEndpoints)
@@ -524,4 +529,47 @@ func (r *DNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord *v1alp
 		return true, err
 	}
 	return false, nil
+}
+
+// filterEndpoints takes a list of zoneEndpoints and removes from it all endpoints
+// that do not belong to the rootDomainName (some.example.com does belong to the example.com domain).
+// it is not using ownerID of this record as well as domainOwners from the status for filtering
+func filterEndpoints(rootDomainName string, zoneEndpoints []*externaldnsendpoint.Endpoint) []*externaldnsendpoint.Endpoint {
+	// these are records that share domain but are not defined in the spec of DNSRecord
+	var filteredEndpoints []*externaldnsendpoint.Endpoint
+
+	// setup domain filter since we can't be sure that zone records are sharing domain with DNSRecord
+	rootDomain, _ := strings.CutPrefix(rootDomainName, v1alpha1.WildcardPrefix)
+	rootDomainFilter := externaldnsendpoint.NewDomainFilter([]string{rootDomain})
+
+	// go through all EPs in the zone
+	for _, zoneEndpoint := range zoneEndpoints {
+		// if zoneEndpoint matches domain filter, it must be added to related EPs
+		if rootDomainFilter.Match(zoneEndpoint.DNSName) {
+			filteredEndpoints = append(filteredEndpoints, zoneEndpoint)
+		}
+	}
+	return filteredEndpoints
+}
+
+// mergeZoneEndpoints merges existing endpoints with new and ensures there are no duplicates
+func mergeZoneEndpoints(currentEndpoints, newEndpoints []*externaldnsendpoint.Endpoint) []*externaldnsendpoint.Endpoint {
+	// map to use as filter
+	combinedMap := make(map[string]*externaldnsendpoint.Endpoint)
+	// return struct
+	var combinedEndpoints []*externaldnsendpoint.Endpoint
+
+	// Use DNSName of EP as unique key. Ensures no duplicates
+	for _, endpoint := range currentEndpoints {
+		combinedMap[endpoint.DNSName] = endpoint
+	}
+	for _, endpoint := range newEndpoints {
+		combinedMap[endpoint.DNSName] = endpoint
+	}
+
+	// Convert a map into an array
+	for _, endpoint := range combinedMap {
+		combinedEndpoints = append(combinedEndpoints, endpoint)
+	}
+	return combinedEndpoints
 }


### PR DESCRIPTION
This PR uses `zoneEndpoints` retrieved from the provider while building plan and reports them in the spec 
An is reported to a DNSRecord if an endpoint that shares rootHost with DNSrecord. 
There could be 3 cases for this: 
1. Endpoint DNSName matches root host - it is reported
2. Endpoint DNSName is a subdomain of the root host (i.e. `one.example.com` and `example.com`) - it is reported 
3. Endpoint DNS name is not sharing the host (i.e. `one.example.com` and `two.example.com`) - is not reported

The format is as proposed in #204 