### PR TITLE
ci: Improve build images job for release tags

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -1,18 +1,13 @@
-name: Build and Publish Images
+name: Build and Publish Images For Tag Release
 
 on:
   push:
-    branches:
-      - main
-      - "release-*"
-  workflow_dispatch:
-
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 env:
-  IMG_TAGS: ${{ github.sha }} ${{ github.ref_name }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   IMG_REGISTRY_REPO: dns-operator
-  MAIN_BRANCH_NAME: main
   OPERATOR_NAME: dns-operator
 
 jobs:
@@ -21,16 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
-      build-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
-      - name: Add latest tag
-        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        id: add-latest-tag
-        run: |
-          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
 
       - name: Install qemu dependency
         run: |
@@ -42,7 +30,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}
-          tags: ${{ env.IMG_TAGS }}
+          tags: ${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             GIT_SHA=${{ github.sha }}
@@ -73,13 +61,22 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     outputs:
-      bundle-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
+      build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
-      - name: Run make bundle
-        run: make bundle IMG=${{ needs.build.outputs.build-image }}
+      - name: Install yq tool
+        run: |
+          # following sub-shells running make target should have yq already installed
+          make yq
+      - name: Read operator image reference URL from the manifest bundle
+        id: parsed-operator-image
+        run: |
+          url=`make bundle-operator-image-url`
+          echo url=$url >> $GITHUB_OUTPUT
+      - name: Verify referenced operator image tag matches the tag currently being built
+        if: ${{ needs.build.outputs.build-tags != steps.parsed-operator-image.outputs.url }}
+        run: exit 1
 
       - name: Install qemu dependency
         run: |
@@ -97,7 +94,7 @@ jobs:
             ./bundle.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ needs.build.outputs.build-image }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ steps.parsed-operator-image.outputs.url }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
@@ -117,13 +114,25 @@ jobs:
     name: Build and Push catalog image
     needs: [build, build-bundle]
     runs-on: ubuntu-latest
+    outputs:
+      build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
+      - name: Install yq tool
+        run: |
+          # following sub-shells running make target should have yq already installed
+          make yq
+      - name: Read operator bundle image reference
+        id: parsed-operator-bundle
+        run: |
+          image=`make print-bundle-image`
+          echo image=$image >> $GITHUB_OUTPUT
+      - name: Verify referenced bundle tag matches the bundle tag currently being built
+        if: ${{ needs.build-bundle.outputs.build-tags != steps.parsed-operator-bundle.outputs.image }}
+        run: exit 1
       - name: Run make catalog-build
-        run: make catalog-build BUNDLE_IMG=${{ needs.build-bundle.outputs.bundle-image }}
-
+        run: make catalog-build
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -141,7 +150,7 @@ jobs:
             ./tmp/catalog/index.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ needs.build-bundle.outputs.bundle-image }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ steps.parsed-operator-bundle.outputs.image }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
@@ -156,3 +165,15 @@ jobs:
 
       - name: Print Image URL
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+  verify-builds:
+    name: Ensure all image references are equal (operator, bundle, catalog)
+    needs: [build, build-bundle, build-catalog]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify bundle and operator image tags match
+        if: ${{ needs.build.outputs.build-tags != needs.build-bundle.outputs.build-tags }}
+        run: exit 1
+      - name: Verify catalog and bundle tags match
+        if: ${{ needs.build-bundle.outputs.build-tags != needs.build-catalog.outputs.build-tags }}
+        run: exit 1

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -74,6 +74,8 @@ jobs:
         run: |
           url=`make bundle-operator-image-url`
           echo url=$url >> $GITHUB_OUTPUT
+      - name: Print tags and references
+        run: echo "Operator image tag = ${{ needs.build.outputs.build-tags }}, Reference in bundle = ${{ steps.parsed-operator-image.outputs.url }}"
       - name: Verify referenced operator image tag matches the tag currently being built
         if: ${{ needs.build.outputs.build-tags != steps.parsed-operator-image.outputs.url }}
         run: exit 1
