### PR TITLE
update probe logic not to share memory

### DIFF
--- a/internal/controller/dnshealthcheckprobe_reconciler.go
+++ b/internal/controller/dnshealthcheckprobe_reconciler.go
@@ -76,17 +76,17 @@ func (r *DNSProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 			return ctrl.Result{}, err
 		}
-
 		return ctrl.Result{}, nil
 	}
 
 	if !controllerutil.ContainsFinalizer(dnsProbe, DNSHealthCheckFinalizer) {
-		controllerutil.AddFinalizer(dnsProbe, DNSHealthCheckFinalizer)
-		if err := r.Client.Update(ctx, dnsProbe); err != nil {
-			if apierrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
+		if controllerutil.AddFinalizer(dnsProbe, DNSHealthCheckFinalizer) {
+			if err := r.Client.Update(ctx, dnsProbe); err != nil {
+				if apierrors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
+				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Running with ```--race``` showed we were sharing some memory across routines. I have adjusted the design not to share memory like this now

Signed-off-by: craig <cbrookes@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED