### PR TITLE
[WIP] [feature] Implement soft_delete and stop_soft_delete flags in the plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,8 +253,10 @@ build: manifests generate fmt vet ## Build manager binary.
 .PHONY: run
 run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
+run: MPORT=:8080
+run: PPORT=:8081
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run -ldflags "-X main.version=v${VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" --race ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure
+	go run -ldflags "-X main.version=v${VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" --race ./cmd/main.go --zap-devel --provider inmemory,aws,google,azure --metrics-bind-address ${MPORT} --health-probe-bind-address ${PPORT}
 
 .PHONY: run-with-probes
 run-with-probes: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")

--- a/internal/controller/dnsrecord_healthchecks.go
+++ b/internal/controller/dnsrecord_healthchecks.go
@@ -144,7 +144,7 @@ func removeUnhealthyEndpoints(specEndpoints []*endpoint.Endpoint, dnsRecord *v1a
 
 		// if unhealthy or we haven't probed yet
 		//delete bad endpoint from all endpoints targets
-		tree.RemoveNode(&common.DNSTreeNode{
+		common.RemoveNode(tree, &common.DNSTreeNode{
 			Name: probe.Spec.Address,
 		})
 		unhealthyAddresses = append(unhealthyAddresses, probe.Spec.Address)


### PR DESCRIPTION
Some useful DNS Records for local testing (will require some tweaking e.g. hostnames): https://gist.github.com/philbrookes/617e03b739f43f01423f9ea94284333d

To test having one or more removed, edit the following:
```
    - dnsName: cluster1-gw1-ns1.klb.loadbalanced.pb.hcpapps.net
      recordTTL: 60
      recordType: A
      targets:
        - 172.18.200.1
```

To look like:
```
    - dnsName: cluster1-gw1-ns1.klb.loadbalanced.pb.hcpapps.net
      recordTTL: 60
      recordType: A
      targets:
        - 172.18.200.1
      labels:
        soft_delete: "true"
```

- mark cluster1 or cluster2 individually for removal, to see it removed.
- mark cluster3 for removal and it will not remove (only record in the GEO)
- mark cluster1 for removal, then afterwards cluster2 and see cluster1 removed but not cluster2 (last record in GEO).

As discussed, this will not cover removing the label on cluster1 and cluster2 simultaneously (i.e. race conditions) that will be covered in future work: https://github.com/Kuadrant/dns-operator/issues/385