### PR TITLE
Helm docs

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,21 @@
+# DNS Operator
+
+This is the Helm Chart to install the official Kuadrant DNS Kubernetes Operator
+
+## Installation
+
+```sh
+helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
+helm install \
+ dns-operator kuadrant/dns-operator \
+ --create-namespace \
+ --namespace kuadrant-system
+```
+
+### Parameters
+
+**Coming soon!** At the moment, there's no configuration parameters exposed.
+
+## Usage
+
+Read the documentation and user guides in the [Getting Started guide](https://github.com/Kuadrant/dns-operator/?tab=readme-ov-file#getting-started).

--- a/charts/dns-operator/Chart.yaml
+++ b/charts/dns-operator/Chart.yaml
@@ -13,6 +13,7 @@ kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
 version: "0.0.0"
+appVersion: "0.0.0"
 maintainers:
   - email: mnairn@redhat.com
     name: Michael Nairn

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -7,6 +7,7 @@ helm-build: yq manifests kustomize operator-sdk ## Build the helm chart from kus
 	# Build the helm chart templates from kustomize manifests
 	$(KUSTOMIZE) build config/helm > charts/dns-operator/templates/manifests.yaml
 	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i charts/dns-operator/Chart.yaml
+	V="$(VERSION)" $(YQ) eval '.appVersion = strenv(V)' -i charts/dns-operator/Chart.yaml
 
 .PHONY: helm-install
 helm-install: $(HELM) ## Install the helm chart


### PR DESCRIPTION
* Helm documentation displayed under the chart page in AritfactHub.io. Needed for the `Official` badge.
* appVersion added in order to shown in helm cli