### PR TITLE
Create/Delete HealthCheckProbeCR from DNSRecord Reconciler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,13 +241,11 @@ run: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
 
-
 .PHONY: run-with-probes
 run-with-probes: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run-with-probes: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 run-with-probes: manifests generate fmt vet ## Run a controller from your host.
 	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
-
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,8 +79,10 @@ func main() {
 	var maxRequeueTime time.Duration
 	var providers stringSliceFlags
 	var dnsProbesEnabled bool
+	var allowInsecureCerts bool
 
 	flag.BoolVar(&dnsProbesEnabled, "enable-probes", true, "Enable DNSHealthProbes controller.")
+	flag.BoolVar(&allowInsecureCerts, "insecure-health-checks", true, "Allow DNSHealthProbes to use insecure certificates")
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -153,7 +155,7 @@ func main() {
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: providerFactory,
-	}).SetupWithManager(mgr, maxRequeueTime, validFor, minRequeueTime); err != nil {
+	}).SetupWithManager(mgr, maxRequeueTime, validFor, minRequeueTime, dnsProbesEnabled, allowInsecureCerts); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DNSRecord")
 		os.Exit(1)
 	}

--- a/internal/controller/dnshealthcheckprobe_reconciler.go
+++ b/internal/controller/dnshealthcheckprobe_reconciler.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	ProbeOwnerLabel         = "kuadrant.io/health-probes-owner"
 	DNSHealthCheckFinalizer = "kuadrant.io/dns-health-check-probe"
 )
 

