### PR TITLE
Helm fix gpg signing target and workflow

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Configure GPG Key
       run: |
-        echo -n "$GPG_SIGNING_KEY" | base64 -d | gpg --import
+        echo -n "$GPG_SIGNING_KEY" | base64 -d > ~/.gnupg/pubring.gpg
       env:
         GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
 

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -40,7 +40,7 @@ GPG_KEY_UID ?= 'Kuadrant Development Team'
 .PHONY: helm-package-sign
 helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
 	# Package the helm chart and sign it
-	$(HELM) package --sign --key $(GPG_KEY_UID) $(CHART_DIRECTORY)
+	$(HELM) package --sign --key "$(GPG_KEY_UID)" $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>


### PR DESCRIPTION
This PR fixes the CI job for signing the packages. The GnuPG v2 stores the secret keyring using the format `kbx` and [Helm](https://helm.sh/docs/topics/provenance/) works with the legacy gpg format.

