### PR TITLE
Signing Helm packages

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -25,11 +25,16 @@ jobs:
         ref: ${{ github.ref }}
         fetch-depth: 0
 
+    - name: Configure GPG Key
+      run: |
+        echo -n "$GPG_SIGNING_KEY" | base64 -d | gpg --import
+      env:
+        GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
+
     - name: Package Helm Chart
       run: |
-        GPG_KEYRING_BASE64=${{ secrets.HELM_CHARTS_SIGNING_KEY }} \
         GPG_KEY_UID="Kuadrant Development Team" \
-        make helm-package
+        make helm-package-sign
 
     - name: Parse Tag
       run: |

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -47,6 +47,16 @@ jobs:
         tag: ${{ env.OPERATOR_TAG }}
         overwrite: true
 
+    - name: Upload provenance file to GitHub Release
+      uses: svenstaro/upload-release-action@v2
+      id: upload-prov-file
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: dns-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+        asset_name: chart-dns-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+        tag: ${{ env.OPERATOR_TAG }}
+        overwrite: true
+
     - name: Sync Helm Chart with repository
       run: |
         make helm-sync-package-created \

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -27,6 +27,8 @@ jobs:
 
     - name: Package Helm Chart
       run: |
+        GPG_KEYRING_BASE64=${{ secrets.HELM_CHARTS_SIGNING_KEY }} \
+        GPG_KEY_UID="Kuadrant Development Team" \
         make helm-package
 
     - name: Parse Tag

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ Dockerfile.cross
 *.swo
 *~
 
+# Helm chart packages
+*operator*.tgz*
+
 # Temporary files and directories
 tmp
 

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -29,18 +29,18 @@ helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
+.PHONY: helm-package
+helm-package: $(HELM) ## Package the helm chart
+	# Package the helm chart
+	$(HELM) package $(CHART_DIRECTORY)
+
 # GPG_KEY_UID: substring of the desired key's uid, the name or email
 GPG_KEY_UID ?= 'Kuadrant Development Team'
-# GPG_KEYRING_BASE64: the gpg keyring base64 encoded
-GPG_KEYRING_BASE64 ?= <KUADRANT_GPG_KEYRING_BASE64>
-
-.PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart and GPG sign it
-	# Store the key
-	mkdir -p .gpg
-	echo $(GPG_KEYRING_BASE64) | base64 -d > .gpg/kuadrantsecring.gpg  #storing base64 GPG key into keyring
-	# Package the helm chart
-	$(HELM) package --sign --key $(GPG_KEY_UID) --keyring .gpg/kuadrantsecring.gpg $(CHART_DIRECTORY)
+# The keyring should've been imported before running this target
+.PHONY: helm-package-sign
+helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
+	# Package the helm chart and sign it
+	$(HELM) package --sign --key $(GPG_KEY_UID) $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -29,10 +29,18 @@ helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
+# GPG_KEY_UID: substring of the desired key's uid, the name or email
+GPG_KEY_UID ?= 'Kuadrant Development Team'
+# GPG_KEYRING_BASE64: the gpg keyring base64 encoded
+GPG_KEYRING_BASE64 ?= <KUADRANT_GPG_KEYRING_BASE64>
+
 .PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart
+helm-package: $(HELM) ## Package the helm chart and GPG sign it
+	# Store the key
+	mkdir -p .gpg
+	echo $(GPG_KEYRING_BASE64) | base64 -d > .gpg/kuadrantsecring.gpg  #storing base64 GPG key into keyring
 	# Package the helm chart
-	$(HELM) package $(CHART_DIRECTORY)
+	$(HELM) package --sign --key $(GPG_KEY_UID) --keyring .gpg/kuadrantsecring.gpg $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,33 +1,38 @@
 ##@ Helm Charts
 
+# Chart name
+CHART_NAME ?= dns-operator
+# Chart directory
+CHART_DIRECTORY ?= charts/$(CHART_NAME)
+
 .PHONY: helm-build
 helm-build: yq manifests kustomize operator-sdk ## Build the helm chart from kustomize manifests
 	# Replace the controller image (Should remain consistent with what `make bundle` does)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Build the helm chart templates from kustomize manifests
-	$(KUSTOMIZE) build config/helm > charts/dns-operator/templates/manifests.yaml
-	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i charts/dns-operator/Chart.yaml
-	V="$(VERSION)" $(YQ) eval '.appVersion = strenv(V)' -i charts/dns-operator/Chart.yaml
+	$(KUSTOMIZE) build config/helm > $(CHART_DIRECTORY)/templates/manifests.yaml
+	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i $(CHART_DIRECTORY)/Chart.yaml
+	V="$(VERSION)" $(YQ) eval '.appVersion = strenv(V)' -i $(CHART_DIRECTORY)/Chart.yaml
 
 .PHONY: helm-install
 helm-install: $(HELM) ## Install the helm chart
 	# Install the helm chart in the cluster
-	$(HELM) install dns-operator charts/dns-operator
+	$(HELM) install $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-uninstall
 helm-uninstall: $(HELM) ## Uninstall the helm chart
 	# Uninstall the helm chart from the cluster
-	$(HELM) uninstall dns-operator
+	$(HELM) uninstall $(CHART_NAME)
 
 .PHONY: helm-upgrade
 helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
-	$(HELM) upgrade dns-operator charts/dns-operator
+	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-package
 helm-package: $(HELM) ## Package the helm chart
 	# Package the helm chart
-	$(HELM) package charts/dns-operator
+	$(HELM) package $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>
@@ -49,7 +54,7 @@ helm-sync-package-created: ## Sync the helm chart package to the helm-charts rep
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
 
 .PHONY: helm-sync-package-deleted
 helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-charts repo
@@ -59,4 +64,4 @@ helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-ch
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)"}}'
+	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)"}}'


### PR DESCRIPTION
Part of the work needed for https://github.com/Kuadrant/helm-charts/issues/18

This PR introduces the GPG signing of Helm chart packages upon creation. It also uploads its provenance file to the GH release page.

The job now requires to be passed an environment variable `GPG_KEYRING_BASE64` which represents the GPG keyring base64 encoded, in order to be stored as a GH action variable.