### PR TITLE
ci: Export dns operator metrics on success

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -95,6 +95,16 @@ jobs:
         run: |
           kubectl get deployments -A
           kubectl logs --all-containers --ignore-errors deployments/dns-operator-controller-manager -n dns-operator-system
+      - name: Dump Controller metrics
+        if: ${{ success() && !inputs.ginkgoDryRun }}
+        run: |
+          kubectl run -q curl --image=curlimages/curl --rm -it --restart=Never --namespace dns-operator-system -- curl -XGET http://dns-operator-controller-manager-metrics-service:8080/metrics > metrics.txt
+          cat metrics.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metrics
+          path: metrics.txt
+          if-no-files-found: warn
       - name: Exit as failure if dry run
         if: ${{ success() && inputs.ginkgoDryRun }}
         run: |


### PR DESCRIPTION
Add step at end of an e2e run to pull the dns operator metrics and upload them as an artifact "metrics"

Example run https://github.com/Kuadrant/dns-operator/actions/runs/11016551834?pr=246

![image](https://github.com/user-attachments/assets/32b56a4b-e76f-4af6-b94d-d6c10227edac)