@@ -128,6 +130,8 @@ jobs:
         run: |
           image=`make print-bundle-image`
           echo image=$image >> $GITHUB_OUTPUT
+      - name: Print tags and references
+        run: echo "Operator bundle image tag = ${{ needs.build-bundle.outputs.build-tags }}, Reference in catalog = ${{ steps.parsed-operator-bundle.outputs.image }}"
       - name: Verify referenced bundle tag matches the bundle tag currently being built
         if: ${{ needs.build-bundle.outputs.build-tags != steps.parsed-operator-bundle.outputs.image }}
         run: exit 1

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
+      image: ${{ steps.push-to-quay.outputs.registry-path }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -62,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
+      image: ${{ steps.push-to-quay.outputs.registry-path }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -75,9 +77,9 @@ jobs:
           url=`make bundle-operator-image-url`
           echo url=$url >> $GITHUB_OUTPUT
       - name: Print tags and references
-        run: echo "Operator image tag = ${{ needs.build.outputs.build-tags }}, Reference in bundle = ${{ steps.parsed-operator-image.outputs.url }}"
+        run: echo "Operator image tag = ${{ needs.build.outputs.image }}, Reference in bundle = ${{ steps.parsed-operator-image.outputs.url }}"
       - name: Verify referenced operator image tag matches the tag currently being built
-        if: ${{ needs.build.outputs.build-tags != steps.parsed-operator-image.outputs.url }}
+        if: ${{ needs.build.outputs.image != steps.parsed-operator-image.outputs.url }}
         run: exit 1
 
       - name: Install qemu dependency
@@ -118,6 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
+      image: ${{ steps.push-to-quay.outputs.registry-path }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -131,9 +134,9 @@ jobs:
           image=`make print-bundle-image`
           echo image=$image >> $GITHUB_OUTPUT
       - name: Print tags and references
-        run: echo "Operator bundle image tag = ${{ needs.build-bundle.outputs.build-tags }}, Reference in catalog = ${{ steps.parsed-operator-bundle.outputs.image }}"
+        run: echo "Operator bundle image tag = ${{ needs.build-bundle.outputs.image }}, Reference in catalog = ${{ steps.parsed-operator-bundle.outputs.image }}"
       - name: Verify referenced bundle tag matches the bundle tag currently being built
-        if: ${{ needs.build-bundle.outputs.build-tags != steps.parsed-operator-bundle.outputs.image }}
+        if: ${{ needs.build-bundle.outputs.image != steps.parsed-operator-bundle.outputs.image }}
         run: exit 1
       - name: Run make catalog-build
         run: make catalog-build

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -92,12 +92,11 @@ jobs:
         run: |
           tag=`make bundle-operator-image-tag`
           echo tag=$tag >> $GITHUB_OUTPUT
-      - name: Verify referenced opeator image has previously been built
-        uses: nick-fields/assert-action@v2
-        with:
-          expected: ${{ steps.operator-image-tag.outputs.tag }}
-          actual: ${{ needs.build.outputs.build-tags }}
-          comparison: contains
+      - name: Verify referenced operator image has previously been built
+        # Only check on tags. On (release) branches, the branch name may not match referenced tag in CSV.
+        # For (release) branches, the workflow builds operator image tags with sha and branch name.
+        if: ${{ startsWith(github.ref, 'refs/tags/') && ! contains(needs.build.outputs.build-tags, steps.operator-image-tag.outputs.tag) }}
+        run: exit 1
 
       - name: Install qemu dependency
         run: |
@@ -147,24 +146,16 @@ jobs:
         run: |
           # following sub-shells running make target should have yq already installed
           make yq
-      - name: Read operator image reference URL from the manifest bundle
-        id: operator-image-url
-        run: |
-          url=`make bundle-operator-image-url`
-          echo url=$url >> $GITHUB_OUTPUT
       - name: Read operator bundle image reference
         id: operator-bundle
         run: |
           image=`make print-bundle-image`
           echo image=$image >> $GITHUB_OUTPUT
+      - name: Verify referenced bundle has previously been built
+        if: ${{ ! contains(needs.build-bundle.outputs.build-tags, steps.operator-bundle.outputs.image) }}
+        run: exit 1
       - name: Run make catalog-build
         run: make catalog-build
-      - name: Verify referenced bundle has previously been built
-        uses: nick-fields/assert-action@v2
-        with:
-          expected: ${{ steps.operator-bundle.outputs.image }}
-          actual: ${{ needs.build-bundle.outputs.build-tags }}
-          comparison: contains
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -202,13 +193,9 @@ jobs:
     needs: [build, build-bundle, build-catalog]
     runs-on: ubuntu-latest
     steps:
-      - name: Verify bundle and image tags match
-        uses: nick-fields/assert-action@v2
-        with:
-          expected: ${{ needs.build.outputs.build-tags }}
-          actual: ${{ needs.build-bundle.outputs.build-tags }}
+      - name: Verify bundle and operator image tags match
+        if: ${{ needs.build.outputs.build-tags != needs.build-bundle.outputs.build-tags }}
+        run: exit 1
       - name: Verify catalog and bundle tags match
-        uses: nick-fields/assert-action@v2
-        with:
-          expected: ${{ needs.build-bundle.outputs.build-tags }}
-          actual: ${{ needs.build-catalog.outputs.build-tags }}
+        if: ${{ needs.build-bundle.outputs.build-tags != needs.build-catalog.outputs.build-tags }}
+        run: exit 1

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run make catalog-build
-        run: make catalog-build BUNDLE_IMG=${{ needs.build-bundle.outputs.bundle-image }}
+        run: make catalog-build
 
       - name: Install qemu dependency
         run: |

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Build and Push image
     runs-on: ubuntu-20.04
     outputs:
-      build-tags: ${{ steps.build-image.outputs.tags  }}
+      build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -73,6 +73,8 @@ jobs:
     name: Build and Push bundle image
     needs: [build]
     runs-on: ubuntu-20.04
+    outputs:
+      build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -81,6 +83,12 @@ jobs:
         run: |
           echo "url=$(make bundle-operator-image-url)" >> $GITHUB_OUTPUT
           echo "tag=$(make bundle-operator-image-tag)" >> $GITHUB_OUTPUT
+      - name: Verify referenced opeator image has previously been built
+        uses: nick-fields/assert-action@v2
+        with:
+          expected: ${{ steps.operator-image.tag }}
+          actual: ${{ needs.build.outputs.build-tags }}
+          comparison: contains
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -123,13 +131,18 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Read operator bundle images reference
+      - name: Read operator bundle image reference
         id: operator-bundle
         run: |
-          echo "images=$(make print-bundle-images)" >> $GITHUB_OUTPUT
+          echo "image=$(make print-bundle-image)" >> $GITHUB_OUTPUT
       - name: Run make catalog-build
         run: make catalog-build
-
+      - name: Verify referenced bundle has previously been built
+        uses: nick-fields/assert-action@v2
+        with:
+          expected: ${{ steps.operator-bundle.image }}
+          actual: ${{ needs.build-bundle.outputs.build-tags }}
+          comparison: contains
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -147,7 +160,7 @@ jobs:
             ./tmp/catalog/index.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMGs = ${{ steps.operator-bundle.images }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ steps.operator-bundle.image }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -11,7 +11,6 @@ on:
 
 env:
   IMG_TAGS: ${{ github.sha }} ${{ github.ref_name }}
-  IMG_REF: ${{ github.sha }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   IMG_REGISTRY_REPO: dns-operator
@@ -23,7 +22,6 @@ jobs:
     name: Build and Push image
     runs-on: ubuntu-20.04
     outputs:
-      build-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ env.IMG_REF }}
       build-tags: ${{ steps.build-image.outputs.tags  }}
     steps:
       - name: Check out code
@@ -34,11 +32,6 @@ jobs:
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-
-      - name: Update image ref on tags
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo "IMG_REF=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Install qemu dependency
         run: |
@@ -80,13 +73,14 @@ jobs:
     name: Build and Push bundle image
     needs: [build]
     runs-on: ubuntu-20.04
-    outputs:
-      bundle-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ env.IMG_REF }}
-
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
+      - name: Read operator image reference from the manifest bundle
+        id: operator-image
+        run: |
+          echo "url=$(make bundle-operator-image-url)" >> $GITHUB_OUTPUT
+          echo "tag=$(make bundle-operator-image-tag)" >> $GITHUB_OUTPUT
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -106,7 +100,7 @@ jobs:
             ./bundle.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ needs.build.outputs.build-image }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ steps.operator-image.url }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
