### PR TITLE
Report healtchecks to status

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -4,3 +4,10 @@ type ConditionType string
 type ConditionReason string
 
 const ConditionTypeReady ConditionType = "Ready"
+const ConditionReasonProviderSuccess ConditionReason = "ProviderSuccess"
+const ConditionReasonAwaitingValidation ConditionReason = "AwaitingValidation"
+
+const ConditionTypeHealthy ConditionType = "Healthy"
+const ConditionReasonHealthy ConditionReason = "AllChecksPassed"
+const ConditionReasonPartiallyHealthy ConditionReason = "SomeChecksPassed"
+const ConditionReasonUnhealthy ConditionReason = "HealthChecksFailed"

--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -1,4 +1,4 @@
-//go:build integration2
+//go:build integration
 
 /*
 Copyright 2024.

--- a/internal/controller/dnsrecord_healthchecks.go
+++ b/internal/controller/dnsrecord_healthchecks.go
@@ -103,7 +103,7 @@ func (r *DNSRecordReconciler) ensureProbe(ctx context.Context, generated *v1alph
 //
 // If this leads to an empty array of endpoints it:
 //   - Does nothing (prevents NXDomain response) if we already published
-//   - Returns empty array of nothing is published (prevent from publishing unhealthy EPs)
+//   - Returns empty array if nothing is published (prevent from publishing unhealthy EPs)
 //
 // it returns the list of healthy endpoints, an array of unhealthy addresses and an error
 func (r *DNSRecordReconciler) removeUnhealthyEndpoints(ctx context.Context, specEndpoints []*endpoint.Endpoint, dnsRecord *v1alpha1.DNSRecord) ([]*endpoint.Endpoint, []string, error) {

--- a/test/e2e/fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml
+++ b/test/e2e/fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml
@@ -4,11 +4,6 @@ metadata:
   name: ${testID}
   namespace: ${testNamespace}
 spec:
-  healthCheck:
-    endpoint: "/health"
-    port: 80
-    protocol: "HTTPS"
-    failureThreshold: 3
   endpoints:
     - dnsName: 14byhk-2k52h1.klb.${testHostname}
       recordTTL: 60


### PR DESCRIPTION
Reports health checks into the status of DNSRecord. 
It also modifies the  `Ready` status. The logic is: 

- If all checks pass - the record is healthy and ready 
- If we have failing and healthy probes - the record is not healthy but ready 
- If all checks fail - the record is not healthy and not ready 