### PR TITLE
fix: Multiple same host/target records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,13 +239,13 @@ build: manifests generate fmt vet ## Build manager binary.
 run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
+	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" --race ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
 
 .PHONY: run-with-probes
 run-with-probes: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run-with-probes: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 run-with-probes: manifests generate fmt vet ## Run a controller from your host.
-	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
+	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" --race  ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.


### PR DESCRIPTION
Fixes an issue where if you had multiple records with the same host and target values all contributing to the same record set, removing one of them would cause invalid records (0 target values) to be returned from the plan.

Fixes an issue in the inmemory provider where it was allowing records with 0 target values to be added, and improves checks to avoid a panic.

Add --race option to make run task, enables the race detector on locally running instances https://go.dev/doc/articles/race_detector. This will report useful information in the logs about race related issues.