@@ -129,7 +123,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-
+      - name: Read operator bundle images reference
+        id: operator-bundle
+        run: |
+          echo "images=$(make print-bundle-images)" >> $GITHUB_OUTPUT
       - name: Run make catalog-build
         run: make catalog-build
 
@@ -150,7 +147,7 @@ jobs:
             ./tmp/catalog/index.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ needs.build-bundle.outputs.bundle-image }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMGs = ${{ steps.operator-bundle.images }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: Build and Push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
@@ -72,23 +72,33 @@ jobs:
   build-bundle:
     name: Build and Push bundle image
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Read operator image reference from the manifest bundle
-        id: operator-image
+      - name: Install yq tool
         run: |
-          echo "url=$(make bundle-operator-image-url)" >> $GITHUB_OUTPUT
-          echo "tag=$(make bundle-operator-image-tag)" >> $GITHUB_OUTPUT
+          # following sub-shells running make target should have yq already installed
+          make yq
+      - name: Read operator image reference URL from the manifest bundle
+        id: operator-image-url
+        run: |
+          url=`make bundle-operator-image-url`
+          echo url=$url >> $GITHUB_OUTPUT
+      - name: Read operator image reference tag from the manifest bundle
+        id: operator-image-tag
+        run: |
+          tag=`make bundle-operator-image-tag`
+          echo tag=$tag >> $GITHUB_OUTPUT
       - name: Verify referenced opeator image has previously been built
         uses: nick-fields/assert-action@v2
         with:
-          expected: ${{ steps.operator-image.tag }}
+          expected: ${{ steps.operator-image-tag.outputs.tag }}
           actual: ${{ needs.build.outputs.build-tags }}
           comparison: contains
+
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -108,7 +118,7 @@ jobs:
             ./bundle.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ steps.operator-image.url }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ steps.operator-image-url.outputs.url }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
