### PR TITLE
add e2e test for healthchecks 

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -68,10 +68,16 @@ jobs:
       - name: Setup environment
         if: ${{ !inputs.ginkgoDryRun }}
         run: |
-          make local-setup DEPLOY=true TEST_NAMESPACE=${{ env.TEST_NAMESPACE }}
+          make local-setup DEPLOY=true MOCK_HEALTH_CHECKS=true TEST_NAMESPACE=${{ env.TEST_NAMESPACE }}
           kubectl -n ${{ env.TEST_NAMESPACE }} get secret/dns-provider-credentials-aws
           kubectl -n ${{ env.TEST_NAMESPACE }} get secret/dns-provider-credentials-gcp
           kubectl -n ${{ env.TEST_NAMESPACE }} get secret/dns-provider-credentials-azure
+      - name: Run healthcheck suite
+        run: |
+          export TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-inmemory
+          export TEST_DNS_ZONE_DOMAIN_NAME=e2e.hcpapps.net
+          export TEST_DNS_NAMESPACES=${{ env.TEST_NAMESPACE }}
+          make test-e2e-healthchecks
       - name: Run suite AWS
         run: |
           export TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-aws

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2024-10-18T15:21:24Z"
+    createdAt: "2024-10-29T13:53:25Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -90,6 +90,18 @@ spec:
     spec:
       clusterPermissions:
       - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -764,6 +764,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,6 +80,9 @@ func main() {
 	var providers stringSliceFlags
 	var dnsProbesEnabled bool
 	var allowInsecureCerts bool
+	var configmapTransport bool
+
+	flag.BoolVar(&configmapTransport, "e2e-test-only-use-mock-health-transport", false, "This enables a mock transport for health checks based on a configmap in the dns-operator namespace named test-health-checks. It will stop proper health checks happening")
 
 	flag.BoolVar(&dnsProbesEnabled, "enable-probes", true, "Enable DNSHealthProbes controller.")
 	flag.BoolVar(&allowInsecureCerts, "insecure-health-checks", true, "Allow DNSHealthProbes to use insecure certificates")
@@ -161,7 +164,10 @@ func main() {
 	}
 
 	if dnsProbesEnabled {
-		probeManager := probes.NewProbeManager()
+		probeManager := probes.NewProbeManager(configmapTransport)
+		if configmapTransport {
+			setupLog.Info("WARNING configmap based transport enabled for health checks")
+		}
 		if err = (&controller.DNSProbeReconciler{
 			Client:       mgr.GetClient(),
 			Scheme:       mgr.GetScheme(),

--- a/config/deploy/mock-transport/kustomization.yaml
+++ b/config/deploy/mock-transport/kustomization.yaml
@@ -1,0 +1,17 @@
+# Local deployment overlay.
+#
+# Set mock transport layer arg for deployment
+#
+
+resources:
+  - ../local
+
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --e2e-test-only-use-mock-health-transport
+    target:
+      kind: Deployment
+      name: controller-manager
+      namespace: system

--- a/config/local-setup/dns-provider/inmemory/kustomization.yaml
+++ b/config/local-setup/dns-provider/inmemory/kustomization.yaml
@@ -10,4 +10,4 @@ secretGenerator:
   - name: dns-provider-credentials
     type: "kuadrant.io/inmemory"
     literals:
-      - INMEM_INIT_ZONES=kuadrant.local
+      - INMEM_INIT_ZONES=e2e.hcpapps.net

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/internal/controller/dnshealthcheckprobe_reconciler.go
+++ b/internal/controller/dnshealthcheckprobe_reconciler.go
@@ -40,6 +40,7 @@ type DNSProbeReconciler struct {
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnshealthcheckprobes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnshealthcheckprobes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnshealthcheckprobes/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 func (r *DNSProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	baseLogger := log.FromContext(ctx).WithName("dnsprobe_controller")

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -48,6 +48,8 @@ import (
 	"github.com/kuadrant/dns-operator/internal/provider"
 )
 
+type HealthCheckOption bool
+
 const (
 	DNSRecordFinalizer        = "kuadrant.io/dns-record"
 	validationRequeueVariance = 0.5
@@ -58,6 +60,11 @@ const (
 	txtRegistryEncryptEnabled      = false
 	txtRegistryEncryptAESKey       = ""
 	txtRegistryCacheInterval       = time.Duration(0)
+
+	EnableHealthCheckProbes             HealthCheckOption = true
+	DisableHealthCheckProbes            HealthCheckOption = false
+	EnableHealthCheckInsecureEndpoints  HealthCheckOption = true
+	DisableHealthCheckInsecureEndpoints HealthCheckOption = false
 )
 
 var (
@@ -446,6 +453,7 @@ func setStatusConditions(record *v1alpha1.DNSRecord, hadChanges bool, notHealthy
 
 	// probes are disabled or not defined, or this is a wildcard record
 	if record.Spec.HealthCheck == nil || strings.HasPrefix(record.Spec.RootHost, v1alpha1.WildcardPrefix) {
+		meta.RemoveStatusCondition(&record.Status.Conditions, string(v1alpha1.ConditionTypeHealthy))
 		return
 	}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeSuite(func() {
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: providerFactory,
-	}).SetupWithManager(mgr, RequeueDuration, ValidityDuration, DefaultValidationDuration, true, true)
+	}).SetupWithManager(mgr, RequeueDuration, ValidityDuration, DefaultValidationDuration, bool(EnableHealthCheckProbes), bool(EnableHealthCheckInsecureEndpoints))
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/internal/probes/worker.go
+++ b/internal/probes/worker.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -203,11 +205,14 @@ func TransportWithDNSResponse(overrides map[string]string, allowInsecureCertific
 
 type ProbeManager struct {
 	probes map[string]context.CancelFunc
+	//main use for this is to configure a test transport
+	overrideTransport bool
 }
 
-func NewProbeManager() *ProbeManager {
+func NewProbeManager(overrideTransport bool) *ProbeManager {
 	return &ProbeManager{
-		probes: map[string]context.CancelFunc{},
+		probes:            map[string]context.CancelFunc{},
+		overrideTransport: overrideTransport,
 	}
 }
 
@@ -285,9 +290,44 @@ func (m *ProbeManager) EnsureProbeWorker(ctx context.Context, k8sClient client.C
 	// Either worker does not exist, or gen changed and old worker got killed. Creating a new one.
 	logger.V(2).Info("health: starting fresh worker for", "generation", probeCR.Generation, "probe", keyForProbe(probeCR))
 	probe := NewProbe(headers)
+	if m.overrideTransport {
+		rt, err := m.EnableConfigmapTransport(ctx, k8sClient, probeCR.Spec.Address)
+		if err != nil {
+			logger.Error(err, "failed to setup configmap transport")
+			return
+		}
+		probe.Transport = rt
+	}
 	m.probes[keyForProbe(probeCR)] = probe.Start(ctx, k8sClient, probeCR)
 }
 
 func keyForProbe(probe *v1alpha1.DNSHealthCheckProbe) string {
 	return fmt.Sprintf("%s/%s", probe.Name, probe.Namespace)
+}
+
+func (m *ProbeManager) EnableConfigmapTransport(ctx context.Context, k8sClient client.Client, ip string) (RoundTripperFunc, error) {
+	//debug and testing configmap
+	rt := func(r *http.Request) (*http.Response, error) {
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mockhealthcheckresponses",
+				// we cannot guarantee this ns to be present
+				Namespace: "dns-operator-system",
+			},
+		}
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+			return nil, fmt.Errorf("failed to load test only configmap based transport %w", err)
+		}
+		if reponseCode, ok := cm.Data[ip]; ok {
+			code, err := strconv.ParseInt(reponseCode, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse response code from configmap %w", err)
+			}
+			return &http.Response{
+				StatusCode: int(code),
+			}, nil
+		}
+		return nil, fmt.Errorf("no response code in configmap for uri %s", r.URL.Host)
+	}
+	return rt, nil
 }

--- a/test/e2e/fixtures/healthcheck_test/geo-dnsrecord.yaml
+++ b/test/e2e/fixtures/healthcheck_test/geo-dnsrecord.yaml
@@ -4,19 +4,12 @@ metadata:
   name: ${testID}
   namespace: ${testNamespace}
 spec:
-  healthCheck:
-    port: 80
-    path: "/health"
-    protocol: "HTTP"
-    interval: 1s
-    failureThreshold: 5
   endpoints:
     - dnsName: 14byhk-2k52h1.klb.${testHostname}
       recordTTL: 60
       recordType: A
       targets:
         - 172.32.200.1
-        - 172.32.200.2
     - dnsName: ${testHostname}
       recordTTL: 300
       recordType: CNAME

--- a/test/e2e/healthcheck_test.go
+++ b/test/e2e/healthcheck_test.go
@@ -1,12 +1,14 @@
-//go:build e2e
+//go:build e2e_healthchecks
 
 package e2e
 
 import (
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +18,6 @@ import (
 	. "github.com/kuadrant/dns-operator/test/e2e/helpers"
 )
 
-// Test Cases covering multiple creation and deletion of health checks
 var _ = Describe("Health Check Test", Serial, Labels{"health_checks"}, func() {
 	// tests can be run in parallel in the same cluster
 	var testID string
@@ -26,6 +27,7 @@ var _ = Describe("Health Check Test", Serial, Labels{"health_checks"}, func() {
 	var testHostname string
 
 	var k8sClient client.Client
+	var transportLayerConfig *v1.ConfigMap
 	var testDNSProviderSecret *v1.Secret
 
 	var dnsRecord *v1alpha1.DNSRecord
@@ -39,6 +41,17 @@ var _ = Describe("Health Check Test", Serial, Labels{"health_checks"}, func() {
 		SetTestEnv("testID", testID)
 		SetTestEnv("testHostname", testHostname)
 		SetTestEnv("testNamespace", testDNSProviderSecret.Namespace)
+
+		transportLayerConfig = &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mockhealthcheckresponses",
+				Namespace: "dns-operator-system",
+			},
+			Data: map[string]string{
+				"172.32.200.1": "400",
+				"172.32.200.2": "400",
+			},
+		}
 	})
 
 	AfterEach(func(ctx SpecContext) {
@@ -47,9 +60,196 @@ var _ = Describe("Health Check Test", Serial, Labels{"health_checks"}, func() {
 				client.PropagationPolicy(metav1.DeletePropagationForeground))
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 		}
+
+		if transportLayerConfig != nil {
+			err := k8sClient.Delete(ctx, transportLayerConfig,
+				client.PropagationPolicy(metav1.DeletePropagationForeground))
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		}
 	})
 
-	Context("On-cluster healthchecks", func() {
-		// TODO test case
+	// single controller against host
+	Context("Sole publisher", func() {
+		It("Correctly react to healthchecks", func(ctx SpecContext) {
+
+			By("overriding transport layer")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Create(ctx, transportLayerConfig)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+			By("creating dnsrecord ")
+			dnsRecord = &v1alpha1.DNSRecord{}
+			err := ResourceFromFile("./fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml", dnsRecord, GetTestEnv)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Create(ctx, dnsRecord)).To(Succeed())
+			}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+			By("checking " + dnsRecord.Name + " haven't published unhealthy endpoints")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(dnsRecord.Status.Endpoints).To(HaveLen(0))
+				g.Expect(dnsRecord.Status.Conditions).To(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":             Equal(metav1.ConditionFalse),
+						"Reason":             Equal(string(v1alpha1.ConditionReasonUnhealthy)),
+						"Message":            Equal("None of the healthchecks succeeded"),
+						"ObservedGeneration": Equal(dnsRecord.Generation),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeHealthy)),
+						"Status":  Equal(metav1.ConditionFalse),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonUnhealthy)),
+						"Message": And(ContainSubstring("Not healthy addresses:"), ContainSubstring("172.32.200.1"), ContainSubstring("172.32.200.2")),
+					}),
+				))
+			}, TestTimeoutLong, time.Second, ctx).Should(Succeed())
+
+			By("making all addresses healthy")
+			transportLayerConfig.Data["172.32.200.1"] = "200"
+			transportLayerConfig.Data["172.32.200.2"] = "200"
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Update(ctx, transportLayerConfig)).To(Succeed())
+			}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+			By("checking " + dnsRecord.Name + " published healthy endpoints")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(dnsRecord.Status.Endpoints).To(HaveLen(5))
+				g.Expect(dnsRecord.Status.Endpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":    Equal("14byhk-2k52h1.klb." + testHostname),
+						"Targets":    ConsistOf("172.32.200.1", "172.32.200.2"),
+						"RecordType": Equal("A"),
+					})),
+				))
+				g.Expect(dnsRecord.Status.Conditions).To(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonProviderSuccess)),
+						"Message": Equal("Provider ensured the dns record"),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeHealthy)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonHealthy)),
+						"Message": Equal("All healthchecks succeeded"),
+					}),
+				))
+			}, TestTimeoutLong, time.Second, ctx).Should(Succeed())
+
+			By("making 172.32.200.2 unhealthy")
+			transportLayerConfig.Data["172.32.200.2"] = "400"
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Update(ctx, transportLayerConfig)).To(Succeed())
+			}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+			By("ensure unhealthy address removed")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(dnsRecord.Status.Endpoints).To(HaveLen(5))
+				g.Expect(dnsRecord.Status.Endpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":    Equal("14byhk-2k52h1.klb." + testHostname),
+						"Targets":    ConsistOf("172.32.200.1"),
+						"RecordType": Equal("A"),
+					})),
+				))
+				g.Expect(dnsRecord.Status.Conditions).To(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonProviderSuccess)),
+						"Message": Equal("Provider ensured the dns record"),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeHealthy)),
+						"Status":  Equal(metav1.ConditionFalse),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonPartiallyHealthy)),
+						"Message": Equal("Not healthy addresses: [172.32.200.2]"),
+					}),
+				))
+			}, TestTimeoutLong, time.Second, ctx).Should(Succeed())
+
+			By("making all addresses unhealthy")
+			transportLayerConfig.Data["172.32.200.1"] = "400"
+			transportLayerConfig.Data["172.32.200.2"] = "400"
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Update(ctx, transportLayerConfig)).To(Succeed())
+			}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+			By("ensure EPs are not removed and status updated")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(dnsRecord.Status.Endpoints).To(HaveLen(5))
+				g.Expect(dnsRecord.Status.Endpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":    Equal("14byhk-2k52h1.klb." + testHostname),
+						"Targets":    ConsistOf("172.32.200.1"),
+						"RecordType": Equal("A"),
+					})),
+				))
+				g.Expect(dnsRecord.Status.Conditions).To(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":  Equal(metav1.ConditionFalse),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonUnhealthy)),
+						"Message": Equal("None of the healthchecks succeeded"),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeHealthy)),
+						"Status":  Equal(metav1.ConditionFalse),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonUnhealthy)),
+						"Message": And(ContainSubstring("Not healthy addresses:"), ContainSubstring("172.32.200.1"), ContainSubstring("172.32.200.2")),
+					}),
+				))
+			}, TestTimeoutLong, time.Second, ctx).Should(Succeed())
+
+			By("removing healthchecks")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				dnsRecord.Spec.HealthCheck = nil
+
+				g.Expect(k8sClient.Update(ctx, dnsRecord)).To(Succeed())
+			}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+			By("ensure EPs are published")
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(dnsRecord.Status.Endpoints).To(HaveLen(5))
+				g.Expect(dnsRecord.Status.Endpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":    Equal("14byhk-2k52h1.klb." + testHostname),
+						"Targets":    ConsistOf("172.32.200.1", "172.32.200.2"),
+						"RecordType": Equal("A"),
+					})),
+				))
+				g.Expect(dnsRecord.Status.Conditions).To(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal(string(v1alpha1.ConditionReasonProviderSuccess)),
+						"Message": Equal("Provider ensured the dns record"),
+					}),
+				))
+				// make sure healthcheck condition is gone
+				g.Expect(dnsRecord.Status.Conditions).ToNot(ContainElements(
+					MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(string(v1alpha1.ConditionTypeHealthy)),
+					}),
+				))
+			}, TestTimeoutLong, time.Second, ctx).Should(Succeed())
+		})
 	})
 })

