### PR TITLE
coredns(install): traffic policy and geoip config

### DIFF
--- a/config/coredns-multi/kuadrant-coredns-1/Corefile
+++ b/config/coredns-multi/kuadrant-coredns-1/Corefile
@@ -9,7 +9,9 @@ k.example.com {
     debug
     errors
     log
-    geoip GeoLite2-City-demo.mmdb
+    geoip GeoLite2-City-demo.mmdb {
+        edns-subnet
+    }
     metadata
     kuadrant
     prometheus 0.0.0.0:9153

--- a/config/coredns-multi/kuadrant-coredns-2/Corefile
+++ b/config/coredns-multi/kuadrant-coredns-2/Corefile
@@ -9,7 +9,9 @@ k.example.com {
     debug
     errors
     log
-    geoip GeoLite2-City-demo.mmdb
+    geoip GeoLite2-City-demo.mmdb {
+        edns-subnet
+    }
     metadata
     kuadrant
     prometheus 0.0.0.0:9153

--- a/config/coredns/kustomization.yaml
+++ b/config/coredns/kustomization.yaml
@@ -93,3 +93,10 @@ patches:
             value: ""
     target:
       kind: Deployment
+  - target:
+      kind: Service
+      name: kuadrant-coredns
+    patch: |
+      - op: add
+        path: /spec/externalTrafficPolicy
+        value: Local


### PR DESCRIPTION
Set the externalTrafficPolicy to Local in the coredns LoadBalancer services to preserve the client source ip.
https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip

Add the `edns-subnet` config to the geoip plugin to use the subnet option if it's available instead of the source ip making things easier to test locally.

```
dig @172.18.0.17 api.k.example.com +subnet=127.0.200.200 +short
```