### PR TITLE
feat: Add additional print columns to the DNSRecord resource

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -163,6 +163,10 @@ type DNSRecordStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="DNSRecord ready."
 //+kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type==\"Healthy\")].status",description="DNSRecord healthy.",priority=2
+//+kubebuilder:printcolumn:name="Root Host",type="string",JSONPath=".spec.rootHost",description="DNSRecord root host.",priority=2
+//+kubebuilder:printcolumn:name="Owner ID",type="string",JSONPath=".status.ownerID",description="DNSRecord owner id.",priority=2
+//+kubebuilder:printcolumn:name="Zone Domain",type="string",JSONPath=".status.zoneDomainName",description="DNSRecord zone domain name.",priority=2
+//+kubebuilder:printcolumn:name="Zone ID",type="string",JSONPath=".status.zoneID",description="DNSRecord zone id.",priority=2
 
 // DNSRecord is the Schema for the dnsrecords API
 type DNSRecord struct {

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2024-12-11T10:05:36Z"
+    createdAt: "2025-01-21T22:21:25Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -24,6 +24,26 @@ spec:
       name: Healthy
       priority: 2
       type: string
+    - description: DNSRecord root host.
+      jsonPath: .spec.rootHost
+      name: Root Host
+      priority: 2
+      type: string
+    - description: DNSRecord owner id.
+      jsonPath: .status.ownerID
+      name: Owner ID
+      priority: 2
+      type: string
+    - description: DNSRecord zone domain name.
+      jsonPath: .status.zoneDomainName
+      name: Zone Domain
+      priority: 2
+      type: string
+    - description: DNSRecord zone id.
+      jsonPath: .status.zoneID
+      name: Zone ID
+      priority: 2
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -149,6 +149,26 @@ spec:
       name: Healthy
       priority: 2
       type: string
+    - description: DNSRecord root host.
+      jsonPath: .spec.rootHost
+      name: Root Host
+      priority: 2
+      type: string
+    - description: DNSRecord owner id.
+      jsonPath: .status.ownerID
+      name: Owner ID
+      priority: 2
+      type: string
+    - description: DNSRecord zone domain name.
+      jsonPath: .status.zoneDomainName
+      name: Zone Domain
+      priority: 2
+      type: string
+    - description: DNSRecord zone id.
+      jsonPath: .status.zoneID
+      name: Zone ID
+      priority: 2
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -24,6 +24,26 @@ spec:
       name: Healthy
       priority: 2
       type: string
+    - description: DNSRecord root host.
+      jsonPath: .spec.rootHost
+      name: Root Host
+      priority: 2
+      type: string
+    - description: DNSRecord owner id.
+      jsonPath: .status.ownerID
+      name: Owner ID
+      priority: 2
+      type: string
+    - description: DNSRecord zone domain name.
+      jsonPath: .status.zoneDomainName
+      name: Zone Domain
+      priority: 2
+      type: string
+    - description: DNSRecord zone id.
+      jsonPath: .status.zoneID
+      name: Zone ID
+      priority: 2
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Adds additional print columns to the "wide" output option to show some useful pieces of information about a DNSRecord.

```
kubectl get dnsrecord -A -l kube-burner-job=scale-test-loadbalanced -o wide
NAMESPACE      NAME                                READY   HEALTHY   ROOT HOST                                           OWNER ID   ZONE DOMAIN             ZONE ID
scale-test-0   dnsrecord-loadbalanced-aws-1        True              api.scale-test-loadbalanced.mn.hcpapps.net          30atvr20   mn.hcpapps.net          /hostedzone/xyz
scale-test-0   dnsrecord-loadbalanced-azure-1      True              api.scale-test-loadbalanced.mn.azure.hcpapps.net    8t57tjiw   mn.azure.hcpapps.net    /subscriptions/xyz/resourceGroups/kk/providers/Microsoft.Network/dnszones/mn.azure.hcpapps.net
scale-test-0   dnsrecord-loadbalanced-gcp-1        True              api.scale-test-loadbalanced.mn.google.hcpapps.net   nzym3hwv   mn.google.hcpapps.net   x-y-z
scale-test-0   dnsrecord-loadbalanced-inmemory-1   True              api.scale-test-loadbalanced.kuadrant.local          0b5b6mcr   kuadrant.local          kuadrant.local
```