--- a/test/e2e/helpers/common.go
+++ b/test/e2e/helpers/common.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	TestTimeoutMedium = 10 * time.Second
-	TestTimeoutLong   = 60 * time.Second
+	TestTimeoutLong   = 2 * time.Minute
 )
 
 func GenerateName() string {

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -655,7 +655,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 				SetTestEnv("testHostname", strings.Join([]string{testID + "-" + strconv.Itoa(i), testDomainName}, "."))
 				SetTestEnv("testID", testID+"-"+strconv.Itoa(i))
 
-				err := ResourceFromFile("./fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml", testRecord, GetTestEnv)
+				err := ResourceFromFile("./fixtures/healthcheck_test/geo-dnsrecord.yaml", testRecord, GetTestEnv)
 				By("creating DNS Record for host " + GetTestEnv("testHostname"))
 				Expect(err).ToNot(HaveOccurred())
 				err = k8sClient.Create(ctx, testRecord)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_healthchecks
 
 package e2e
 


### PR DESCRIPTION
Add a basic e2e test for healtchchecks. I'm splitting it from the rest of the e2e checks and running it with an in-memory provider. This makes it strange to have such a test in the e2e suite - the integration suite (that uses the same provider) mocks controllers and does 99% of the same job. The only difference is that here we actually rely on the probe worker to do a request (to the mock transport layer, but still a real request) compared to manually updating probe CRs in the integration suite 
Also allow for overriding of the transport layer for the HTTP client probe is using. 