@@ -127,22 +137,32 @@ jobs:
   build-catalog:
     name: Build and Push catalog image
     needs: [build, build-bundle]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Install yq tool
+        run: |
+          # following sub-shells running make target should have yq already installed
+          make yq
+      - name: Read operator image reference URL from the manifest bundle
+        id: operator-image-url
+        run: |
+          url=`make bundle-operator-image-url`
+          echo url=$url >> $GITHUB_OUTPUT
       - name: Read operator bundle image reference
         id: operator-bundle
         run: |
-          echo "image=$(make print-bundle-image)" >> $GITHUB_OUTPUT
+          image=`make print-bundle-image`
+          echo image=$image >> $GITHUB_OUTPUT
       - name: Run make catalog-build
         run: make catalog-build
       - name: Verify referenced bundle has previously been built
         uses: nick-fields/assert-action@v2
         with:
-          expected: ${{ steps.operator-bundle.image }}
+          expected: ${{ steps.operator-bundle.outputs.image }}
           actual: ${{ needs.build-bundle.outputs.build-tags }}
           comparison: contains
       - name: Install qemu dependency
@@ -162,7 +182,7 @@ jobs:
             ./tmp/catalog/index.Dockerfile
 
       - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ steps.operator-bundle.image }}"
+        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ steps.operator-bundle.outputs.image }}"
 
       - name: Push Image
         if: github.repository_owner == 'kuadrant'

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -87,9 +87,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Run make bundle
-        run: make bundle IMG=${{ needs.build.outputs.build-image }}
-
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -128,6 +128,8 @@ jobs:
     name: Build and Push catalog image
     needs: [build, build-bundle]
     runs-on: ubuntu-20.04
