### PR TITLE
fix: Azure provider error parsing

### DIFF
--- a/internal/external-dns/provider/azure/azure.go
+++ b/internal/external-dns/provider/azure/azure.go
@@ -466,8 +466,10 @@ func CleanAzureError(err error) error {
 	reg := regexp.MustCompile(`\"message\": \".*\"`)
 	errMsg := err.Error()
 	msg := reg.FindString(errMsg)
-	msgBits := strings.SplitAfterN(msg, ":", 2)
-	msgBits = strings.Split(msgBits[1], `"`)
-	msg = msgBits[1]
+	if msgBits := strings.SplitAfterN(msg, ":", 2); len(msgBits) > 1 {
+		if msgBits = strings.Split(msgBits[1], `"`); len(msgBits) > 1 {
+			msg = msgBits[1]
+		}
+	}
 	return errors.New(msg)
 }

--- a/internal/external-dns/provider/azure/azure_test.go
+++ b/internal/external-dns/provider/azure/azure_test.go
@@ -575,6 +575,14 @@ func TestCleanAzureError(t *testing.T) {
 				Expect(err.Error()).To(Equal("The following locations specified in the geoMapping property for endpoint ‘foo-example-com’ are not supported: NOTAGEOCODE. For a list of supported locations, see the Traffic Manager documentation."))
 			},
 		},
+		{
+			name: "cleans up error that doesn't match expected format",
+			err:  fmt.Errorf("some other error"),
+			Verify: func(err error) {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal(""))
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes an issue in the cleanup of azure error messages that could cause a panic.