### PR TITLE
ci: Fix image build jobs to use ref instead of sha on tags

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   IMG_TAGS: ${{ github.sha }} ${{ github.ref_name }}
+  IMG_REF: ${{ github.sha }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   IMG_REGISTRY_REPO: dns-operator
@@ -22,7 +23,7 @@ jobs:
     name: Build and Push image
     runs-on: ubuntu-20.04
     outputs:
-      build-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
+      build-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ env.IMG_REF }}
       build-tags: ${{ steps.build-image.outputs.tags  }}
     steps:
       - name: Check out code
@@ -33,6 +34,11 @@ jobs:
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+
+      - name: Update image ref on tags
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "IMG_REF=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Install qemu dependency
         run: |
@@ -75,7 +81,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-20.04
     outputs:
-      bundle-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
+      bundle-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ env.IMG_REF }}
 
     steps:
       - name: Check out code
@@ -103,7 +109,7 @@ jobs:
             ./bundle.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ needs.build.outputs.build-image }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
@@ -147,7 +153,7 @@ jobs:
             ./tmp/catalog/index.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ needs.build-bundle.outputs.bundle-image }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'


### PR DESCRIPTION
Update the image build jobs to ensure the bundle references the operator image, and the catalog references the bundle image using the tag for the git ref_name(main, v0.9.0, release-0.9 etc..) rather than the commit sha.

Before:
```
docker cp $(docker create --name temp-container quay.io/kuadrant/dns-operator-bundle:v0.6.0 tail):/manifests dns-operator-v0.6.0 && docker rm temp-container
cat dns-operator-v0.6.0/dns-operator.clusterserviceversion.yaml | yq .spec.install.spec.deployments[0].spec.template.spec.containers[0].image
quay.io/kuadrant/dns-operator:a1cc37d47d1980e9b2187587afcdb1cfb2a4bac0
```

After:
```
docker cp $(docker create --name temp-container quay.io/kuadrant/dns-operator-bundle:ci_fix_image_build_job tail):/manifests dns-operator-ci_fix_image_build_job && docker rm temp-container
cat dns-operator-ci_fix_image_build_job/dns-operator.clusterserviceversion.yaml | yq .spec.install.spec.deployments[0].spec.template.spec.containers[0].image
quay.io/kuadrant/dns-operator:ci_fix_image_build_job
```