+    outputs:
+      build-tags: ${{ steps.build-image.outputs.tags }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -175,3 +177,18 @@ jobs:
 
       - name: Print Image URL
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+  verify-builds:
+    name: Ensure all image references are equal (operator, bundle, catalog)
+    needs: [build, build-bundle, build-catalog]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify bundle and image tags match
+        uses: nick-fields/assert-action@v2
+        with:
+          expected: ${{ needs.build.outputs.build-tags }}
+          actual: ${{ needs.build-bundle.outputs.build-tags }}
+      - name: Verify catalog and bundle tags match
+        uses: nick-fields/assert-action@v2
+        with:
+          expected: ${{ needs.build-bundle.outputs.build-tags }}
+          actual: ${{ needs.build-catalog.outputs.build-tags }}

--- a/Makefile
+++ b/Makefile
@@ -445,9 +445,6 @@ bundle: manifests manifests-gen-base-csv kustomize operator-sdk ## Generate bund
 bundle-operator-image-url: $(YQ) ## Read operator image reference URL from the manifest bundle.
 	@$(YQ) '.metadata.annotations.containerImage' bundle/manifests/dns-operator.clusterserviceversion.yaml
 
-bundle-operator-image-tag: $(YQ) ## Read operator image reference TAG from the manifest bundle.
-	@$(YQ) '.metadata.annotations.containerImage | split(":") | .[1]' bundle/manifests/dns-operator.clusterserviceversion.yaml
-
 # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle
 # even if it is patched:
 #   https://github.com/operator-framework/operator-sdk/pull/6136

--- a/Makefile
+++ b/Makefile
@@ -513,8 +513,8 @@ catalog-build: opm ## Build a catalog image.
 	cd tmp/catalog && $(OPM) index add --container-tool docker --mode semver --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT) --generate
 	cd tmp/catalog && docker build -t $(CATALOG_IMG) -f index.Dockerfile .
 
-print-bundle-images: ## Pring bundle images.
-	@echo $(BUNDLE_IMGS)
+print-bundle-image: ## Pring bundle images.
+	@echo $(BUNDLE_IMG)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/Makefile
+++ b/Makefile
@@ -230,13 +230,13 @@ local-deploy-namespaced: docker-build kind-load-image ## Deploy the dns operator
 ##@ Build
 
 .PHONY: build
-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown") 
+build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 build: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 build: manifests generate fmt vet ## Build manager binary.
 	go build -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o bin/manager cmd/main.go
 
 .PHONY: run
-run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown") 
+run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
@@ -253,7 +253,7 @@ run-with-probes: manifests generate fmt vet ## Run a controller from your host.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown") 
+docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 docker-build: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} . --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY)
@@ -442,6 +442,12 @@ bundle: manifests manifests-gen-base-csv kustomize operator-sdk ## Generate bund
 	$(OPERATOR_SDK) bundle validate ./bundle
 	$(MAKE) bundle-ignore-createdAt
 
+bundle-operator-image-url: $(YQ) ## Read operator image reference URL from the manifest bundle.
+	@$(YQ) '.metadata.annotations.containerImage' bundle/manifests/dns-operator.clusterserviceversion.yaml
+
+bundle-operator-image-tag: $(YQ) ## Read operator image reference TAG from the manifest bundle.
+	@$(YQ) '.metadata.annotations.containerImage | split(":") | .[1]' bundle/manifests/dns-operator.clusterserviceversion.yaml
+
 # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle
 # even if it is patched:
 #   https://github.com/operator-framework/operator-sdk/pull/6136