--- a/internal/controller/dnsrecord_healthchecks_test.go
+++ b/internal/controller/dnsrecord_healthchecks_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/pkg/builder"
+)
+
+var _ = Describe("DNSRecordReconciler_HealthChecks", func() {
+	var (
+		dnsRecord *v1alpha1.DNSRecord
+
+		testNamespace, testHostname string
+	)
+
+	BeforeEach(func() {
+		CreateNamespace(&testNamespace)
+
+		testZoneDomainName := strings.Join([]string{GenerateName(), "example.com"}, ".")
+		testHostname = strings.Join([]string{"foo", testZoneDomainName}, ".")
+
+		dnsProviderSecret := builder.NewProviderBuilder("inmemory-credentials", testNamespace).
+			For(v1alpha1.SecretTypeKuadrantInmemory).
+			WithZonesInitialisedFor(testZoneDomainName).
+			Build()
+		Expect(k8sClient.Create(ctx, dnsProviderSecret)).To(Succeed())
+
+		dnsRecord = &v1alpha1.DNSRecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testHostname,
+				Namespace: testNamespace,
+			},
+			Spec: v1alpha1.DNSRecordSpec{
+				RootHost: testHostname,
+				ProviderRef: v1alpha1.ProviderRef{
+					Name: dnsProviderSecret.Name,
+				},
+				Endpoints:   getTestLBEndpoints(testHostname),
+				HealthCheck: getTestHealthCheckSpec(),
+			},
+		}
+	})
+
+	It("Should create valid probe CRs and remove them on DNSRecord deletion", func() {
+		//Create default test dnsrecord
+		Expect(k8sClient.Create(ctx, dnsRecord)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dnsRecord.Status.Conditions).To(
+				ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+					"Status":  Equal(metav1.ConditionTrue),
+					"Reason":  Equal("ProviderSuccess"),
+					"Message": Equal("Provider ensured the dns record"),
+				})),
+			)
+		}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+		By("Validating created probes")
+		Eventually(func(g Gomega) {
+			probes := &v1alpha1.DNSHealthCheckProbeList{}
+
+			g.Expect(k8sClient.List(ctx, probes, &client.ListOptions{
+				LabelSelector: labels.SelectorFromSet(map[string]string{
+					ProbeOwnerLabel: BuildOwnerLabelValue(dnsRecord),
+				}),
+				Namespace: dnsRecord.Namespace,
+			})).To(Succeed())
+
+			g.Expect(probes.Items).To(HaveLen(2))
+			g.Expect(probes.Items).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+						"Name":      Equal(fmt.Sprintf("%s-%s", dnsRecord.Name, "172.32.200.1")),
+						"Namespace": Equal(testNamespace),
+					}),
+					"Spec": MatchFields(IgnoreExtras, Fields{
+						"Port":     Equal(443),
+						"Hostname": Equal(testHostname),
+						"Address":  Equal("172.32.200.1"),
+						"Path":     Equal("/healthz"),
+						"Protocol": Equal(v1alpha1.Protocol("HTTPS")),
+						"Interval": Equal(metav1.Duration{Duration: time.Minute}),
+						"AdditionalHeadersRef": PointTo(MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("headers"),
+						})),
+						"FailureThreshold":         Equal(5),
+						"AllowInsecureCertificate": Equal(true),
+					}),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+						"Name":      Equal(fmt.Sprintf("%s-%s", dnsRecord.Name, "172.32.200.2")),
+						"Namespace": Equal(testNamespace),
+					}),
+					"Spec": MatchFields(IgnoreExtras, Fields{
+						"Port":     Equal(443),
+						"Hostname": Equal(testHostname),
+						"Address":  Equal("172.32.200.2"),
+						"Path":     Equal("/healthz"),
+						"Protocol": Equal(v1alpha1.Protocol("HTTPS")),
+						"Interval": Equal(metav1.Duration{Duration: time.Minute}),
+						"AdditionalHeadersRef": PointTo(MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("headers"),
+						})),
+						"FailureThreshold":         Equal(5),
+						"AllowInsecureCertificate": Equal(true),
+					}),
+				}),
+			))
+		}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+		By("Ensuring probes block DNSRecord deletion and correctly removed")
+		Eventually(func(g Gomega) {
+			probes := &v1alpha1.DNSHealthCheckProbeList{}
+
+			g.Expect(k8sClient.List(ctx, probes, &client.ListOptions{
+				LabelSelector: labels.SelectorFromSet(map[string]string{
+					ProbeOwnerLabel: BuildOwnerLabelValue(dnsRecord),
+				}),
+				Namespace: dnsRecord.Namespace,
+			})).To(Succeed())
+
+			g.Expect(probes.Items).To(HaveLen(2))
+			g.Expect(probes.Items).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+						"Name":      Equal(fmt.Sprintf("%s-%s", dnsRecord.Name, "172.32.200.1")),
+						"Namespace": Equal(testNamespace),
+						"OwnerReferences": ConsistOf(MatchFields(IgnoreExtras, Fields{
+							"Name":               Equal(dnsRecord.Name),
+							"UID":                Equal(dnsRecord.UID),
+							"Controller":         PointTo(Equal(true)),
+							"BlockOwnerDeletion": PointTo(Equal(true)),
+						})),
+					}),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+						"Name":      Equal(fmt.Sprintf("%s-%s", dnsRecord.Name, "172.32.200.2")),
+						"Namespace": Equal(testNamespace),
+						"OwnerReferences": ConsistOf(MatchFields(IgnoreExtras, Fields{
+							"Name":               Equal(dnsRecord.Name),
+							"UID":                Equal(dnsRecord.UID),
+							"Controller":         PointTo(Equal(true)),
+							"BlockOwnerDeletion": PointTo(Equal(true)),
+						})),
+					}),
+				}),
+			))
+
+			g.Expect(k8sClient.Delete(ctx, dnsRecord)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.List(ctx, probes, &client.ListOptions{
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						ProbeOwnerLabel: BuildOwnerLabelValue(dnsRecord),
+					}),
+					Namespace: dnsRecord.Namespace,
+				})).To(Succeed())
+
+				g.Expect(probes.Items).To(HaveLen(0))
+			}, TestTimeoutShort, time.Second)
+
+		}, TestTimeoutMedium, time.Second).Should(Succeed())
+	})
+
+})

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/goombaio/namegenerator"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 const (
@@ -39,6 +42,108 @@ func getTestEndpoints(dnsName, ip string) []*externaldnsendpoint.Endpoint {
 			RecordTTL:        60,
 			Labels:           nil,
 			ProviderSpecific: nil,
+		},
+	}
+}
+
+func getTestHealthCheckSpec() *v1alpha1.HealthCheckSpec {
+	return &v1alpha1.HealthCheckSpec{
+		Path:             "/healthz",
+		Port:             443,
+		Protocol:         "HTTPS",
+		FailureThreshold: 5,
+		Interval:         metav1.Duration{Duration: time.Minute},
+		AdditionalHeadersRef: &v1alpha1.AdditionalHeadersRef{
+			Name: "headers",
+		},
+	}
+}
+func getTestLBEndpoints(testDomain string) []*externaldnsendpoint.Endpoint {
+	return []*externaldnsendpoint.Endpoint{
+		{
+			DNSName:    testDomain,
+			RecordTTL:  300,
+			RecordType: "CNAME",
+			Targets: []string{
+				"klb." + testDomain,
+			},
+		},
+		{
+			DNSName:    "ip1." + testDomain,
+			RecordTTL:  60,
+			RecordType: "A",
+			Targets: []string{
+				"172.32.200.1",
+			},
+		},
+		{
+			DNSName:    "ip2." + testDomain,
+			RecordTTL:  60,
+			RecordType: "A",
+			Targets: []string{
+				"172.32.200.2",
+			},
+		},
+		{
+			DNSName:    "eu.klb." + testDomain,
+			RecordTTL:  60,
+			RecordType: "CNAME",
+			Targets: []string{
+				"ip2." + testDomain,
+			},
+		},
+		{
+			DNSName:    "us.klb." + testDomain,
+			RecordTTL:  60,
+			RecordType: "CNAME",
+			Targets: []string{
+				"ip1." + testDomain,
+			},
+		},
+		{
+			DNSName: "klb." + testDomain,
+			ProviderSpecific: []externaldnsendpoint.ProviderSpecificProperty{
+				{
+					Name:  "geo-code",
+					Value: "*",
+				},
+			},
+			RecordTTL:     300,
+			RecordType:    "CNAME",
+			SetIdentifier: "",
+			Targets: []string{
+				"eu.klb." + testDomain,
+			},
+		},
+		{
+			DNSName: "klb." + testDomain,
+			ProviderSpecific: []externaldnsendpoint.ProviderSpecificProperty{
+				{
+					Name:  "geo-code",
+					Value: "GEO-NA",
+				},
+			},
+			RecordTTL:     300,
+			RecordType:    "CNAME",
+			SetIdentifier: "",
+			Targets: []string{
+				"us.klb." + testDomain,
+			},
+		},
+		{
+			DNSName: "klb." + testDomain,
+			ProviderSpecific: []externaldnsendpoint.ProviderSpecificProperty{
+				{
+					Name:  "geo-code",
+					Value: "GEO-EU",
+				},
+			},
+			RecordTTL:     300,
+			RecordType:    "CNAME",
+			SetIdentifier: "",
+			Targets: []string{
+				"eu.klb." + testDomain,
+			},
 		},
 	}
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeSuite(func() {
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: providerFactory,
-	}).SetupWithManager(mgr, RequeueDuration, ValidityDuration, DefaultValidationDuration)
+	}).SetupWithManager(mgr, RequeueDuration, ValidityDuration, DefaultValidationDuration, true, true)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/test/e2e/healthcheck_test.go
+++ b/test/e2e/healthcheck_test.go
@@ -3,18 +3,13 @@
 package e2e
 
 import (
-	"fmt"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
@@ -54,181 +49,7 @@ var _ = Describe("Health Check Test", Serial, Labels{"health_checks"}, func() {
 		}
 	})
 
