### PR TITLE
ci: Add "CI Required Checks" job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ on:
       - 'LICENSE'
   merge_group:
     types: [checks_requested]
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -129,7 +130,6 @@ jobs:
       - name: Verify generate command
         run: |
           make verify-generate
-
   verify-go-mod:
     name: Verify go.mod
     runs-on: ubuntu-latest
@@ -145,7 +145,6 @@ jobs:
       - name: Verify generate command
         run: |
           make verify-go-mod
-
   unit_test_suite:
     name: Unit Test Suite
     runs-on: ubuntu-latest
@@ -170,3 +169,11 @@ jobs:
       - name: Run suite
         run: |
           make test-integration
+  required-checks:
+    name: CI Required Checks
+    needs: [ lint, verify-code, verify-manifests, verify-bundle, verify-helm-build, verify-imports, verify-generate, verify-go-mod, unit_test_suite, integration_test_suite]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
Adds a new job to the CI jobs workflow that can be used to check the status of all ci jobs in the workflow.

Intention is this will be used as part of the merge queue configuration allowing a single job to be specified, inspired by https://github.com/orgs/community/discussions/75568#discussioncomment-10351973

Add workflow_dispatch trigger to CI workflow.

![image](https://github.com/user-attachments/assets/814bd8dc-d2d8-488d-b796-b6decd9cbb41)