@@ -506,6 +512,9 @@ catalog-build: opm ## Build a catalog image.
 	mkdir -p tmp/catalog
 	cd tmp/catalog && $(OPM) index add --container-tool docker --mode semver --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT) --generate
 	cd tmp/catalog && docker build -t $(CATALOG_IMG) -f index.Dockerfile .
+
+print-bundle-images: ## Pring bundle images.
+	@echo $(BUNDLE_IMGS)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -32,7 +32,7 @@ git tag v0.2.0
 git push upstream release-0.2
 git push upstream v0.2.0
 ```
-8. Verify that the build [image workflow](https://github.com/Kuadrant/dns-operator/actions/workflows/build-images.yaml) is triggered and completes for the new tag
+8. Verify that the build [release tag workflow](https://github.com/Kuadrant/dns-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag
 
 9. Verify the new version can be installed from the catalog image, see [Verify OLM Deployment](#verify-olm-deployment)
 
@@ -56,7 +56,7 @@ git tag v0.2.1
 git push upstream release-0.2
 git push upstream v0.2.1
 ```
-4. Verify that the build [image workflow](https://github.com/Kuadrant/dns-operator/actions/workflows/build-images.yaml) is triggered and completes for the new tag
+4. Verify that the build [release tag workflow](https://github.com/Kuadrant/dns-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag
 
 5. Verify the new version can be installed from the catalog image, see [Verify OLM Deployment](#verify-olm-deployment)
 


### PR DESCRIPTION
### What

New CI workflow named `Build and Publish Images For Tag Release` that:

- [X] Skip the bundle build [step](https://github.com/Kuadrant/dns-operator/blob/main/.github/workflows/build-images.yaml#L90)
- [x]  Don't set the BUNDLE_IMG value in the build-catalog [step](https://github.com/Kuadrant/dns-operator/blob/main/.github/workflows/build-images.yaml#L136)
- [x] Ensure current image values reference the same tag name currently being built
- [x] Ensure all image references are equal (operator, bundle, catalog)
- [ ] Golang version check

### Verification steps: create a release that should succeed.

```
git checkout -b release-0.7-testing 262-ci-improve-build-images-job-for-release-tags
```

Run prepare release for final version `v0.0.100`. 
```sh
make prepare-release VERSION=0.0.100 CHANNELS=stable REPLACES_VERSION=0.6.0
```
Verify local changes, commit, push and tag with the typo:
```sh
git add .
git commit -m "prepare-release: v0.7.0"
git tag v0.0.100 
git push origin release-0.7-testing
git push origin v0.0.100 
```
Verify that the build [image for release tag workflow](https://github.com/Kuadrant/dns-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag

* Clean up
```
git checkout 262-ci-improve-build-images-job-for-release-tags
git push --delete origin v0.0.100
git tag -d v0.0.100
git push --delete origin release-0.7-testing
git branch -D release-0.7-testing
```

### Verification steps: create a release that should fail.

Let's prepare a release with a typo.

```
git checkout -b release-0.7-testing 262-ci-improve-build-images-job-for-release-tags
```

Run prepare release for final version `v0.0.200`. 
```sh
make prepare-release VERSION=0.0.200 CHANNELS=stable REPLACES_VERSION=0.6.0
```
Verify local changes, commit, push and tag with one typo: instead of tag `v0.0.200` which would be the right one, tag it with `v0.0.201`.
```sh
git add .
git commit -m "prepare-release: v0.7.0"
git tag v0.0.201
git push origin release-0.7-testing
git push origin v0.0.201
```
Verify that the build [image for release tag workflow](https://github.com/Kuadrant/dns-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and fails

* Clean up

```
git checkout 262-ci-improve-build-images-job-for-release-tags
git push --delete origin v0.0.201
git tag -d v0.0.201
git push --delete origin release-0.7-testing
git branch -D release-0.7-testing
```