-	Context("DNS Provider health checks", func() {
-		It("creates health checks for a health check spec", func(ctx SpecContext) {
-			healthChecksSupported := false
-			if slices.Contains(supportedHealthCheckProviders, strings.ToLower(testDNSProvider)) {
-				healthChecksSupported = true
-			}
-
-			dnsRecord = &v1alpha1.DNSRecord{}
-			err := ResourceFromFile("./fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml", dnsRecord, GetTestEnv)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("creating dnsrecord " + dnsRecord.Name)
-			err = k8sClient.Create(ctx, dnsRecord)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("checking " + dnsRecord.Name + " becomes ready")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(dnsRecord.Status.Conditions).To(
-					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(string(v1alpha1.ConditionTypeReady)),
-						"Status": Equal(metav1.ConditionTrue),
-					})),
-				)
-			}, recordsReadyMaxDuration, 10*time.Second, ctx).Should(Succeed())
-
-			By("Confirming the DNS Record status")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
-				g.Expect(err).ToNot(HaveOccurred())
-
-				if healthChecksSupported {
-					g.Expect(dnsRecord.Status.HealthCheck).ToNot(BeNil())
-					g.Expect(&dnsRecord.Status.HealthCheck.Probes).ToNot(BeNil())
-					g.Expect(len(dnsRecord.Status.HealthCheck.Probes)).ToNot(BeZero())
-					for _, condition := range dnsRecord.Status.HealthCheck.Conditions {
-						if condition.Type == "healthProbesSynced" {
-							g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
-							g.Expect(condition.Reason).To(Equal("AllProbesSynced"))
-						}
-					}
-				} else {
-					g.Expect(dnsRecord.Status.HealthCheck).ToNot(BeNil())
-					g.Expect(dnsRecord.Status.HealthCheck.Probes).To(BeNil())
-				}
-
-				for _, probe := range dnsRecord.Status.HealthCheck.Probes {
-					g.Expect(probe.Host).To(Equal(testHostname))
-					g.Expect(probe.IPAddress).To(Equal("172.32.200.1"))
-					g.Expect(probe.ID).ToNot(Equal(""))
-
-					for _, probeCondition := range probe.Conditions {
-						g.Expect(probeCondition.Type).To(Equal("ProbeSynced"))
-						g.Expect(probeCondition.Status).To(Equal(metav1.ConditionTrue))
-						g.Expect(probeCondition.Message).To(ContainSubstring(fmt.Sprintf("id: %v, address: %v, host: %v", probe.ID, probe.IPAddress, probe.Host)))
-					}
-				}
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			provider, err := ProviderForDNSRecord(ctx, dnsRecord, k8sClient)
-			Expect(err).To(BeNil())
-
-			By("confirming the health checks exist in the provider")
-			Eventually(func(g Gomega) {
-				if !healthChecksSupported {
-					g.Expect(len(dnsRecord.Status.HealthCheck.Probes)).To(BeZero())
-				}
-				for _, healthCheck := range dnsRecord.Status.HealthCheck.Probes {
-					exists, err := provider.HealthCheckReconciler().HealthCheckExists(ctx, &healthCheck)
-					g.Expect(err).To(BeNil())
-					g.Expect(exists).To(BeTrue())
-				}
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			By("Removing the health check")
-			oldHealthCheckStatus := dnsRecord.Status.HealthCheck.DeepCopy()
-			Eventually(func(g Gomega) {
-				patchFrom := client.MergeFrom(dnsRecord.DeepCopy())
-				dnsRecord.Spec.HealthCheck = nil
-				err := k8sClient.Patch(ctx, dnsRecord, patchFrom)
-				g.Expect(err).To(BeNil())
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			By("Confirming the DNS Record status")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(dnsRecord.Status.HealthCheck).To(BeNil())
-			})
-
-			By("confirming the health checks were removed in the provider")
-			Eventually(func(g Gomega) {
-				for _, healthCheck := range oldHealthCheckStatus.Probes {
-					exists, err := provider.HealthCheckReconciler().HealthCheckExists(ctx, &healthCheck)
-					g.Expect(err).NotTo(BeNil())
-					g.Expect(exists).To(BeFalse())
-				}
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			By("Adding a health check spec")
-			Eventually(func(g Gomega) {
-				patchFrom := client.MergeFrom(dnsRecord.DeepCopy())
-				err = ResourceFromFile("./fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml", dnsRecord, GetTestEnv)
-				g.Expect(err).ToNot(HaveOccurred())
-				err := k8sClient.Patch(ctx, dnsRecord, patchFrom)
-				g.Expect(err).To(BeNil())
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			By("Confirming the DNS Record status")
-			Eventually(func(g Gomega) {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
-				g.Expect(err).ToNot(HaveOccurred())
-
-				if healthChecksSupported {
-					g.Expect(dnsRecord.Status.HealthCheck).ToNot(BeNil())
-					g.Expect(&dnsRecord.Status.HealthCheck.Probes).ToNot(BeNil())
-					g.Expect(len(dnsRecord.Status.HealthCheck.Probes)).ToNot(BeZero())
-					for _, condition := range dnsRecord.Status.HealthCheck.Conditions {
-						if condition.Type == "healthProbesSynced" {
-							g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
-							g.Expect(condition.Reason).To(Equal("AllProbesSynced"))
-						}
-					}
-				} else {
-					g.Expect(dnsRecord.Status.HealthCheck).ToNot(BeNil())
-					g.Expect(dnsRecord.Status.HealthCheck.Probes).To(BeNil())
-				}
-
-				for _, probe := range dnsRecord.Status.HealthCheck.Probes {
-					g.Expect(probe.Host).To(Equal(testHostname))
-					g.Expect(probe.IPAddress).To(Equal("172.32.200.1"))
-					g.Expect(probe.ID).ToNot(Equal(""))
-
-					for _, probeCondition := range probe.Conditions {
-						g.Expect(probeCondition.Type).To(Equal("ProbeSynced"))
-						g.Expect(probeCondition.Status).To(Equal(metav1.ConditionTrue))
-						g.Expect(probeCondition.Message).To(ContainSubstring(fmt.Sprintf("id: %v, address: %v, host: %v", probe.ID, probe.IPAddress, probe.Host)))
-					}
-				}
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			By("confirming the health checks exist in the provider")
-			Eventually(func(g Gomega) {
-				if !healthChecksSupported {
-					g.Expect(len(dnsRecord.Status.HealthCheck.Probes)).To(BeZero())
-				}
-				for _, healthCheck := range dnsRecord.Status.HealthCheck.Probes {
-					exists, err := provider.HealthCheckReconciler().HealthCheckExists(ctx, &healthCheck)
-					g.Expect(err).To(BeNil())
-					g.Expect(exists).To(BeTrue())
-				}
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			By("Deleting the DNS Record")
-			oldHealthCheckStatus = dnsRecord.Status.HealthCheck.DeepCopy()
-			err = ResourceFromFile("./fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml", dnsRecord, GetTestEnv)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(func(g Gomega) {
-				err := k8sClient.Delete(ctx, dnsRecord)
-				g.Expect(client.IgnoreNotFound(err)).To(BeNil())
-
-				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
-				g.Expect(errors.IsNotFound(err)).Should(BeTrue())
-			}, recordsRemovedMaxDuration, time.Second).Should(Succeed())
-
-			By("confirming the health checks were removed in the provider")
-			Eventually(func(g Gomega) {
-				for _, healthCheck := range oldHealthCheckStatus.Probes {
-					exists, err := provider.HealthCheckReconciler().HealthCheckExists(ctx, &healthCheck)
-					g.Expect(err).NotTo(BeNil())
-					g.Expect(exists).To(BeFalse())
-				}
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-		})
+	Context("On-cluster healthchecks", func() {
+		// TODO test case
 	})
 })


### PR DESCRIPTION
Create and delete `DNSHealthProbe` CRs during reconciliation of the DNSRecords. 
This replaced logic in `internal/controller/dnsrecord_healthchecks.go` to create new healthchecks but does not remove the code that would generate old healthchecks. 