### PR TITLE
ci: Only run happy path tests for Azure on PRs 

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -22,10 +22,26 @@ on:
       - 'samples/**'
       - 'LICENSE'
   workflow_dispatch:
+    inputs:
+      ginkgoParallel:
+        description: Run tests in parallel
+        default: false
+        type: boolean
+      ginkgoDryRun:
+        description: Run tests with dry run
+        default: false
+        type: boolean
+      ginkgoFlags:
+        description: Flags to pass directly to the ginkgo command
+        default: "-v"
+        type: string
   merge_group:
 
 env:
   TEST_NAMESPACE: e2e-test
+  GINKGO_PARALLEL: ${{ inputs.ginkgoParallel }}
+  GINKGO_DRYRUN: ${{ inputs.ginkgoDryRun }}
+  GINKGO_FLAGS:  ${{ inputs.ginkgoFlags }}
 
 jobs:
   e2e_test_suite:
@@ -49,6 +65,7 @@ jobs:
         run: |
           make local-setup-azure-clean local-setup-azure-generate KUADRANT_AZURE_CREDENTIALS='${{ secrets.E2E_AZURE_CREDENTIALS }}'
       - name: Setup environment
+        if: ${{ !inputs.ginkgoDryRun }}
         run: |
           make local-setup DEPLOY=true TEST_NAMESPACE=${{ env.TEST_NAMESPACE }}
           kubectl -n ${{ env.TEST_NAMESPACE }} get secret/dns-provider-credentials-aws
@@ -67,13 +84,19 @@ jobs:
           export TEST_DNS_NAMESPACES=${{ env.TEST_NAMESPACE }}
           make test-e2e
       - name: Run suite Azure
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           export TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-azure
           export TEST_DNS_ZONE_DOMAIN_NAME=e2e.azure.hcpapps.net
           export TEST_DNS_NAMESPACES=${{ env.TEST_NAMESPACE }}
           make test-e2e
       - name: Dump Controller logs
-        if: ${{ failure() }}
+        if: ${{ failure() && !inputs.ginkgoDryRun }}
         run: |
           kubectl get deployments -A
           kubectl logs --all-containers --ignore-errors deployments/dns-operator-controller-manager -n dns-operator-system
+      - name: Exit as failure if dry run
+        if: ${{ success() && inputs.ginkgoDryRun }}
+        run: |
+          echo "Executed using dry run, exiting as failure"
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,12 @@ ifeq ($(GINKGO_PARALLEL), true)
 	GINKGO_FLAGS += -p
 endif
 
+# To enable set flag to true
+GINKGO_DRYRUN ?= false
+ifeq ($(GINKGO_DRYRUN), true)
+	GINKGO_FLAGS += --dry-run
+endif
+
 .PHONY: all
 all: build
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -3,6 +3,20 @@
 The e2e test suite is used to test common scenarios in each supported dns provider. The suite contains tests for single instance tests (single_record) where only a single running controller are expected as well as multi instance tests (multi_record) that are intended to test scenarios where multiple instances of the dns operator are running, each reconciling DNSRecord resources contributing to the same shared dns zone. 
 The suite allows runtime configuration to alter the number of instances that are under test allowing stress testing scenarios to be executed using more extreme numbers of instances and records.
 
+## Test Labels
+
+Tests are organized with [labels](https://onsi.github.io/ginkgo/#spec-labels) allowing subsets of specs to be easily run using ginkgo command line [options](https://onsi.github.io/ginkgo/#combining-filters).
+
+| label           | description                                                                               |
+|-----------------|-------------------------------------------------------------------------------------------|
+| multi_record    | Test cases covering multiple DNSRecords updating a set of records in a zone (Distributed) |
+| single_record   | Test cases covering a single DNSRecord updating a set of records in a zone                | 
+| simple          | Test cases for DNSRecords using the simple endpoint structure                             | 
+| loadbalanced    | Test cases for DNSRecords using the loadbalanced endpoint structure                       | 
+| provider_errors | Tests cases that put DNSRecords into known error states                                   | 
+| health_checks   | Tests cases covering DNSRecords with health checks                                        | 
+| happy           | Happy path test cases, minimum set of tests that check basic functionality                | 
+
 ## Local Setup
 
 ### Cluster scoped on single cluster

--- a/test/e2e/multi_record_test.go
+++ b/test/e2e/multi_record_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 		}, time.Minute, 10*time.Second, ctx).Should(Succeed())
 	})
 
-	Context("simple", func() {
+	Context("simple", Labels{"simple"}, func() {
 		It("creates and deletes distributed dns records", func(ctx SpecContext) {
 			By(fmt.Sprintf("creating %d simple dnsrecords accross %d clusters", len(testNamespaces)*len(testClusters), len(testClusters)))
 			for ci, tc := range testClusters {
@@ -310,7 +310,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 
 	})
 
-	Context("loadbalanced", func() {
+	Context("loadbalanced", Labels{"loadbalanced"}, func() {
 		It("creates and deletes distributed dns records", func(ctx SpecContext) {
 			testGeoRecords := map[string][]testDNSRecord{}
 

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Test Cases covering a single DNSRecord updating a set of records in a zone
-var _ = Describe("Single Record Test", func() {
+var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 	// testID is a randomly generated identifier for the test
 	// it is used to name resources and/or namespaces so different
 	// tests can be run in parallel in the same cluster
@@ -174,8 +174,8 @@ var _ = Describe("Single Record Test", func() {
 		))
 	})
 
-	Context("simple", func() {
-		It("makes available a hostname that can be resolved", func(ctx SpecContext) {
+	Context("simple", Labels{"simple"}, func() {
+		It("makes available a hostname that can be resolved", Labels{"happy"}, func(ctx SpecContext) {
 			testTargetIP := "127.0.0.1"
 			dnsRecord = &v1alpha1.DNSRecord{
 				ObjectMeta: metav1.ObjectMeta{
@@ -257,8 +257,8 @@ var _ = Describe("Single Record Test", func() {
 		})
 	})
 
-	Context("loadbalanced", func() {
-		It("makes available a hostname that can be resolved", func(ctx SpecContext) {
+	Context("loadbalanced", Labels{"loadbalanced"}, func() {
+		It("makes available a hostname that can be resolved", Labels{"happy"}, func(ctx SpecContext) {
 			testTargetIP := "127.0.0.1"
 
 			klbHostName := "klb." + testHostname


### PR DESCRIPTION
Update the e2e github action to only run the e2e test suite for Azure on pushes (merges to main) or workflow dispatch (manually).

Updates the e2e github action to allow overriding ginkgo flags with inputs when running via workflow dispatch (manually).

Add labels to all e2e test specs.

| label           | description                                                                               |
|-----------------|-------------------------------------------------------------------------------------------|
| multi_record    | Test cases covering multiple DNSRecords updating a set of records in a zone (Distributed) |
| single_record   | Test cases covering a single DNSRecord updating a set of records in a zone                | 
| simple          | Test cases for DNSRecords using the simple endpoint structure                             | 
| loadbalanced    | Test cases for DNSRecords using the loadbalanced endpoint structure                       | 
| provider_errors | Tests cases that put DNSRecords into known error states                                   | 
| health_checks   | Tests cases covering DNSRecords with health checks                                        | 
| happy           | Happy path test cases, minimum set of tests that check basic functionality                | 