### PR TITLE
TXT records per hostname + owner

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -966,7 +966,7 @@ func (r *DNSRecordReconciler) applyExternalDNSChanges(ctx context.Context, dnsRe
 
 	plan := externaldnsplan.NewPlan(ctx, zoneEndpoints, statusEndpoints, healthySpecEndpoints, []externaldnsplan.Policy{policy},
 		externaldnsendpoint.MatchAllDomainFilters{&zoneDomainFilter}, managedDNSRecordTypes, excludeDNSRecordTypes,
-		registry.OwnerID(), &rootDomainName,
+		&rootDomainName, registry,
 	)
 
 	plan = plan.Calculate()

--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -319,13 +319,13 @@ var _ = Describe("DNSRecordReconciler", func() {
 	})
 
 	It("should allow ownerID to be set explicitly and not allow it to be updated after", func() {
-		dnsRecord.Spec.OwnerID = "owner1"
+		dnsRecord.Spec.OwnerID = "owner111"
 		Expect(k8sClient.Create(ctx, dnsRecord)).To(Succeed())
 		Eventually(func(g Gomega) {
 			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(dnsRecord.Spec.OwnerID).To(Equal("owner1"))
-			g.Expect(dnsRecord.Status.OwnerID).To(Equal("owner1"))
+			g.Expect(dnsRecord.Spec.OwnerID).To(Equal("owner111"))
+			g.Expect(dnsRecord.Status.OwnerID).To(Equal("owner111"))
 			g.Expect(dnsRecord.Status.Conditions).To(
 				ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -338,14 +338,14 @@ var _ = Describe("DNSRecordReconciler", func() {
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
 			g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName))
-			g.Expect(dnsRecord.Status.DomainOwners).To(ConsistOf("owner1"))
+			g.Expect(dnsRecord.Status.DomainOwners).To(ConsistOf("owner111"))
 		}, TestTimeoutMedium, time.Second).Should(Succeed())
 
 		//Does not allow ownerID to change once set
 		Eventually(func(g Gomega) {
 			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(dnsRecord.Status.OwnerID).To(Equal("owner1"))
+			g.Expect(dnsRecord.Status.OwnerID).To(Equal("owner111"))
 
 			dnsRecord.Spec.OwnerID = "foobarbaz"
 			err = k8sClient.Update(ctx, dnsRecord)
@@ -357,8 +357,8 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(dnsRecord.Status.OwnerID).To(Equal("owner1"))
-			g.Expect(dnsRecord.Status.DomainOwners).To(ConsistOf("owner1"))
+			g.Expect(dnsRecord.Status.OwnerID).To(Equal("owner111"))
+			g.Expect(dnsRecord.Status.DomainOwners).To(ConsistOf("owner111"))
 		}, TestTimeoutMedium, time.Second).Should(Succeed())
 	})
 

--- a/internal/external-dns/plan/plan_test.go
+++ b/internal/external-dns/plan/plan_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 
+	"github.com/kuadrant/dns-operator/internal/external-dns/registry"
 	"github.com/kuadrant/dns-operator/internal/external-dns/testutils"
 )
 
@@ -112,8 +113,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"v1"},
 		RecordType: "CNAME",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/foo-v1",
-			endpoint.OwnerLabelKey:    "pwner",
+			"pwner111": endpoint.ResourceLabelKey + "=ingress/default/foo-v1",
 		},
 	}
 	// same resource as fooV1Cname, but target is different. It will never be picked because its target lexicographically bigger than "v1"
@@ -122,8 +122,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"v3"},
 		RecordType: "CNAME",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/foo-v1",
-			endpoint.OwnerLabelKey:    "pwner",
+			"pwner111": endpoint.ResourceLabelKey + "=ingress/default/foo-v1",
 		},
 	}
 	suite.fooV2Cname = &endpoint.Endpoint{
@@ -131,7 +130,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"v2"},
 		RecordType: "CNAME",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/foo-v2",
+			"": endpoint.ResourceLabelKey + "=ingress/default/foo-v2",
 		},
 	}
 	suite.fooV2CnameUppercase = &endpoint.Endpoint{
@@ -139,7 +138,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"V2"},
 		RecordType: "CNAME",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/foo-v2",
+			"": endpoint.ResourceLabelKey + "=ingress/default/foo-v2",
 		},
 	}
 	suite.fooV2TXT = &endpoint.Endpoint{
@@ -156,7 +155,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"5.5.5.5"},
 		RecordType: "A",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/foo-5",
+			"": endpoint.ResourceLabelKey + "=ingress/default/foo-5",
 		},
 	}
 	suite.fooAAAA = &endpoint.Endpoint{
@@ -164,7 +163,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"2001:DB8::1"},
 		RecordType: "AAAA",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/foo-AAAA",
+			"": endpoint.ResourceLabelKey + "=ingress/default/foo-AAAA",
 		},
 	}
 	suite.dsA = &endpoint.Endpoint{
@@ -172,7 +171,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"1.1.1.1"},
 		RecordType: "A",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/ds",
+			"": endpoint.ResourceLabelKey + "=ingress/default/ds",
 		},
 	}
 	suite.dsAAAA = &endpoint.Endpoint{
@@ -180,7 +179,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"2001:DB8::1"},
 		RecordType: "AAAA",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/ds-AAAAA",
+			"": endpoint.ResourceLabelKey + "=ingress/default/ds-AAAAA",
 		},
 	}
 	suite.bar127A = &endpoint.Endpoint{
@@ -188,7 +187,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"127.0.0.1"},
 		RecordType: "A",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/bar-127",
+			"": endpoint.ResourceLabelKey + "=ingress/default/bar-127",
 		},
 	}
 	suite.bar127AWithTTL = &endpoint.Endpoint{
@@ -197,7 +196,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		RecordTTL:  300,
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/bar-127",
+			"": endpoint.ResourceLabelKey + "=ingress/default/bar-127",
 		},
 	}
 	suite.bar127AWithProviderSpecificTrue = &endpoint.Endpoint{
@@ -205,7 +204,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"127.0.0.1"},
 		RecordType: "A",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/bar-127",
+			"": endpoint.ResourceLabelKey + "=ingress/default/bar-127",
 		},
 		ProviderSpecific: endpoint.ProviderSpecific{
 			endpoint.ProviderSpecificProperty{
@@ -223,7 +222,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"127.0.0.1"},
 		RecordType: "A",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/bar-127",
+			"": endpoint.ResourceLabelKey + "=ingress/default/bar-127",
 		},
 		ProviderSpecific: endpoint.ProviderSpecific{
 			endpoint.ProviderSpecificProperty{
@@ -241,7 +240,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"127.0.0.1"},
 		RecordType: "A",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/bar-127",
+			"": endpoint.ResourceLabelKey + "=ingress/default/bar-127",
 		},
 		ProviderSpecific: endpoint.ProviderSpecific{
 			endpoint.ProviderSpecificProperty{
@@ -255,7 +254,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		Targets:    endpoint.Targets{"192.168.0.1"},
 		RecordType: "A",
 		Labels: map[string]string{
-			endpoint.ResourceLabelKey: "ingress/default/bar-192",
+			"": endpoint.ResourceLabelKey + "=ingress/default/bar-192",
 		},
 	}
 	suite.multiple1 = &endpoint.Endpoint{
@@ -323,7 +322,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"1.1.1.1"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.fooA1Owner2 = &endpoint.Endpoint{
@@ -331,7 +330,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"1.1.1.1"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	suite.fooA1Owner12 = &endpoint.Endpoint{
@@ -339,7 +338,8 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"1.1.1.1"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1&&owner2",
+			"owner111": "",
+			"owner222": "",
 		},
 	}
 	suite.fooA2Owner1 = &endpoint.Endpoint{
@@ -347,7 +347,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"2.2.2.2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.fooA2Owner2 = &endpoint.Endpoint{
@@ -355,7 +355,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"2.2.2.2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	suite.fooA12Owner12 = &endpoint.Endpoint{
@@ -363,7 +363,8 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"1.1.1.1", "2.2.2.2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1&&owner2",
+			"owner111": "",
+			"owner222": "",
 		},
 	}
 	suite.barA3Owner1 = &endpoint.Endpoint{
@@ -371,7 +372,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"3.3.3.3"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.barA3Owner2 = &endpoint.Endpoint{
@@ -379,7 +380,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"3.3.3.3"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	suite.barA4Owner1 = &endpoint.Endpoint{
@@ -387,7 +388,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"4.4.4.4"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.barA4Owner2 = &endpoint.Endpoint{
@@ -395,7 +396,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"4.4.4.4"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	// A Records with SetIdentifier
@@ -404,7 +405,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"1.1.1.1"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 		SetIdentifier: "1",
 	}
@@ -413,7 +414,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"2.2.2.2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 		SetIdentifier: "1",
 	}
@@ -422,7 +423,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"2.2.2.2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 		SetIdentifier: "2",
 	}
@@ -431,7 +432,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "A",
 		Targets:    endpoint.Targets{"2.2.2.2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 		SetIdentifier: "2",
 	}
@@ -462,7 +463,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v1"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.fooCNAMEv2Owner1 = &endpoint.Endpoint{
@@ -470,7 +471,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.fooCNAMEv2Owner2 = &endpoint.Endpoint{
@@ -478,7 +479,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	suite.fooCNAMEv12Owner12 = &endpoint.Endpoint{
@@ -486,7 +487,8 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v1", "v2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1&&owner2",
+			"owner111": "",
+			"owner222": "",
 		},
 	}
 	suite.barCNAMEv3Owner1 = &endpoint.Endpoint{
@@ -494,7 +496,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v3"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.barCNAMEv3Owner2 = &endpoint.Endpoint{
@@ -502,7 +504,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v3"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	suite.barCNAMEv4Owner1 = &endpoint.Endpoint{
@@ -510,7 +512,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v4"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.barCNAMEv4Owner2 = &endpoint.Endpoint{
@@ -518,7 +520,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v4"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	suite.barCNAMEv34Owner2 = &endpoint.Endpoint{
@@ -526,7 +528,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v3", "v4"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 	}
 	suite.barCNAMEv34Owner12 = &endpoint.Endpoint{
@@ -534,7 +536,8 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v3", "v4"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1&&owner2",
+			"owner111": "",
+			"owner222": "",
 		},
 	}
 	// CNAME Records with SetIdentifier
@@ -543,7 +546,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v1"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 		SetIdentifier: "1",
 	}
@@ -552,7 +555,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 		SetIdentifier: "1",
 	}
@@ -561,7 +564,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAMEA",
 		Targets:    endpoint.Targets{"v2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 		SetIdentifier: "2",
 	}
@@ -570,7 +573,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"v2"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner2",
+			"owner222": "",
 		},
 		SetIdentifier: "2",
 	}
@@ -594,7 +597,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"foo.example.com"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.fooecCNAMEbarecOwner1 = &endpoint.Endpoint{
@@ -602,7 +605,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"bar.example.com"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 	suite.barecCNAMEbodoOwner1 = &endpoint.Endpoint{
@@ -610,7 +613,7 @@ func (suite *PlanTestSuite) SetupTest() {
 		RecordType: "CNAME",
 		Targets:    endpoint.Targets{"baz.other.domain.com"},
 		Labels: map[string]string{
-			endpoint.OwnerLabelKey: "owner1",
+			"owner111": "",
 		},
 	}
 }
@@ -630,9 +633,12 @@ func (suite *PlanTestSuite) TestSyncFirstRound() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -656,9 +662,12 @@ func (suite *PlanTestSuite) TestSyncSecondRound() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -683,9 +692,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundMigration() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -709,9 +721,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithTTLChange() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -735,9 +750,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificChange() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -761,9 +779,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificRemoval() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -787,9 +808,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithProviderSpecificAddition() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -811,6 +835,8 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithOwnerInherited() {
 		RecordType: suite.fooV2Cname.RecordType,
 		RecordTTL:  suite.fooV2Cname.RecordTTL,
 		Labels: map[string]string{
+			// TODO once compatable update labels to a new format
+			// ownerID : key=value
 			endpoint.ResourceLabelKey: suite.fooV2Cname.Labels[endpoint.ResourceLabelKey],
 			endpoint.OwnerLabelKey:    suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 		},
@@ -824,9 +850,12 @@ func (suite *PlanTestSuite) TestSyncSecondRoundWithOwnerInherited() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -853,6 +882,9 @@ func (suite *PlanTestSuite) TestIdempotency() {
 		Policies: []Policy{&SyncPolicy{}},
 		Current:  current,
 		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 	}
 
 	cp := p.Calculate()
@@ -966,11 +998,14 @@ func (suite *PlanTestSuite) TestExistingOwnerNotMatchingDualStackDesired() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnerID:        "pwner",
+		OwnerID:        "pwner111",
 	}
 
 	cp := p.Calculate()
@@ -1004,7 +1039,8 @@ func (suite *PlanTestSuite) TestConflictingCurrentNonConflictingDesired() {
 		Current:        current,
 		Desired:        desired,
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
+		// TODO once compatable extract owner from the key
+		OwnerID: suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
 
 	cp := p.Calculate()
@@ -1017,7 +1053,12 @@ func (suite *PlanTestSuite) TestConflictingCurrentNonConflictingDesired() {
 // caching issues. In this case there are no desired enpoint candidates so plan
 // on deleting the records.
 func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
-	suite.fooA5.Labels[endpoint.OwnerLabelKey] = suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]
+	var fooV1CnameOwner string
+	for fooV1CnameOwner = range suite.fooV1Cname.Labels {
+		suite.fooA5.Labels[fooV1CnameOwner] = suite.fooA5.Labels[""]
+	}
+	delete(suite.fooA5.Labels, "")
+	//suite.fooA5.Labels[endpoint.OwnerLabelKey] = suite.fooV1Cname.Labels[endpoint.OwnerLabelKey]
 	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooA5}
 	desired := []*endpoint.Endpoint{}
 	expectedCreate := []*endpoint.Endpoint{}
@@ -1032,11 +1073,14 @@ func (suite *PlanTestSuite) TestConflictingCurrentNoDesired() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
-		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
+		OwnerID:        fooV1CnameOwner,
 	}
 
 	cp := p.Calculate()
@@ -1064,9 +1108,10 @@ func (suite *PlanTestSuite) TestCurrentWithConflictingDesired() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		// TODO once compatible extrat owner from the key
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 		OwnerID:        suite.fooV1Cname.Labels[endpoint.OwnerLabelKey],
 	}
@@ -1094,9 +1139,12 @@ func (suite *PlanTestSuite) TestNoCurrentWithConflictingDesired() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1120,9 +1168,12 @@ func (suite *PlanTestSuite) TestIgnoreTXT() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1146,9 +1197,12 @@ func (suite *PlanTestSuite) TestExcludeTXT() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME, endpoint.RecordTypeTXT},
 		ExcludeRecords: []string{endpoint.RecordTypeTXT},
 	}
@@ -1176,6 +1230,9 @@ func (suite *PlanTestSuite) TestIgnoreTargetCase() {
 		Policies: []Policy{&SyncPolicy{}},
 		Current:  current,
 		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 	}
 
 	cp := p.Calculate()
@@ -1198,9 +1255,12 @@ func (suite *PlanTestSuite) TestRemoveEndpoint() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1225,9 +1285,12 @@ func (suite *PlanTestSuite) TestRemoveEndpointWithUpsert() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&UpsertOnlyPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&UpsertOnlyPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1252,9 +1315,12 @@ func (suite *PlanTestSuite) TestMultipleRecordsSameNameDifferentSetIdentifier() 
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1278,9 +1344,12 @@ func (suite *PlanTestSuite) TestSetIdentifierUpdateCreatesAndDeletes() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1305,9 +1374,12 @@ func (suite *PlanTestSuite) TestDomainFiltersInitial() {
 
 	domainFilter := endpoint.NewDomainFilterWithExclusions([]string{"domain.tld"}, []string{"ex.domain.tld"})
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
@@ -1333,9 +1405,12 @@ func (suite *PlanTestSuite) TestDomainFiltersUpdate() {
 
 	domainFilter := endpoint.NewDomainFilterWithExclusions([]string{"domain.tld"}, []string{"ex.domain.tld"})
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		DomainFilter:   endpoint.MatchAllDomainFilters{&domainFilter},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeCNAME},
 	}
@@ -1358,9 +1433,12 @@ func (suite *PlanTestSuite) TestAAAARecords() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1382,9 +1460,12 @@ func (suite *PlanTestSuite) TestDualStackRecords() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1406,9 +1487,12 @@ func (suite *PlanTestSuite) TestDualStackRecordsDelete() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1431,9 +1515,12 @@ func (suite *PlanTestSuite) TestDualStackToSingleStack() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1458,10 +1545,13 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordCreate() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner1",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner111",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1482,10 +1572,13 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordWithSetIdentifierCreate() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1507,11 +1600,14 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateCreate() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Previous:       previous,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Previous: previous,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1535,11 +1631,14 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateSameOwner() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Previous:       previous,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Previous: previous,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1561,11 +1660,14 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateRecordTypeConflict() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Previous:       previous,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Previous: previous,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1587,10 +1689,13 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordUpdateSameOwnerWithSetIdentifie
 	}
 
 	p := &Plan{
-		OwnerID:        "owner1",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner111",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1611,9 +1716,12 @@ func (suite *PlanTestSuite) TestNoPlanOwnerARecordUpdate() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1635,10 +1743,13 @@ func (suite *PlanTestSuite) TestPlanOwnerARecordUpdateNoOwner() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1660,9 +1771,12 @@ func (suite *PlanTestSuite) TestNoOwnerARecordUpdate() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1684,11 +1798,14 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordDelete() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
-		Previous:       previous,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		Previous: previous,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1710,11 +1827,14 @@ func (suite *PlanTestSuite) TestMultiOwnerARecordDeleteSameAddress() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
-		Previous:       previous,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		Previous: previous,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1737,10 +1857,13 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordCreate() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner1",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner111",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1761,10 +1884,13 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordWithSetIdentifierCreate() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1785,9 +1911,12 @@ func (suite *PlanTestSuite) TestRootHost() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 	cp := p.Calculate()
@@ -1804,10 +1933,13 @@ func (suite *PlanTestSuite) TestRootHost() {
 	}
 
 	p = &Plan{
-		RootHost:       ptr.To("example.com"),
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		RootHost: ptr.To("example.com"),
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 	cp = p.Calculate()
@@ -1824,11 +1956,14 @@ func (suite *PlanTestSuite) TestRootHost() {
 	}
 
 	p = &Plan{
-		RootHost:       ptr.To("bar.example.com"),
-		DomainFilter:   endpoint.MatchAllDomainFilters{ptr.To(endpoint.NewDomainFilter([]string{"example.com"}))},
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		RootHost:     ptr.To("bar.example.com"),
+		DomainFilter: endpoint.MatchAllDomainFilters{ptr.To(endpoint.NewDomainFilter([]string{"example.com"}))},
+		Policies:     []Policy{&SyncPolicy{}},
+		Current:      current,
+		Desired:      desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 	cp = p.Calculate()
@@ -1854,11 +1989,14 @@ func (suite *PlanTestSuite) TestRootHostCNAMERecordCreateWithMissingManagedTarge
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		RootHost:       ptr.To("example.com"),
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		RootHost: ptr.To("example.com"),
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1882,11 +2020,14 @@ func (suite *PlanTestSuite) TestRootHostCNAMERecordCreateManagedTarget() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		RootHost:       ptr.To("example.com"),
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		RootHost: ptr.To("example.com"),
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1907,10 +2048,13 @@ func (suite *PlanTestSuite) TestNoRootHostCNAMERecordCreateMissingManagedTarget(
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1934,11 +2078,14 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateDifferentOwner() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Previous:       previous,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Previous: previous,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1961,11 +2108,14 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateSameOwner() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Previous:       previous,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Previous: previous,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -1987,11 +2137,14 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateRecordTypeConflict() 
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Previous:       previous,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Previous: previous,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -2014,11 +2167,14 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordUpdateSameOwnerWithSetIdent
 	}
 
 	p := &Plan{
-		OwnerID:        "owner1",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Previous:       previous,
-		Desired:        desired,
+		OwnerID:  "owner111",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Previous: previous,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -2039,9 +2195,12 @@ func (suite *PlanTestSuite) TestNoPlanOwnerCNAMERecordUpdate() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -2063,10 +2222,13 @@ func (suite *PlanTestSuite) TestPlanOwnerCNAMERecordUpdateNoOwner() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -2088,9 +2250,12 @@ func (suite *PlanTestSuite) TestNoPlanOwnerCNAMERecordUpdateNoOwner() {
 	}
 
 	p := &Plan{
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 
@@ -2113,11 +2278,14 @@ func (suite *PlanTestSuite) TestMultiOwnerCNAMERecordDelete() {
 	}
 
 	p := &Plan{
-		OwnerID:        "owner2",
-		Policies:       []Policy{&SyncPolicy{}},
-		Current:        current,
-		Desired:        desired,
-		Previous:       previous,
+		OwnerID:  "owner222",
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+		Previous: previous,
+		registry: &registry.TXTRegistry{
+			LabelsPacker: registry.NewTXTLabelsPacker(),
+		},
 		ManagedRecords: []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME},
 	}
 

--- a/internal/external-dns/registry/README.md
+++ b/internal/external-dns/registry/README.md
@@ -1,0 +1,30 @@
+# Registry 
+This is a high-level overview of the registry. 
+The purpose of the registry is: 
+- To read records from the provider and interpret them into the array of endpoints. 
+- To translate an array of endpoints into that format that could be stored in the provider 
+
+We use the `externaldns` implementation of endpoints. Metadata is stored in a labels map (`map[string]string`). Metadata is owner-specific, and we do not merge values from multiple owners. 
+
+The structure of labels: 
+- "ownerID-1" : "key1=value1,key2=value2"
+- "ownerID-2" : "key1=value1,key2=value2"
+
+Each registry contains "labels packer" that provides conversion of labels to and from the following structure: 
+
+- "ownerID-1" :
+  - "key1" : "value1"
+  - "key2" : "value2"
+- "ownerID-2"
+  - "key1" : "value1"
+  - "key2" : "value2"
+
+Each type of registry implements the `Registry` interface that provides access to the labels packer, ownerID and, the registry-specific filter of the endpoints. 
+
+## TXT Registry
+The TXT registry uses TXT records to store metadata. We create a TXT record per hostname+owner combination. 
+The record name is `kuadrant-ownerID-recordType-hostname` and target is `heritage=external-dns,external-dns/key1=value1`. 
+Record will be created with one target per key/value pair. 
+Controller will be able to read records that will have multiple key/value pairs in one target. Also, if there are no extra labels to be stored the target will be `""` (not and empty string!)
+
+TXT records are stored alongside endpoints in the provider. Note that the deletion of the DNSRecord/endpoint not always results in the deletion of the corresponding endpoint in the provider but will always result in the deletion of the corresponding TXT record. The same is true about creation. This is because multiple owners can define the same endpoint, but they will always define unique TXT records. 

--- a/internal/external-dns/registry/labelsPacker.go
+++ b/internal/external-dns/registry/labelsPacker.go
@@ -1,0 +1,158 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+type TXTLabelsPacker struct{}
+
+var _ LabelsPacker = TXTLabelsPacker{}
+
+const (
+	keyAndValueSeparator = "="
+	labelsSeparator      = ","
+)
+
+func NewTXTLabelsPacker() *TXTLabelsPacker {
+	return &TXTLabelsPacker{}
+}
+
+// UnpackLabels
+// gets
+// owner1: key1:value1,key2:value2
+//
+// returns
+// owner1:
+//
+//	key1: value1
+//	key2: value2
+func (p TXTLabelsPacker) UnpackLabels(labels endpoint.Labels) map[string]endpoint.Labels {
+	ownersMap := make(map[string]endpoint.Labels)
+
+	if packed, _ := p.LabelsPacked(labels); !packed {
+		return nil
+	}
+
+	for ownerID, labelsPerOwner := range labels {
+		ownersMap[ownerID] = map[string]string{}
+		labelsPerOwnerArray := strings.Split(labelsPerOwner, labelsSeparator)
+		for _, labelPerOwner := range labelsPerOwnerArray {
+			mapEntry := strings.Split(labelPerOwner, keyAndValueSeparator)
+			if len(mapEntry) == 2 {
+				ownersMap[ownerID][mapEntry[0]] = mapEntry[1]
+			}
+		}
+	}
+
+	return ownersMap
+}
+
+// PackLabels
+// gets
+// owner1:
+//
+//	key1: value1
+//	key2: value2
+//
+// returns
+// owner1: key1:value1,key2:value2
+func (p TXTLabelsPacker) PackLabels(labelsPerOwner map[string]endpoint.Labels) endpoint.Labels {
+	endpointMap := endpoint.Labels{}
+
+	for owner, labels := range labelsPerOwner {
+		labelsArray := make([]string, 0)
+		for key, value := range labels {
+			labelsArray = append(labelsArray, fmt.Sprintf("%s%s%s", key, keyAndValueSeparator, value))
+		}
+		endpointMap[owner] = strings.Join(labelsArray, labelsSeparator)
+	}
+
+	return endpointMap
+}
+
+// LabelsPacked investigates labels and returns
+// true if labels of format:
+// key1=value1
+// key2=value2
+//
+// false if of format
+// owner1: key1=value1, key2=value2
+// owner2: key1=value1, key2=value2
+// returns error otherwise
+func (p TXTLabelsPacker) LabelsPacked(labels endpoint.Labels) (bool, error) {
+	// checked - is true after first loop
+	// packed - key/value consistently of a packed format
+	var keyPacked, keyChecked, valuePacked, valueChecked bool
+
+	// no labels to work on
+	if len(labels) == 0 {
+		return false, errors.New("no labels found")
+	}
+	for key, value := range labels {
+		// the key should be owner ID or empty string
+		// it could also happen that random key has length of ownerID
+
+		if !keyChecked {
+			keyPacked = keyOfPackedFormat(key)
+			keyChecked = true
+		}
+
+		// all new keys must agree with the first key
+		if keyPacked != keyOfPackedFormat(key) {
+			// mismatch of keys!
+			return false, errors.New("unknown format")
+		}
+
+		if !valueChecked {
+			valuePacked = valueOfPackedFormat(value)
+			valueChecked = true
+		}
+
+		if valuePacked != valueOfPackedFormat(value) {
+			return false, errors.New("unknown format")
+		}
+
+		// key and value should be consistent
+		if keyPacked != valuePacked {
+			// exception
+			// it could happen that unpacked key is of the owner ID length
+			// in this case we will assume we are dealing with packed key
+			// this is a problem since we can also happens to have broken label
+			// explicitly checking value for key/value separator does not guarantee it will work
+			if len(key) == ownerIDLen && !strings.Contains(value, keyAndValueSeparator) {
+				continue
+			}
+
+			return false, errors.New("unknown format")
+		}
+	}
+	// everything matches return value in case of key length exception
+	return valuePacked, nil
+}
+
+func keyOfPackedFormat(key string) bool {
+	return len(key) == ownerIDLen || key == ""
+}
+
+func valueOfPackedFormat(value string) bool {
+	pairs := strings.Split(value, labelsSeparator)
+	for _, pair := range pairs {
+		// pair should contain =
+		if !strings.Contains(pair, keyAndValueSeparator) {
+			// if it is empty we are packed but have no labels
+			if pair == "" {
+				continue
+			}
+			return false
+		}
+		pairSplit := strings.Split(pair, keyAndValueSeparator)
+		if len(pairSplit) != 2 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/external-dns/registry/labelsPacker_test.go
+++ b/internal/external-dns/registry/labelsPacker_test.go
@@ -1,0 +1,212 @@
+package registry
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+func TestTXTLabelsPacker_LabelsPacked(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  endpoint.Labels
+		want    bool
+		wantErr error
+	}{
+		{
+			name: "unpacked labels",
+			labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			want: false,
+		},
+		{
+			name: "unpacked labels with key of owner length",
+			labels: map[string]string{
+				"12345678": "value1",
+			},
+			want: false,
+		},
+		{
+			name: "packed labels",
+			labels: map[string]string{
+				"owner111": "key1=value1",
+			},
+			want: true,
+		},
+		{
+			name: "packed empty owner",
+			labels: map[string]string{
+				"owner111": "",
+			},
+			want: true,
+		},
+		{
+			name: "unknown owner",
+			labels: map[string]string{
+				"": "key1=value1",
+			},
+			want: true,
+		},
+		{
+			name: "multiple owners",
+			labels: map[string]string{
+				"owner111": "key1=value1",
+				"owner222": "key1=value1",
+				"":         "key1=value1",
+			},
+			want: true,
+		},
+		{
+			name: "multiple values",
+			labels: map[string]string{
+				"owner111": "key1=value1,key2=value2",
+			},
+			want: true,
+		},
+		{
+			name: "mixed formats",
+			labels: map[string]string{
+				"key1":     "value1",
+				"owner111": "key1=value1",
+			},
+			want:    false,
+			wantErr: errors.New("unknown format"),
+		},
+		{
+			name: "mixed values",
+			labels: map[string]string{
+				"owner111": "key1=value1",
+				"owner222": "value1",
+			},
+			want:    false,
+			wantErr: errors.New("unknown format"),
+		},
+		{
+			name: "invalid packed format",
+			labels: map[string]string{
+				"owner111": "key1=value1,key2==",
+			},
+			want:    false,
+			wantErr: errors.New("unknown format"),
+		},
+		{
+			name:    "empty labels",
+			labels:  map[string]string{},
+			want:    false,
+			wantErr: errors.New("no labels found"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := TXTLabelsPacker{}
+			got, err := p.LabelsPacked(tt.labels)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equalf(t, tt.want, got, "LabelsUnPacked(%v)", tt.labels)
+		})
+	}
+}
+
+func TestTXTLabelsPacker_PackLabels(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		labelsPerOwner map[string]endpoint.Labels
+		want           endpoint.Labels
+	}{
+		{
+			name: "pack labels",
+			labelsPerOwner: map[string]endpoint.Labels{
+				"owner111": {
+					"key1": "value1",
+					"key2": "value2",
+				},
+				"owner222": {
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			want: endpoint.Labels{
+				"owner111": "key1=value1,key2=value2",
+				"owner222": "key1=value1,key2=value2",
+			},
+		},
+		{
+			name: "pack empty labels",
+			labelsPerOwner: map[string]endpoint.Labels{
+				"owner111": {},
+			},
+			want: endpoint.Labels{
+				"owner111": "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := TXTLabelsPacker{}
+			got := p.PackLabels(tt.labelsPerOwner)
+			for wantKey, wantValue := range tt.want {
+				_, ok := got[wantKey]
+				assert.True(t, ok, "key %s not found in labels map", wantKey)
+				wantValueSplit := strings.Split(wantValue, labelsSeparator)
+				for _, singleWantValueSplit := range wantValueSplit {
+					assert.Contains(t, got[wantKey], singleWantValueSplit)
+				}
+			}
+		})
+	}
+}
+
+func TestTXTLabelsPacker_UnpackLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels endpoint.Labels
+		want   map[string]endpoint.Labels
+	}{
+		{
+			name: "unpack labels",
+			labels: endpoint.Labels{
+				"owner111": "key1=value1,key2=value2",
+				"owner222": "key1=value1,key2=value2",
+			},
+			want: map[string]endpoint.Labels{
+				"owner111": {
+					"key1": "value1",
+					"key2": "value2",
+				},
+				"owner222": {
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+		},
+		{
+			name: "unpack empty labels",
+			labels: endpoint.Labels{
+				"owner111": "",
+			},
+			want: map[string]endpoint.Labels{
+				"owner111": {},
+			},
+		},
+		{
+			name: "unpack unpacked labels",
+			labels: endpoint.Labels{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := TXTLabelsPacker{}
+			assert.Equalf(t, tt.want, p.UnpackLabels(tt.labels), "UnpackLabels(%v)", tt.labels)
+		})
+	}
+}

--- a/internal/external-dns/registry/nameMapper.go
+++ b/internal/external-dns/registry/nameMapper.go
@@ -1,0 +1,186 @@
+package registry
+
+import (
+	"strings"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+/**
+  nameMapper is the interface for mapping between the endpoint for the source
+  and the endpoint for the TXT record.
+*/
+
+type affixNameMapper struct {
+	prefix              string
+	suffix              string
+	wildcardReplacement string
+}
+
+var _ nameMapper = affixNameMapper{}
+
+func newaffixNameMapper(prefix, suffix, wildcardReplacement string) affixNameMapper {
+	return affixNameMapper{prefix: strings.ToLower(prefix), suffix: strings.ToLower(suffix), wildcardReplacement: strings.ToLower(wildcardReplacement)}
+}
+
+// extractRecordTypeDefaultPosition extracts record type from the default position
+// when not using '%{record_type}' in the prefix/suffix
+func extractRecordTypeDefaultPosition(name string) (string, string) {
+	nameS := strings.Split(name, "-")
+	for _, t := range getSupportedTypes() {
+		if nameS[0] == strings.ToLower(t) {
+			return strings.TrimPrefix(name, nameS[0]+"-"), t
+		}
+	}
+	return name, ""
+}
+
+func (pr affixNameMapper) extractOwnerIDAndRecordType(name string) (baseName, recordType, ownerID string) {
+	nameS := strings.Split(name, affixSeparator)
+	if pr.isPrefix() {
+
+		// could be
+		// owner-type-hostname
+		// type-hostname
+		// hostname
+		// ensure there is an owner
+		if len(nameS[0]) == ownerIDLen && len(nameS) > 2 {
+			ownerID = nameS[0]
+			name = strings.Join(nameS[1:], affixSeparator)
+		}
+	}
+
+	if pr.isSuffix() {
+
+		// could be
+		// type-hostname-id
+		// type-hostname
+		// hostname
+		if len(nameS[len(nameS)-1]) == ownerIDLen && len(nameS) > 2 {
+			ownerID = nameS[len(nameS)-1]
+			name = strings.Join(nameS[:len(nameS)-1], affixSeparator)
+		}
+	}
+
+	baseName, recordType = extractRecordTypeDefaultPosition(name)
+
+	return baseName, recordType, ownerID
+}
+
+// dropAffixExtractType strips TXT record to find an endpoint name it manages
+// it also returns the record type
+func (pr affixNameMapper) dropAffixExtractType(name string) (baseName, recordType, ownerID string) {
+	// potential values are:
+	// prefixowner-recordtype-dnsname
+	// prefixrecordtype-dnsname
+	// prefixdnsname
+	// recordtype-dnsname-ownersuffix
+	// dnsname-ownersuffix
+	// dnsnamesuffix
+
+	if pr.isPrefix() && strings.HasPrefix(name, pr.prefix) {
+		return pr.extractOwnerIDAndRecordType(strings.TrimPrefix(name, pr.prefix))
+	}
+
+	if pr.isSuffix() && strings.HasSuffix(name, pr.suffix) {
+		return pr.extractOwnerIDAndRecordType(strings.TrimSuffix(name, pr.suffix))
+	}
+
+	return "", "", ""
+}
+
+func (pr affixNameMapper) isPrefix() bool {
+	return len(pr.suffix) == 0
+}
+
+func (pr affixNameMapper) isSuffix() bool {
+	return len(pr.prefix) == 0 && len(pr.suffix) > 0
+}
+
+func (pr affixNameMapper) toEndpointName(txtDNSName string) (endpointName, recordType, ownerID string) {
+	lowerDNSName := strings.ToLower(txtDNSName)
+
+	// drop prefix
+	if pr.isPrefix() {
+		return pr.dropAffixExtractType(lowerDNSName)
+	}
+
+	// drop suffix
+	if pr.isSuffix() {
+		dc := strings.Count(pr.suffix, ".")
+		DNSName := strings.SplitN(lowerDNSName, ".", 2+dc)
+		domainWithSuffix := strings.Join(DNSName[:1+dc], ".")
+
+		r, rType, owner := pr.dropAffixExtractType(domainWithSuffix)
+		return r + "." + DNSName[1+dc], rType, owner
+	}
+	return "", "", ""
+}
+
+func (pr affixNameMapper) recordTypeInAffix() bool {
+	if strings.Contains(pr.prefix, recordTemplate) {
+		return true
+	}
+	if strings.Contains(pr.suffix, recordTemplate) {
+		return true
+	}
+	return false
+}
+
+func (pr affixNameMapper) normalizeAffixTemplate(afix, recordType string) string {
+	if strings.Contains(afix, recordTemplate) {
+		return strings.ReplaceAll(afix, recordTemplate, recordType)
+	}
+	return afix
+}
+
+func (pr affixNameMapper) toTXTName(endpointDNSName, id, recordType string) string {
+	DNSName := strings.SplitN(endpointDNSName, ".", 2)
+	recordType = strings.ToLower(recordType)
+	id = strings.ToLower(id)
+	recordT := recordType + affixSeparator
+
+	prefix := pr.normalizeAffixTemplate(pr.prefix, recordType)
+	suffix := pr.normalizeAffixTemplate(pr.suffix, recordType)
+
+	if pr.isPrefix() {
+		prefix = prefix + id + affixSeparator
+	} else {
+		suffix = affixSeparator + id + suffix
+	}
+
+	// If specified, replace a leading asterisk in the generated txt record name with some other string
+	if pr.wildcardReplacement != "" && DNSName[0] == "*" {
+		DNSName[0] = pr.wildcardReplacement
+	}
+
+	if !pr.recordTypeInAffix() {
+		DNSName[0] = recordT + DNSName[0]
+	}
+
+	if len(DNSName) < 2 {
+		return prefix + DNSName[0] + suffix
+	}
+
+	return prefix + DNSName[0] + suffix + "." + DNSName[1]
+}
+
+func (im *TXTRegistry) addToCache(ep *endpoint.Endpoint) {
+	if im.recordsCache != nil {
+		im.recordsCache = append(im.recordsCache, ep)
+	}
+}
+
+func (im *TXTRegistry) removeFromCache(ep *endpoint.Endpoint) {
+	if im.recordsCache == nil || ep == nil {
+		return
+	}
+
+	for i, e := range im.recordsCache {
+		if e.DNSName == ep.DNSName && e.RecordType == ep.RecordType && e.SetIdentifier == ep.SetIdentifier && e.Targets.Same(ep.Targets) {
+			// We found a match delete the endpoint from the cache.
+			im.recordsCache = append(im.recordsCache[:i], im.recordsCache[i+1:]...)
+			return
+		}
+	}
+}

--- a/internal/external-dns/registry/nameMapper_test.go
+++ b/internal/external-dns/registry/nameMapper_test.go
@@ -1,0 +1,352 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDropPrefix(t *testing.T) {
+	mapper := newaffixNameMapper("foo-", "", "")
+
+	tests := []struct {
+		txtName          string
+		expectedHostname string
+		expectedID       string
+		expectedType     string
+	}{
+		{
+			"foo-11111111-cname-test.example.com",
+			"test.example.com",
+			"11111111",
+			"CNAME",
+		},
+		{
+			"foo-a-test.example.com",
+			"test.example.com",
+			"",
+			"A",
+		},
+		// this is not a format we support - id plus prefix
+		{
+			"foo-11111111-test.example.com",
+			"11111111-test.example.com",
+			"",
+			"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.txtName, func(t *testing.T) {
+			actualOutput, gotType, gotID := mapper.dropAffixExtractType(tc.txtName)
+			assert.Equal(t, tc.expectedHostname, actualOutput)
+			assert.Equal(t, tc.expectedID, gotID)
+			assert.Equal(t, tc.expectedType, gotType)
+		})
+	}
+}
+
+func TestDropSuffix(t *testing.T) {
+	mapper := newaffixNameMapper("", "-foo", "")
+
+	tests := []struct {
+		txtName      string
+		expectedHost string
+		expectedID   string
+		expectedType string
+	}{
+		{
+			"a-test-foo.example.com",
+			"test.example.com",
+			"",
+			"A",
+		},
+		{
+			"test--foo.example.com",
+			"test-.example.com",
+			"",
+			"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.txtName, func(t *testing.T) {
+			r := strings.SplitN(tc.txtName, ".", 2)
+			rClean, recordType, gotID := mapper.dropAffixExtractType(r[0])
+			actualOutput := rClean + "." + r[1]
+			assert.Equal(t, tc.expectedHost, actualOutput)
+			assert.Equal(t, tc.expectedID, gotID)
+			assert.Equal(t, tc.expectedType, recordType)
+		})
+	}
+}
+
+func TestExtractRecordTypeDefaultPosition(t *testing.T) {
+	tests := []struct {
+		input        string
+		expectedName string
+		expectedType string
+	}{
+		{
+			input:        "ns-zone.example.com",
+			expectedName: "zone.example.com",
+			expectedType: "NS",
+		},
+		{
+			input:        "aaaa-zone.example.com",
+			expectedName: "zone.example.com",
+			expectedType: "AAAA",
+		},
+		{
+			input:        "ptr-zone.example.com",
+			expectedName: "ptr-zone.example.com",
+			expectedType: "",
+		},
+		{
+			input:        "zone.example.com",
+			expectedName: "zone.example.com",
+			expectedType: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			actualName, actualType := extractRecordTypeDefaultPosition(tc.input)
+			assert.Equal(t, tc.expectedName, actualName)
+			assert.Equal(t, tc.expectedType, actualType)
+		})
+	}
+}
+
+func TestToTXTName(t *testing.T) {
+	tests := []struct {
+		name       string
+		mapper     affixNameMapper
+		domain     string
+		txtDomain  string
+		recordType string
+		id         string
+	}{
+		{
+			name:       "prefix",
+			mapper:     newaffixNameMapper("foo", "", ""),
+			domain:     "example.com",
+			recordType: "A",
+			txtDomain:  "foo11111111-a-example.com",
+			id:         "11111111",
+		},
+		{
+			name:       "suffix",
+			mapper:     newaffixNameMapper("", "foo", ""),
+			domain:     "example.com",
+			recordType: "AAAA",
+			txtDomain:  "aaaa-example-11111111foo.com",
+			id:         "11111111",
+		},
+		{
+			name:       "prefix with dash",
+			mapper:     newaffixNameMapper("foo-", "", ""),
+			domain:     "example.com",
+			recordType: "A",
+			txtDomain:  "foo-11111111-a-example.com",
+			id:         "11111111",
+		},
+		{
+			name:       "suffix with dash",
+			mapper:     newaffixNameMapper("", "-foo", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+			txtDomain:  "cname-example-11111111-foo.com",
+			id:         "11111111",
+		},
+		{
+			name:       "prefix with dot",
+			mapper:     newaffixNameMapper("foo.", "", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+			txtDomain:  "foo.11111111-cname-example.com",
+			id:         "11111111",
+		},
+		{
+			name:       "suffix with dot",
+			mapper:     newaffixNameMapper("", ".foo", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+			txtDomain:  "cname-example-11111111.foo.com",
+			id:         "11111111",
+		},
+		{
+			name:       "prefix with multiple dots",
+			mapper:     newaffixNameMapper("foo.bar.", "", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+			txtDomain:  "foo.bar.11111111-cname-example.com",
+			id:         "11111111",
+		},
+		{
+			name:       "suffix with multiple dots",
+			mapper:     newaffixNameMapper("", ".foo.bar.test", ""),
+			domain:     "example.com",
+			recordType: "CNAME",
+			txtDomain:  "cname-example-11111111.foo.bar.test.com",
+			id:         "11111111",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.txtDomain, tc.mapper.toTXTName(tc.domain, tc.id, tc.recordType))
+		})
+	}
+}
+
+func TestToEndpointsName(t *testing.T) {
+	tests := []struct {
+		name               string
+		mapper             affixNameMapper
+		txtName            string
+		expectedDomain     string
+		expectedRecordType string
+		expectedID         string
+	}{
+		// V3 records - id, type and affix
+		{
+			name:               "prefix",
+			mapper:             newaffixNameMapper("foo", "", ""),
+			txtName:            "foo11111111-a-example.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "A",
+			expectedID:         "11111111",
+		},
+		{
+			name:               "suffix",
+			mapper:             newaffixNameMapper("", "foo", ""),
+			txtName:            "cname-example-11111111foo.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+			expectedID:         "11111111",
+		},
+		{
+			name:               "prefix with dash",
+			mapper:             newaffixNameMapper("foo-", "", ""),
+			txtName:            "foo-11111111-cname-example.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+			expectedID:         "11111111",
+		},
+		{
+			name:               "suffix with dash",
+			mapper:             newaffixNameMapper("", "-foo", ""),
+			txtName:            "a-example-11111111-foo.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "A",
+			expectedID:         "11111111",
+		},
+		{
+			name:               "prefix with dot",
+			mapper:             newaffixNameMapper("foo.", "", ""),
+			txtName:            "foo.11111111-cname-example.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+			expectedID:         "11111111",
+		},
+		{
+			name:               "suffix with dot",
+			mapper:             newaffixNameMapper("", ".foo", ""),
+			txtName:            "cname-example-11111111.foo.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+			expectedID:         "11111111",
+		},
+		// V2 records - type and affix
+		{
+			name:               "prefix",
+			mapper:             newaffixNameMapper("foo", "", ""),
+			txtName:            "fooa-example.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "A",
+		},
+		{
+			name:               "suffix",
+			mapper:             newaffixNameMapper("", "foo", ""),
+			txtName:            "cname-examplefoo.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+		},
+		{
+			name:               "prefix with dash",
+			mapper:             newaffixNameMapper("foo-", "", ""),
+			txtName:            "foo-cname-example.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+		},
+		{
+			name:               "suffix with dash",
+			mapper:             newaffixNameMapper("", "-foo", ""),
+			txtName:            "a-example-foo.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "A",
+		},
+		{
+			name:               "prefix with dot",
+			mapper:             newaffixNameMapper("foo.", "", ""),
+			txtName:            "foo.cname-example.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+		},
+		{
+			name:               "suffix with dot",
+			mapper:             newaffixNameMapper("", ".foo", ""),
+			txtName:            "cname-example.foo.com",
+			expectedDomain:     "example.com",
+			expectedRecordType: "CNAME",
+		},
+		// V1 records - affix
+		{
+			name:           "prefix",
+			mapper:         newaffixNameMapper("foo", "", ""),
+			txtName:        "fooexample.com",
+			expectedDomain: "example.com",
+		},
+		{
+			name:           "suffix",
+			mapper:         newaffixNameMapper("", "foo", ""),
+			txtName:        "examplefoo.com",
+			expectedDomain: "example.com",
+		},
+		{
+			name:           "prefix with dash",
+			mapper:         newaffixNameMapper("foo-", "", ""),
+			txtName:        "foo-example.com",
+			expectedDomain: "example.com",
+		},
+		{
+			name:           "suffix with dash",
+			mapper:         newaffixNameMapper("", "-foo", ""),
+			txtName:        "example-foo.com",
+			expectedDomain: "example.com",
+		},
+		{
+			name:           "prefix with dot",
+			mapper:         newaffixNameMapper("foo.", "", ""),
+			txtName:        "foo.example.com",
+			expectedDomain: "example.com",
+		},
+		{
+			name:           "suffix with dot",
+			mapper:         newaffixNameMapper("", ".foo", ""),
+			txtName:        "example.foo.com",
+			expectedDomain: "example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			domain, recordType, id := tc.mapper.toEndpointName(tc.txtName)
+			assert.Equal(t, tc.expectedDomain, domain)
+			assert.Equal(t, tc.expectedRecordType, recordType)
+			assert.Equal(t, tc.expectedID, id)
+		})
+	}
+}

--- a/internal/external-dns/registry/txt.go
+++ b/internal/external-dns/registry/txt.go
@@ -31,7 +31,10 @@ import (
 
 const (
 	recordTemplate              = "%{record_type}"
+	affixSeparator              = "-"
+	ownerIDLen                  = 8
 	providerSpecificForceUpdate = "txt/force-update"
+	nonceLabelKey               = "txt-encryption-nonce"
 )
 
 // TXTRegistry implements registry interface with ownership implemented via associated TXT records
@@ -53,11 +56,16 @@ type TXTRegistry struct {
 	managedRecordTypes []string
 	excludeRecordTypes []string
 
+	// retains a list of existing txt records
+	txtRecordsMap map[endpoint.EndpointKey]struct{}
+
 	// encrypt text records
 	txtEncryptEnabled bool
 	txtEncryptAESKey  []byte
 
 	logger logr.Logger
+
+	LabelsPacker *TXTLabelsPacker
 }
 
 // NewTXTRegistry returns new TXTRegistry object
@@ -92,9 +100,11 @@ func NewTXTRegistry(ctx context.Context, provider provider.Provider, txtPrefix, 
 		wildcardReplacement: txtWildcardReplacement,
 		managedRecordTypes:  managedRecordTypes,
 		excludeRecordTypes:  excludeRecordTypes,
+		txtRecordsMap:       make(map[endpoint.EndpointKey]struct{}),
 		txtEncryptEnabled:   txtEncryptEnabled,
 		txtEncryptAESKey:    txtEncryptAESKey,
 		logger:              logger,
+		LabelsPacker:        NewTXTLabelsPacker(),
 	}, nil
 }
 
@@ -111,8 +121,7 @@ func (im *TXTRegistry) OwnerID() string {
 }
 
 // Records returns the current records from the registry excluding TXT Records
-// If TXT records was created previously to indicate ownership its corresponding value
-// will be added to the endpoints Labels map
+// If TXT records were are present, their metadata will be transferred into labels on the endpoint
 func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	// If we have the zones cached AND we have refreshed the cache since the
 	// last given interval, then just use the cached results.
@@ -128,37 +137,69 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 
 	endpoints := []*endpoint.Endpoint{}
 
-	labelMap := map[endpoint.EndpointKey]endpoint.Labels{}
-	txtRecordsMap := map[string]struct{}{}
+	// this map will hold labels for all endpoints
+	// for each endpoint it will be a map with ownedID as a key and labels as value
+	labelMap := map[endpoint.EndpointKey]map[string]endpoint.Labels{}
 
 	for _, record := range records {
+
 		if record.RecordType != endpoint.RecordTypeTXT {
 			endpoints = append(endpoints, record)
 			continue
 		}
-		// We simply assume that TXT records for the registry will always have only one target.
-		labels, err := endpoint.NewLabelsFromString(record.Targets[0], im.txtEncryptAESKey)
-		if err == endpoint.ErrInvalidHeritage {
+		labels := make(map[string]string)
+		// convert targets into labels
+		for _, target := range record.Targets {
+			// if empty target there is nothing to convert
+			if target == "\"\"" {
+				continue
+			}
+			var labelsFromTarget endpoint.Labels
+			labelsFromTarget, err = endpoint.NewLabelsFromString(target, im.txtEncryptAESKey)
+			if errors.Is(err, endpoint.ErrInvalidHeritage) {
+				break
+			}
+			// in case we have multiple targets join them into the same map
+			// the latest value takes precedence
+			for key, value := range labelsFromTarget {
+				labels[key] = value
+			}
+		}
+		// if we failed decoding targets just return this TXT record
+		if errors.Is(err, endpoint.ErrInvalidHeritage) {
 			// if no heritage is found or it is invalid
 			// case when value of txt record cannot be identified
 			// record will not be removed as it will have empty owner
 			endpoints = append(endpoints, record)
+			// reset err to be nil - if the next txt record has no targets, it should not inherit invalid heritage err
+			err = nil
 			continue
 		}
 		if err != nil {
 			return nil, err
 		}
 
-		endpointName, recordType := im.mapper.toEndpointName(record.DNSName)
+		// convert TXT record name into the name of endpoint, recordType of said endpoint and owner of the TXT record.
+		endpointName, recordType, ownerID := im.mapper.toEndpointName(record.DNSName)
+		// compose endpoint key; this is an actual endpoint in the provider.
+
 		key := endpoint.EndpointKey{
 			DNSName:       endpointName,
 			RecordType:    recordType,
 			SetIdentifier: record.SetIdentifier,
 		}
-		labelMap[key] = labels
-		txtRecordsMap[record.DNSName] = struct{}{}
+
+		if _, exists := labelMap[key]; !exists {
+			labelMap[key] = map[string]endpoint.Labels{}
+		}
+		// store metadata for endpoint
+		labelMap[key][ownerID] = labels
+		// txtRecordsMap is just a list of all TXT records
+		im.txtRecordsMap[record.Key()] = struct{}{}
+
 	}
 
+	// set metadata on endpoints from TXT records
 	for _, ep := range endpoints {
 		if ep.Labels == nil {
 			ep.Labels = endpoint.NewLabels()
@@ -180,26 +221,70 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			key.RecordType = endpoint.RecordTypeCNAME
 		}
 
-		// Handle both new and old registry format with the preference for the new one
-		labels, labelsExist := labelMap[key]
-		if !labelsExist && ep.RecordType != endpoint.RecordTypeAAAA {
+		// using the key of this endpoint check if we stored any metadata for it
+		labelsForKey, labelsExist := labelMap[key]
+
+		// if it is an old format we might not know record type
+		if !labelsExist {
 			key.RecordType = ""
-			labels, labelsExist = labelMap[key]
+			labelsForKey, labelsExist = labelMap[key]
 		}
+
+		// we recorded metadata
 		if labelsExist {
-			for k, v := range labels {
-				ep.Labels[k] = v
+			// endpoint naturally newer has any labels - we use TXT records to carry them
+			// here endpoint is how we got it from the provider
+			// depending on the implementation of the provider we might have labels already set
+			// in this case any existing labels should be copied to each owner
+			for _, ownerLabels := range labelsForKey {
+				for endpointLabelKey, endpointLabelValue := range ep.Labels {
+					// give precedence to labels from TXT record
+					if _, exists := ownerLabels[endpointLabelKey]; !exists {
+						ownerLabels[endpointLabelKey] = endpointLabelValue
+					}
+				}
 			}
+
+			// additionally, if we got an old TXT record, we would not know the owner of the labels
+			// in this case, copy unknown labels to each owner (and create the owner if there is none)
+			unknownOwnerLabels, exists := labelsForKey[""]
+			// bother only if an old format had the current owner as one of the owners
+			if exists && strings.Contains(unknownOwnerLabels[endpoint.OwnerLabelKey], im.ownerID) {
+				delete(labelsForKey, "")
+				// also delete owner=owner1 key/value from old format
+				delete(unknownOwnerLabels, endpoint.OwnerLabelKey)
+				// there is no other owners - create one
+				if len(labelsForKey) == 0 {
+					labelsForKey[im.ownerID] = unknownOwnerLabels
+				} else {
+					// there are other owners
+					for _, ownerLabels := range labelsForKey {
+						for unknownKey, unknownValue := range unknownOwnerLabels {
+							// for each value in labels of unknown owner, check if such a key exists
+							// in labels of the owner; copy the value only if it doesn't exist
+							if _, ownerHasKey := ownerLabels[unknownKey]; !ownerHasKey {
+								// do not create
+								ownerLabels[unknownKey] = unknownValue
+							}
+						}
+					}
+				}
+
+			}
+
+			// pack labels into endpoint
+			ep.Labels = im.LabelsPacker.PackLabels(labelsForKey)
 		}
 
 		// Handle the migration of TXT records created before the new format (introduced in v0.12.0).
 		// The migration is done for the TXT records owned by this instance only.
-		if len(txtRecordsMap) > 0 && ep.Labels[endpoint.OwnerLabelKey] == im.ownerID {
+		if _, ownerExists := ep.Labels[im.ownerID]; ownerExists {
 			if plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes, im.excludeRecordTypes) {
 				// Get desired TXT records and detect the missing ones
 				desiredTXTs := im.generateTXTRecord(ep)
 				for _, desiredTXT := range desiredTXTs {
-					if _, exists := txtRecordsMap[desiredTXT.DNSName]; !exists {
+					if _, exists := im.txtRecordsMap[desiredTXT.Key()]; !exists {
+						// this will indicate that this endpoint has old TXT associated with it
 						ep.WithProviderSpecific(providerSpecificForceUpdate, "true")
 					}
 				}
@@ -216,29 +301,45 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	return endpoints, nil
 }
 
-// generateTXTRecord generates both "old" and "new" TXT records.
-// Once we decide to drop old format we need to drop toTXTName() and rename toNewTXTName
+// generateTXTRecord generates TXT records.
 func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpoint {
 	endpoints := make([]*endpoint.Endpoint, 0)
-
-	//mnairn: Seems to be no way to prevent the creation of the old format TXT records other than removing the code
-	//if !im.txtEncryptEnabled && !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA {
-	//	// old TXT record format
-	//	txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
-	//	if txt != nil {
-	//		txt.WithSetIdentifier(r.SetIdentifier)
-	//		txt.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
-	//		txt.ProviderSpecific = r.ProviderSpecific
-	//		endpoints = append(endpoints, txt)
-	//	}
-	//}
-	// new TXT record format (containing record type)
 	recordType := r.RecordType
 	// AWS Alias records are encoded as type "cname"
 	if isAlias, found := r.GetProviderSpecificProperty("alias"); found && isAlias == "true" && recordType == endpoint.RecordTypeA {
 		recordType = endpoint.RecordTypeCNAME
 	}
-	txtNew := endpoint.NewEndpoint(im.mapper.toNewTXTName(r.DNSName, recordType), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
+
+	targets := make([]string, 0)
+	// if we have packed labels we need to unpack them and use only a set for the current owner
+	ownedLabels := r.Labels
+	if packed, _ := im.LabelsPacker.LabelsPacked(r.Labels); packed {
+		// error will return false
+		ownedLabels = im.LabelsPacker.UnpackLabels(r.Labels)[im.ownerID]
+	}
+
+	// the nonce label is a metadata of encryption and should be copied
+	nonceLabel, nonceExists := ownedLabels[nonceLabelKey]
+	for key, value := range ownedLabels {
+		if !nonceExists {
+			targets = append(targets, endpoint.Labels{key: value}.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
+			continue
+		}
+
+		// add nonce to each target but the once itself
+		if key == nonceLabelKey {
+			continue
+		}
+		targets = append(targets, endpoint.Labels{
+			key:           value,
+			nonceLabelKey: nonceLabel,
+		}.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
+	}
+
+	if len(targets) == 0 {
+		targets = append(targets, "\"\"")
+	}
+	txtNew := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName, im.OwnerID(), recordType), endpoint.RecordTypeTXT, targets...)
 	if txtNew != nil {
 		txtNew.WithSetIdentifier(r.SetIdentifier)
 		txtNew.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
@@ -257,25 +358,32 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		//ToDo Ideally we would still be able to ensure ownership on update
 		UpdateNew: changes.UpdateNew,
 		UpdateOld: changes.UpdateOld,
-		Delete:    endpoint.FilterEndpointsByOwnerID(im.ownerID, changes.Delete),
+		// make sure we don't delete endpoints that we don't own.
+		// this should not be allowed by the plan, but better safe
+		Delete: im.FilterEndpointsByOwnerID(im.ownerID, changes.Delete),
 	}
+
+	// We do not receive TXT records here
+	// Instead we need to generate them from endpoints and metadata on them
+
 	for _, r := range filteredChanges.Create {
 		if r.Labels == nil {
-			r.Labels = make(map[string]string)
+			r.Labels = endpoint.NewLabels()
 		}
-		r.Labels[endpoint.OwnerLabelKey] = im.ownerID
 
+		// for create request just generate TXT record
 		filteredChanges.Create = append(filteredChanges.Create, im.generateTXTRecord(r)...)
 
 		if im.cacheInterval > 0 {
 			im.addToCache(r)
 		}
 	}
-
 	for _, r := range filteredChanges.Delete {
-		// when we delete TXT records for which value has changed (due to new label) this would still work because
-		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
-		// !!! After migration to the new TXT registry format we can drop records in old format here!!!
+		// if we decide to facilitate migrations here, we delete old TXT records for ednpoint with
+		// providerSpecific txt/force-update
+		if _, err := im.LabelsPacker.LabelsPacked(r.Labels); err != nil {
+			return err
+		}
 		filteredChanges.Delete = append(filteredChanges.Delete, im.generateTXTRecord(r)...)
 
 		if im.cacheInterval > 0 {
@@ -283,11 +391,11 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 		}
 	}
 
-	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateOld {
-		// when we updateOld TXT records for which value has changed (due to new label) this would still work because
-		// !!! TXT record value is uniquely generated from the Labels of the endpoint. Hence old TXT record can be uniquely reconstructed
-		filteredChanges.UpdateOld = append(filteredChanges.UpdateOld, im.generateTXTRecord(r)...)
+		if _, err := im.LabelsPacker.LabelsPacked(r.Labels); err != nil {
+			return err
+		}
+		filteredChanges.Create, filteredChanges.UpdateOld = im.ensureTXTRecord(filteredChanges.Create, filteredChanges.UpdateOld, im.generateTXTRecord(r), false)
 		// remove old version of record from cache
 		if im.cacheInterval > 0 {
 			im.removeFromCache(r)
@@ -296,13 +404,25 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateNew {
-		filteredChanges.UpdateNew = append(filteredChanges.UpdateNew, im.generateTXTRecord(r)...)
+		if packed, err := im.LabelsPacker.LabelsPacked(r.Labels); err != nil {
+			return err
+		} else if packed {
+			r.Labels = im.LabelsPacker.UnpackLabels(r.Labels)[im.ownerID]
+		}
+
+		// if we have nil labels for this owner - we should remove ownership
+		// this is done by deleting TXT record
+		if r.Labels == nil {
+			filteredChanges.Delete = append(filteredChanges.Delete, im.generateTXTRecord(r)...)
+		} else {
+			filteredChanges.Create, filteredChanges.UpdateNew = im.ensureTXTRecord(filteredChanges.Create, filteredChanges.UpdateNew, im.generateTXTRecord(r), true)
+		}
+
 		// add new version of record to cache
 		if im.cacheInterval > 0 {
 			im.addToCache(r)
 		}
 	}
-
 	// when caching is enabled, disable the provider from using the cache
 	if im.cacheInterval > 0 {
 		ctx = context.WithValue(ctx, provider.RecordsContextKey, nil)
@@ -315,184 +435,55 @@ func (im *TXTRegistry) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpo
 	return im.provider.AdjustEndpoints(endpoints)
 }
 
-/**
-  nameMapper is the interface for mapping between the endpoint for the source
-  and the endpoint for the TXT record.
-*/
-
-type nameMapper interface {
-	toEndpointName(string) (endpointName string, recordType string)
-	toTXTName(string) string
-	toNewTXTName(string, string) string
-	recordTypeInAffix() bool
+// GetLabelsPacker implementing Registry interface
+func (im *TXTRegistry) GetLabelsPacker() LabelsPacker {
+	return im.LabelsPacker
 }
 
-type affixNameMapper struct {
-	prefix              string
-	suffix              string
-	wildcardReplacement string
-}
-
-var _ nameMapper = affixNameMapper{}
-
-func newaffixNameMapper(prefix, suffix, wildcardReplacement string) affixNameMapper {
-	return affixNameMapper{prefix: strings.ToLower(prefix), suffix: strings.ToLower(suffix), wildcardReplacement: strings.ToLower(wildcardReplacement)}
-}
-
-// extractRecordTypeDefaultPosition extracts record type from the default position
-// when not using '%{record_type}' in the prefix/suffix
-func extractRecordTypeDefaultPosition(name string) (baseName, recordType string) {
-	nameS := strings.Split(name, "-")
-	for _, t := range getSupportedTypes() {
-		if nameS[0] == strings.ToLower(t) {
-			return strings.TrimPrefix(name, nameS[0]+"-"), t
+// FilterEndpointsByOwnerID implementing Registry interface
+func (im *TXTRegistry) FilterEndpointsByOwnerID(ownerID string, list []*endpoint.Endpoint) []*endpoint.Endpoint {
+	filtered := []*endpoint.Endpoint{}
+	for _, ep := range list {
+		if _, ok := ep.Labels[ownerID]; ok {
+			filtered = append(filtered, ep)
 		}
 	}
-	return name, ""
+	return filtered
 }
 
-// dropAffixExtractType strips TXT record to find an endpoint name it manages
-// it also returns the record type
-func (pr affixNameMapper) dropAffixExtractType(name string) (baseName, recordType string) {
-	prefix := pr.prefix
-	suffix := pr.suffix
+// ensureTXTRecord creates TXT record if id don't exist. If it exists - updates it.
+func (im *TXTRegistry) ensureTXTRecord(createArray, updateArray, candidateTXTs []*endpoint.Endpoint, updateRecordsMap bool) (create []*endpoint.Endpoint, update []*endpoint.Endpoint) {
+	for _, candidateTXT := range candidateTXTs {
+		_, exists := im.txtRecordsMap[candidateTXT.Key()]
+		if !exists {
+			// make sure we are not creating twice
+			// happens when creating record for the hostname that already exists with a new owner
+			index := endpointIndex(createArray, candidateTXT)
 
-	if pr.recordTypeInAffix() {
-		for _, t := range getSupportedTypes() {
-			tLower := strings.ToLower(t)
-			iPrefix := strings.ReplaceAll(prefix, recordTemplate, tLower)
-			iSuffix := strings.ReplaceAll(suffix, recordTemplate, tLower)
-
-			if pr.isPrefix() && strings.HasPrefix(name, iPrefix) {
-				return strings.TrimPrefix(name, iPrefix), t
+			if index == -1 {
+				createArray = append(createArray, candidateTXT)
+				// if we are working with updateOld we should not update this map,
+				// it will make controller think that record exists in the provider
+				// this enables us to override create request with updateNew TXT record
+				if updateRecordsMap {
+					im.txtRecordsMap[candidateTXT.Key()] = struct{}{}
+				}
+			} else {
+				createArray[index] = candidateTXT
 			}
-
-			if pr.isSuffix() && strings.HasSuffix(name, iSuffix) {
-				return strings.TrimSuffix(name, iSuffix), t
-			}
-		}
-
-		// handle old TXT records
-		prefix = pr.dropAffixTemplate(prefix)
-		suffix = pr.dropAffixTemplate(suffix)
-	}
-
-	if pr.isPrefix() && strings.HasPrefix(name, prefix) {
-		return extractRecordTypeDefaultPosition(strings.TrimPrefix(name, prefix))
-	}
-
-	if pr.isSuffix() && strings.HasSuffix(name, suffix) {
-		return extractRecordTypeDefaultPosition(strings.TrimSuffix(name, suffix))
-	}
-
-	return "", ""
-}
-
-func (pr affixNameMapper) dropAffixTemplate(name string) string {
-	return strings.ReplaceAll(name, recordTemplate, "")
-}
-
-func (pr affixNameMapper) isPrefix() bool {
-	return len(pr.suffix) == 0
-}
-
-func (pr affixNameMapper) isSuffix() bool {
-	return len(pr.prefix) == 0 && len(pr.suffix) > 0
-}
-
-func (pr affixNameMapper) toEndpointName(txtDNSName string) (endpointName string, recordType string) {
-	lowerDNSName := strings.ToLower(txtDNSName)
-
-	// drop prefix
-	if pr.isPrefix() {
-		return pr.dropAffixExtractType(lowerDNSName)
-	}
-
-	// drop suffix
-	if pr.isSuffix() {
-		dc := strings.Count(pr.suffix, ".")
-		DNSName := strings.SplitN(lowerDNSName, ".", 2+dc)
-		domainWithSuffix := strings.Join(DNSName[:1+dc], ".")
-
-		r, rType := pr.dropAffixExtractType(domainWithSuffix)
-		return r + "." + DNSName[1+dc], rType
-	}
-	return "", ""
-}
-
-func (pr affixNameMapper) toTXTName(endpointDNSName string) string {
-	DNSName := strings.SplitN(endpointDNSName, ".", 2)
-
-	prefix := pr.dropAffixTemplate(pr.prefix)
-	suffix := pr.dropAffixTemplate(pr.suffix)
-	// If specified, replace a leading asterisk in the generated txt record name with some other string
-	if pr.wildcardReplacement != "" && DNSName[0] == "*" {
-		DNSName[0] = pr.wildcardReplacement
-	}
-
-	if len(DNSName) < 2 {
-		return prefix + DNSName[0] + suffix
-	}
-	return prefix + DNSName[0] + suffix + "." + DNSName[1]
-}
-
-func (pr affixNameMapper) recordTypeInAffix() bool {
-	if strings.Contains(pr.prefix, recordTemplate) {
-		return true
-	}
-	if strings.Contains(pr.suffix, recordTemplate) {
-		return true
-	}
-	return false
-}
-
-func (pr affixNameMapper) normalizeAffixTemplate(afix, recordType string) string {
-	if strings.Contains(afix, recordTemplate) {
-		return strings.ReplaceAll(afix, recordTemplate, recordType)
-	}
-	return afix
-}
-
-func (pr affixNameMapper) toNewTXTName(endpointDNSName, recordType string) string {
-	DNSName := strings.SplitN(endpointDNSName, ".", 2)
-	recordType = strings.ToLower(recordType)
-	recordT := recordType + "-"
-
-	prefix := pr.normalizeAffixTemplate(pr.prefix, recordType)
-	suffix := pr.normalizeAffixTemplate(pr.suffix, recordType)
-
-	// If specified, replace a leading asterisk in the generated txt record name with some other string
-	if pr.wildcardReplacement != "" && DNSName[0] == "*" {
-		DNSName[0] = pr.wildcardReplacement
-	}
-
-	if !pr.recordTypeInAffix() {
-		DNSName[0] = recordT + DNSName[0]
-	}
-
-	if len(DNSName) < 2 {
-		return prefix + DNSName[0] + suffix
-	}
-
-	return prefix + DNSName[0] + suffix + "." + DNSName[1]
-}
-
-func (im *TXTRegistry) addToCache(ep *endpoint.Endpoint) {
-	if im.recordsCache != nil {
-		im.recordsCache = append(im.recordsCache, ep)
-	}
-}
-
-func (im *TXTRegistry) removeFromCache(ep *endpoint.Endpoint) {
-	if im.recordsCache == nil || ep == nil {
-		return
-	}
-
-	for i, e := range im.recordsCache {
-		if e.DNSName == ep.DNSName && e.RecordType == ep.RecordType && e.SetIdentifier == ep.SetIdentifier && e.Targets.Same(ep.Targets) {
-			// We found a match delete the endpoint from the cache.
-			im.recordsCache = append(im.recordsCache[:i], im.recordsCache[i+1:]...)
-			return
+		} else {
+			updateArray = append(updateArray, candidateTXT)
 		}
 	}
+	return createArray, updateArray
+}
+
+// endpointIndex returns index of endpoint in a slice. If not found returns -1
+func endpointIndex(list []*endpoint.Endpoint, ep *endpoint.Endpoint) int {
+	for i, element := range list {
+		if element.DNSName == ep.DNSName && element.SetIdentifier == ep.SetIdentifier && element.RecordType == ep.RecordType {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/external-dns/registry/txt_test.go
+++ b/internal/external-dns/registry/txt_test.go
@@ -19,7 +19,6 @@ package registry
 import (
 	"context"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -35,7 +34,8 @@ import (
 )
 
 const (
-	testZone = "test-zone.example.org"
+	testZone    = "test-zone.example.org"
+	testTXTZone = "-txt"
 )
 
 func TestTXTRegistry(t *testing.T) {
@@ -89,143 +89,172 @@ func testTXTRegistryRecords(t *testing.T) {
 	t.Run("With prefix", testTXTRegistryRecordsPrefixed)
 	t.Run("With suffix", testTXTRegistryRecordsSuffixed)
 	t.Run("No prefix", testTXTRegistryRecordsNoPrefix)
-	t.Run("With templated prefix", testTXTRegistryRecordsPrefixedTemplated)
-	t.Run("With templated suffix", testTXTRegistryRecordsSuffixedTemplated)
 }
 
 func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	ctx := context.Background()
 	p := inmemory.NewInMemoryProvider()
 	p.CreateZone(testZone)
+	// records in the zone
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerAndLabels("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"foo": "somefoo"}),
-			newEndpointWithOwnerAndLabels("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"bar": "somebar"}),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwnerAndLabels("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"tar": "sometar"}),
-			newEndpointWithOwner("TxT.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""), // case-insensitive TXT prefix
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("*.wildcard.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.wc.wildcard.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("dualstack.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("txt.dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
-			newEndpointWithOwner("txt.aaaa-dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
+			// no owner
+			// EP1 - random cname in the zone
+			newEndpointWithLabels("foo.test-zone.example.org", endpoint.RecordTypeCNAME, endpoint.Labels{"foo": "somefoo"}, "foo.loadbalancer.com"),
+
+			// EP2 - random cname in the zone that matches txt record format
+			endpoint.NewEndpoint("txt-owner111-cname-bar.test-zone.example.org", endpoint.RecordTypeCNAME, "baz.test-zone.example.org"),
+
+			// EP3 - txt record that we are not managing
+			endpoint.NewEndpoint("qux.test-zone.example.org", endpoint.RecordTypeTXT, "random"),
+
+			// EP4 - TXT record has the wrong format - should not be used
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// owner
+			// EP5 - wildcard record
+			endpoint.NewEndpoint("*.wildcard.test-zone.example.org", endpoint.RecordTypeCNAME, "foo.loadbalancer.com"),
+			endpoint.NewEndpoint("txt-owner111-cname-wc.wildcard.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP6 - cname we manage with extra labels
+			newEndpointWithLabels("bar.test-zone.example.org", endpoint.RecordTypeCNAME, endpoint.Labels{"bar": "somebar"}, "my-domain.com"),
+			endpoint.NewEndpoint("txt-owner111-cname-bar.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP7 - lb cname we manage with setID
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
+			endpoint.NewEndpoint("txt-owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT).WithSetIdentifier("test-set-1"),
+
+			// EP8 - lb cname we manage with setID
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			endpoint.NewEndpoint("txt-owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT).WithSetIdentifier("test-set-2"),
+
+			// EP9 - a record that shares name with EP11
+			endpoint.NewEndpoint("dualstack.test-zone.example.org", endpoint.RecordTypeA, "1.1.1.1"),
+			endpoint.NewEndpoint("txt-owner111-a-dualstack.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// owner-2
+			// EP10 - case-sensitive txt prefix for cname and composite target on TXT
+			// We aren't generating composite targets anymore - this is a legacy check
+			newEndpointWithLabels("tar.test-zone.example.org", endpoint.RecordTypeCNAME, endpoint.Labels{"tar": "sometar"}, "tar.loadbalancer.com"),
+			endpoint.NewEndpoint("TxT-owner222-cname-tar.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
+
+			// EP11 - aaaa record that shares name with EP9
+			endpoint.NewEndpoint("dualstack.test-zone.example.org", endpoint.RecordTypeAAAA, "2001:DB8::1"),
+			endpoint.NewEndpoint("txt-owner222-aaaa-dualstack.test-zone.example.org", endpoint.RecordTypeTXT),
 		},
 	})
+	// how we expect the registry to translate records from the zone
 	expectedRecords := []*endpoint.Endpoint{
+		// EP1
 		{
 			DNSName:    "foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-				"foo":                  "somefoo",
+				"foo": "somefoo",
 			},
 		},
+		// EP2
+		{
+			DNSName:    "txt-owner111-cname-bar.test-zone.example.org",
+			Targets:    endpoint.Targets{"baz.test-zone.example.org"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     map[string]string{},
+		},
+		// EP3
+		{
+			DNSName:    "qux.test-zone.example.org",
+			Targets:    endpoint.Targets{"random"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels:     map[string]string{},
+		},
+		// EP4
+		{
+			DNSName:    "foobar.test-zone.example.org",
+			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     map[string]string{},
+		},
+		// EP5
+		{
+			DNSName:    "*.wildcard.test-zone.example.org",
+			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				"owner111": "",
+			},
+		},
+		// EP6
 		{
 			DNSName:    "bar.test-zone.example.org",
 			Targets:    endpoint.Targets{"my-domain.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-				"bar":                  "somebar",
+				"owner111": "bar=somebar",
 			},
 		},
-		{
-			DNSName:    "txt.bar.test-zone.example.org",
-			Targets:    endpoint.Targets{"baz.test-zone.example.org"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
-		{
-			DNSName:    "qux.test-zone.example.org",
-			Targets:    endpoint.Targets{"random"},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
-		{
-			DNSName:    "tar.test-zone.example.org",
-			Targets:    endpoint.Targets{"tar.loadbalancer.com"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner-2",
-				"tar":                  "sometar",
-			},
-		},
-		{
-			DNSName:    "foobar.test-zone.example.org",
-			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
+		// EP7
 		{
 			DNSName:       "multiple.test-zone.example.org",
 			Targets:       endpoint.Targets{"lb1.loadbalancer.com"},
 			SetIdentifier: "test-set-1",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				"owner111": "",
 			},
 		},
+		// EP8
 		{
 			DNSName:       "multiple.test-zone.example.org",
 			Targets:       endpoint.Targets{"lb2.loadbalancer.com"},
 			SetIdentifier: "test-set-2",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				"owner111": "",
 			},
 		},
-		{
-			DNSName:    "*.wildcard.test-zone.example.org",
-			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
+		// EP9
 		{
 			DNSName:    "dualstack.test-zone.example.org",
 			Targets:    endpoint.Targets{"1.1.1.1"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 		},
+		// EP10
+		{
+			DNSName:    "tar.test-zone.example.org",
+			Targets:    endpoint.Targets{"tar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				"owner222": "resource=ingress/default/my-ingress,tar=sometar",
+			},
+		},
+		// EP11
 		{
 			DNSName:    "dualstack.test-zone.example.org",
 			Targets:    endpoint.Targets{"2001:DB8::1"},
 			RecordType: endpoint.RecordTypeAAAA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner-2",
+				"owner222": "",
 			},
 		},
 	}
 
-	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner", time.Hour, "wc", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "txt-", "", "owner111", time.Hour, "wc", []string{}, []string{}, false, nil)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(context.Background(), p, "TxT.", "", "owner", time.Hour, "wc", []string{}, []string{}, false, nil)
+	r, _ = NewTXTRegistry(context.Background(), p, "TxT-", "", "owner111", time.Hour, "wc", []string{}, []string{}, false, nil)
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 }
 
 func testTXTRegistryRecordsSuffixed(t *testing.T) {
@@ -234,122 +263,148 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerAndLabels("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"foo": "somefoo"}),
-			newEndpointWithOwnerAndLabels("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"bar": "somebar"}),
-			newEndpointWithOwner("bar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("bar-txt.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwnerAndLabels("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"tar": "sometar"}),
-			newEndpointWithOwner("tar-TxT.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""), // case-insensitive TXT prefix
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("dualstack.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("dualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
-			newEndpointWithOwner("aaaa-dualstack-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
+			// no owner
+			// EP1 - random cname that we do not manage
+			newEndpointWithLabels("foo.test-zone.example.org", endpoint.RecordTypeCNAME, endpoint.Labels{"foo": "somefoo"}, "foo.loadbalancer.com"),
+
+			// EP2 - random cname in the zone that matches txt record format
+			endpoint.NewEndpoint("cname-bar-owner111-txt.test-zone.example.org", endpoint.RecordTypeCNAME, "baz.test-zone.example.org"),
+
+			// EP3 - txt record that we are not managing
+			endpoint.NewEndpoint("qux.test-zone.example.org", endpoint.RecordTypeTXT, "random"),
+
+			// EP4 - invalid txt record format - it should not be used
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("foobar-cname-txt.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// owner
+			// EP5 - cname that we manage with extra labels
+			newEndpointWithLabels("bar.test-zone.example.org", endpoint.RecordTypeCNAME, endpoint.Labels{"bar": "somebar"}, "my-domain.com"),
+			endpoint.NewEndpoint("cname-bar-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP6 - lb cname we manage with setID
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
+			endpoint.NewEndpoint("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT).WithSetIdentifier("test-set-1"),
+
+			// EP7 - lb cname we manage with setID
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			endpoint.NewEndpoint("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT).WithSetIdentifier("test-set-2"),
+
+			// EP8 - a record that shares name with EP10
+			endpoint.NewEndpoint("dualstack.test-zone.example.org", endpoint.RecordTypeA, "1.1.1.1"),
+			endpoint.NewEndpoint("a-dualstack-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// owner-2
+			// EP9 - case sensitive TXT record
+			newEndpointWithLabels("tar.test-zone.example.org", endpoint.RecordTypeCNAME, endpoint.Labels{"tar": "sometar"}, "tar.loadbalancer.com"),
+			endpoint.NewEndpoint("cname-tar-owner222-TxT.test-zone.example.org", endpoint.RecordTypeTXT), // case-insensitive TXT suffix
+
+			// EP10 - aaaa record that shares name with EP8
+			endpoint.NewEndpoint("dualstack.test-zone.example.org", endpoint.RecordTypeAAAA, "2001:DB8::1"),
+			endpoint.NewEndpoint("aaaa-dualstack-owner222-txt.test-zone.example.org", endpoint.RecordTypeTXT),
 		},
 	})
+	// compared to prefix missing wildcard case
 	expectedRecords := []*endpoint.Endpoint{
+		// EP1
 		{
 			DNSName:    "foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-				"foo":                  "somefoo",
+				"foo": "somefoo",
 			},
 		},
+		// EP2
+		{
+			DNSName:    "cname-bar-owner111-txt.test-zone.example.org",
+			Targets:    endpoint.Targets{"baz.test-zone.example.org"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     map[string]string{},
+		},
+		// EP3
+		{
+			DNSName:    "qux.test-zone.example.org",
+			Targets:    endpoint.Targets{"random"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels:     map[string]string{},
+		},
+		// EP4
+		{
+			DNSName:    "foobar.test-zone.example.org",
+			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     map[string]string{},
+		},
+		// EP5
 		{
 			DNSName:    "bar.test-zone.example.org",
 			Targets:    endpoint.Targets{"my-domain.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-				"bar":                  "somebar",
+				"owner111": "bar=somebar",
 			},
 		},
-		{
-			DNSName:    "bar-txt.test-zone.example.org",
-			Targets:    endpoint.Targets{"baz.test-zone.example.org"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
-		{
-			DNSName:    "qux.test-zone.example.org",
-			Targets:    endpoint.Targets{"random"},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
-		{
-			DNSName:    "tar.test-zone.example.org",
-			Targets:    endpoint.Targets{"tar.loadbalancer.com"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner-2",
-				"tar":                  "sometar",
-			},
-		},
-		{
-			DNSName:    "foobar.test-zone.example.org",
-			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
+		// EP6
 		{
 			DNSName:       "multiple.test-zone.example.org",
 			Targets:       endpoint.Targets{"lb1.loadbalancer.com"},
 			SetIdentifier: "test-set-1",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				"owner111": "",
 			},
 		},
+		// EP7
 		{
 			DNSName:       "multiple.test-zone.example.org",
 			Targets:       endpoint.Targets{"lb2.loadbalancer.com"},
 			SetIdentifier: "test-set-2",
 			RecordType:    endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				"owner111": "",
 			},
 		},
+		// EP8
 		{
 			DNSName:    "dualstack.test-zone.example.org",
 			Targets:    endpoint.Targets{"1.1.1.1"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 		},
+		// EP9
+		{
+			DNSName:    "tar.test-zone.example.org",
+			Targets:    endpoint.Targets{"tar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				"owner222": "tar=sometar",
+			},
+		},
+		// EP10
 		{
 			DNSName:    "dualstack.test-zone.example.org",
 			Targets:    endpoint.Targets{"2001:DB8::1"},
 			RecordType: endpoint.RecordTypeAAAA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner-2",
+				"owner222": "",
 			},
 		},
 	}
 
-	r, _ := NewTXTRegistry(context.Background(), p, "", "-txt", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "-txt", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(context.Background(), p, "", "-TxT", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ = NewTXTRegistry(context.Background(), p, "", "-TxT", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
 	records, _ = r.Records(ctx)
 
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 }
 
@@ -359,46 +414,97 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("alias.test-zone.example.org", "my-domain.com", endpoint.RecordTypeA, "").WithProviderSpecific("alias", "true"),
-			newEndpointWithOwner("cname-alias.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("dualstack.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("dualstack.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, ""),
-			newEndpointWithOwner("aaaa-dualstack.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
+			// no owner
+			// EP1 - random cname that we do not manage
+			endpoint.NewEndpoint("foo.test-zone.example.org", endpoint.RecordTypeCNAME, "foo.loadbalancer.com"),
+
+			// EP2 - random cname in the zone that matches txt record format
+			endpoint.NewEndpoint("bar.test-zone.example.org", endpoint.RecordTypeCNAME, "my-domain.com"),
+
+			// EP3 - txt record that we are not managing
+			endpoint.NewEndpoint("qux.test-zone.example.org", endpoint.RecordTypeTXT, "random"),
+
+			// EP4 - invalid txt record format - it should not be used
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("invalid-foobar.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP5 - record with prefix when we expect no prefix
+			endpoint.NewEndpoint("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "tar.loadbalancer.com"),
+			endpoint.NewEndpoint("txt-owner111-cname-tar.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// owner
+			// EP6 - cname that we manage with multiple targets on TXT
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", endpoint.RecordTypeCNAME, "baz.test-zone.example.org"),
+			endpoint.NewEndpoint("owner111-cname-txt.bar.test-zone.example.org", endpoint.RecordTypeTXT,
+				"\"heritage=external-dns,external-dns/foo=bar\"",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
+
+			// EP7 - alias A record
+			endpoint.NewEndpoint("alias.test-zone.example.org", endpoint.RecordTypeA, "my-domain.com").WithProviderSpecific("alias", "true"),
+			endpoint.NewEndpoint("owner111-cname-alias.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP8 - A record that shares hostname with EP9
+			endpoint.NewEndpoint("dualstack.test-zone.example.org", endpoint.RecordTypeA, "1.1.1.1"),
+			endpoint.NewEndpoint("owner111-a-dualstack.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// owner-2
+			// EP9 - AAAA record that shares the name with EP8
+			endpoint.NewEndpoint("dualstack.test-zone.example.org", endpoint.RecordTypeAAAA, "2001:DB8::1"),
+			endpoint.NewEndpoint("owner222-aaaa-dualstack.test-zone.example.org", endpoint.RecordTypeTXT),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
+		// EP1
 		{
 			DNSName:    "foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
+			Labels:     map[string]string{},
 		},
+		// EP2
 		{
 			DNSName:    "bar.test-zone.example.org",
 			Targets:    endpoint.Targets{"my-domain.com"},
 			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     map[string]string{},
+		},
+		// EP3
+		{
+			DNSName:    "qux.test-zone.example.org",
+			Targets:    endpoint.Targets{"random"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels:     map[string]string{},
+		},
+		// EP4
+		{
+			DNSName:    "foobar.test-zone.example.org",
+			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     map[string]string{},
+		},
+		// EP5
+		{
+			DNSName:    "tar.test-zone.example.org",
+			Targets:    endpoint.Targets{"tar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     map[string]string{},
+		},
+		// EP6
+		{
+			DNSName:    "txt.bar.test-zone.example.org",
+			Targets:    endpoint.Targets{"baz.test-zone.example.org"},
+			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
+				"owner111": "foo=bar," + endpoint.ResourceLabelKey + "=ingress/default/my-ingress",
 			},
 		},
+		// EP7
 		{
 			DNSName:    "alias.test-zone.example.org",
 			Targets:    endpoint.Targets{"my-domain.com"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 			ProviderSpecific: []endpoint.ProviderSpecificProperty{
 				{
@@ -407,133 +513,105 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 				},
 			},
 		},
-		{
-			DNSName:    "txt.bar.test-zone.example.org",
-			Targets:    endpoint.Targets{"baz.test-zone.example.org"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey:    "owner",
-				endpoint.ResourceLabelKey: "ingress/default/my-ingress",
-			},
-		},
-		{
-			DNSName:    "qux.test-zone.example.org",
-			Targets:    endpoint.Targets{"random"},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
-		{
-			DNSName:    "tar.test-zone.example.org",
-			Targets:    endpoint.Targets{"tar.loadbalancer.com"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
-		},
-		{
-			DNSName:    "foobar.test-zone.example.org",
-			Targets:    endpoint.Targets{"foobar.loadbalancer.com"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
+		// EP8
 		{
 			DNSName:    "dualstack.test-zone.example.org",
 			Targets:    endpoint.Targets{"1.1.1.1"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 		},
+		// EP9
 		{
 			DNSName:    "dualstack.test-zone.example.org",
 			Targets:    endpoint.Targets{"2001:DB8::1"},
 			RecordType: endpoint.RecordTypeAAAA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner-2",
+				"owner222": "",
 			},
 		},
 	}
 
-	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
-}
-
-func testTXTRegistryRecordsPrefixedTemplated(t *testing.T) {
-	ctx := context.Background()
-	p := inmemory.NewInMemoryProvider()
-	p.CreateZone(testZone)
-	p.ApplyChanges(ctx, &plan.Changes{
-		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("txt-a.foo.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-		},
-	})
-	expectedRecords := []*endpoint.Endpoint{
-		{
-			DNSName:    "foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"1.1.1.1"},
-			RecordType: endpoint.RecordTypeA,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
-	}
-
-	r, _ := NewTXTRegistry(context.Background(), p, "txt-%{record_type}.", "", "owner", time.Hour, "wc", []string{}, []string{}, false, nil)
-	records, _ := r.Records(ctx)
-
-	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
-
-	r, _ = NewTXTRegistry(context.Background(), p, "TxT-%{record_type}.", "", "owner", time.Hour, "wc", []string{}, []string{}, false, nil)
-	records, _ = r.Records(ctx)
-
-	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
-}
-
-func testTXTRegistryRecordsSuffixedTemplated(t *testing.T) {
-	ctx := context.Background()
-	p := inmemory.NewInMemoryProvider()
-	p.CreateZone(testZone)
-	p.ApplyChanges(ctx, &plan.Changes{
-		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("bar.test-zone.example.org", "8.8.8.8", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bartxtcname.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-		},
-	})
-	expectedRecords := []*endpoint.Endpoint{
-		{
-			DNSName:    "bar.test-zone.example.org",
-			Targets:    endpoint.Targets{"8.8.8.8"},
-			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-		},
-	}
-
-	r, _ := NewTXTRegistry(context.Background(), p, "", "txt%{record_type}", "owner", time.Hour, "wc", []string{}, []string{}, false, nil)
-	records, _ := r.Records(ctx)
-
-	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
-
-	r, _ = NewTXTRegistry(context.Background(), p, "", "TxT%{record_type}", "owner", time.Hour, "wc", []string{}, []string{}, false, nil)
-	records, _ = r.Records(ctx)
-
-	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 }
 
 func testTXTRegistryApplyChanges(t *testing.T) {
+	t.Run("Multiple owners", testTXTRegistryApplyChangesMultipleOwners)
 	t.Run("With Prefix", testTXTRegistryApplyChangesWithPrefix)
 	t.Run("With Templated Prefix", testTXTRegistryApplyChangesWithTemplatedPrefix)
 	t.Run("With Templated Suffix", testTXTRegistryApplyChangesWithTemplatedSuffix)
 	t.Run("With Suffix", testTXTRegistryApplyChangesWithSuffix)
 	t.Run("No prefix", testTXTRegistryApplyChangesNoPrefix)
+}
+
+func testTXTRegistryApplyChangesMultipleOwners(t *testing.T) {
+	p := inmemory.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	ctxEndpoints := []*endpoint.Endpoint{}
+	ctx := context.WithValue(context.Background(), provider.RecordsContextKey, ctxEndpoints)
+	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
+		assert.Equal(t, ctxEndpoints, ctx.Value(provider.RecordsContextKey))
+	}
+	p.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+
+			// EP1
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("txt.owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "\"\""),
+
+			// EP2
+			endpoint.NewEndpoint("txt.owner222-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "\"\""),
+		},
+	})
+	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
+	// Update registry with content of the zone (create request above)
+	// otherwise will be creating exising TXT records
+	_, _ = r.Records(ctx)
+
+	changes := &plan.Changes{
+		UpdateNew: []*endpoint.Endpoint{
+			// EP1 / EP2 cname is owner by two. On delete of one of the owners plan will instead move cname into update new without deleted owner
+			// simulate this scenario and expect there to be a delete on the TXT record
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner222", "foobar.loadbalancer.com"),
+		},
+	}
+	expected := &plan.Changes{
+		Create: []*endpoint.Endpoint{},
+		Delete: []*endpoint.Endpoint{
+			newEndpointWithOwnedRecord("txt.owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "foobar.test-zone.example.org", "\"\""),
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+		},
+		UpdateOld: []*endpoint.Endpoint{},
+	}
+	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+		assert.True(t, testutils.SameEndpointLabels(mGot["Create"], mExpected["Create"]))
+		assert.True(t, testutils.SameEndpointLabels(mGot["UpdateNew"], mExpected["UpdateNew"]))
+		assert.True(t, testutils.SameEndpointLabels(mGot["UpdateOld"], mExpected["UpdateOld"]))
+		assert.True(t, testutils.SameEndpointLabels(mGot["Delete"], mExpected["Delete"]))
+		assert.Equal(t, nil, ctx.Value(provider.RecordsContextKey))
+	}
+	err := r.ApplyChanges(ctx, changes)
+	require.NoError(t, err)
 }
 
 func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
@@ -546,72 +624,116 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	}
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.cname-tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+
+			// EP4
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("txt.owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "\"\""),
+
+			// EP5
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
+			endpoint.NewEndpoint("txt.owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT, "\"\"").WithSetIdentifier("test-set-1"),
+
+			// EP6 / EP8
+			endpoint.NewEndpoint("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "tar.loadbalancer.com"),
+			// do not create this TXT record. Simulates scenario when CNAME record already exists from another owner
+			// on plan.Calsulate() the cname record will be moved to update, however TXTs are unique per owner
+			// so we should have this appear in create request instead of an update
+			// newEndpointWithOwner("txt.owner111-cname-tar.test-zone.example.org", endpoint.RecordTypeTXT, "", "\"heritage=external-dns,external-dns/owner=owner111\""),
+
+			// EP7 / EP9
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			endpoint.NewEndpoint("txt.owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT, "\"\"").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
+	// Update registry with content of the zone (create request above)
+	// otherwise will be creating exising TXT records
+	_, _ = r.Records(ctx)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
-			newEndpointWithOwnerResource("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
+			// EP1 - a new cname
+			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+
+			// EP2 - a new cname with set id
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "lb3.loadbalancer.com").WithSetIdentifier("test-set-3"),
+
+			// EP3 - a new cname outside the zone
+			newEndpointWithOwnerResource("example", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
+			//EP4 - deleting cname
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
+
+			// EP5 - deleting cname with set id
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
+			// EP6 - updating cname
+			newEndpointWithOwnerResource("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new-tar.loadbalancer.com"),
+
+			// EP7 - updating cname with set id
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new.loadbalancer.com").WithSetIdentifier("test-set-2"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
+			// EP8 - updating EP6
+			newEndpointWithOwner("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "tar.loadbalancer.com"),
+
+			// EP9 - updating old cname with set id
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
 		},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-3"),
-			newEndpointWithOwnerResource("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-example", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "example"),
+			// EP1
+			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("txt.owner111-cname-new-record-1.test-zone.example.org", endpoint.RecordTypeTXT, "new-record-1.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
+
+			// EP2
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "lb3.loadbalancer.com").WithSetIdentifier("test-set-3"),
+			newEndpointWithOwnedRecord("txt.owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\"").WithSetIdentifier("test-set-3"),
+
+			// EP3
+			newEndpointWithOwnerResource("example", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("txt.owner111-cname-example", endpoint.RecordTypeTXT, "example",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
+
+			// EP6
+			newEndpointWithOwnedRecord("txt.owner111-cname-tar.test-zone.example.org", endpoint.RecordTypeTXT, "tar.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress-2\""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-1"),
+			// EP4
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
+			newEndpointWithOwnedRecord("txt.owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "foobar.test-zone.example.org"),
+
+			// EP5
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwnedRecord("txt.owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org").WithSetIdentifier("test-set-1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, "", "tar.test-zone.example.org"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-2"),
+			// EP6
+			newEndpointWithOwnerResource("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new-tar.loadbalancer.com"),
+			// this change is transferred to the create
+			//newEndpointWithOwnerAndOwnedRecord("txt.owner111-cname-tar.test-zone.example.org", endpoint.RecordTypeTXT, "", "tar.test-zone.example.org",
+			//	"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress-2\""),
+
+			// EP7
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwnedRecord("txt.owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress-2\"").WithSetIdentifier("test-set-2"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "tar.test-zone.example.org"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-2"),
+			// EP8
+			newEndpointWithOwner("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "tar.loadbalancer.com"),
+			// this change is transfered to the create and overriden with updateNew
+			//newEndpointWithOwnerAndOwnedRecord("txt.owner111-cname-tar.test-zone.example.org", endpoint.RecordTypeTXT, "", "tar.test-zone.example.org"),
+
+			// EP9
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwnedRecord("txt.owner111-cname-multiple.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org").WithSetIdentifier("test-set-2"),
 		},
 	}
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
@@ -645,10 +767,11 @@ func testTXTRegistryApplyChangesWithTemplatedPrefix(t *testing.T) {
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{},
 	})
-	r, _ := NewTXTRegistry(context.Background(), p, "prefix%{record_type}.", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "prefix%{record_type}.", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
+
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
+			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
 		},
 		Delete:    []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
@@ -656,8 +779,9 @@ func testTXTRegistryApplyChangesWithTemplatedPrefix(t *testing.T) {
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("prefixcname.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
+			newEndpointWithResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("prefixcname.owner111-new-record-1.test-zone.example.org", endpoint.RecordTypeTXT, "new-record-1.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
 		},
 	}
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
@@ -688,10 +812,11 @@ func testTXTRegistryApplyChangesWithTemplatedSuffix(t *testing.T) {
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
 		assert.Equal(t, ctxEndpoints, ctx.Value(provider.RecordsContextKey))
 	}
-	r, _ := NewTXTRegistry(context.Background(), p, "", "-%{record_type}suffix", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "-%{record_type}suffix", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
+
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
+			newEndpointWithResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
 		},
 		Delete:    []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
@@ -699,8 +824,9 @@ func testTXTRegistryApplyChangesWithTemplatedSuffix(t *testing.T) {
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("new-record-1-cnamesuffix.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
+			newEndpointWithResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("new-record-1-owner111-cnamesuffix.test-zone.example.org", endpoint.RecordTypeTXT, "new-record-1.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
 		},
 	}
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
@@ -733,76 +859,114 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 	}
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar-txt.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("cname-bar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("tar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("cname-tar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("cname-foobar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("cname-multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("cname-multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
+			// EP5
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("cname-foobar-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "\"\""),
+
+			// EP6
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
+			endpoint.NewEndpoint("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "\"\"").WithSetIdentifier("test-set-1"),
+
+			// EP9
+			endpoint.NewEndpoint("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "tar.loadbalancer.com"),
+			endpoint.NewEndpoint("cname-tar-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "\"\""),
+
+			// EP10
+			endpoint.NewEndpoint("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			endpoint.NewEndpoint("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "\"\"").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(context.Background(), p, "", "-txt", "owner", time.Hour, "wildcard", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "-txt", "owner111", time.Hour, "wildcard", []string{}, []string{}, false, nil)
+	// Update registry with content of the zone (create request above)
+	// otherwise will be creating exising TXT records
+	_, _ = r.Records(ctx)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
-			newEndpointWithOwnerResource("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
-			newEndpointWithOwnerResource("*.wildcard.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
+			// EP1 - a new record
+			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+
+			// EP2 - a new record with set id
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "lb3.loadbalancer.com").WithSetIdentifier("test-set-3"),
+
+			// EP3 - a new record outside zone
+			newEndpointWithOwnerResource("example", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+
+			// EP4 - a new wildcard record
+			newEndpointWithOwnerResource("*.wildcard.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
+			// EP5 - delete cname
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
+
+			// EP6 - delete cname with set id
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
+			// EP7 - updating new record
+			newEndpointWithOwnerResource("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new-tar.loadbalancer.com"),
+
+			// EP8 - updating new record with set id
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new.loadbalancer.com").WithSetIdentifier("test-set-2"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
+			// EP9 - updating old record
+			newEndpointWithOwner("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "tar.loadbalancer.com"),
+
+			// EP10 - updating old record with set id
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
 		},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("cname-new-record-1-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "lb3.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress").WithSetIdentifier("test-set-3"),
-			newEndpointWithOwnerAndOwnedRecord("cname-multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-3"),
-			newEndpointWithOwnerResource("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("cname-example-txt", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "example"),
-			newEndpointWithOwnerResource("*.wildcard.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress"),
-			newEndpointWithOwnerAndOwnedRecord("cname-wildcard-txt.wildcard.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress\"", endpoint.RecordTypeTXT, "", "*.wildcard.test-zone.example.org"),
+			// EP1
+			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("cname-new-record-1-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "new-record-1.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
+
+			// EP2
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "lb3.loadbalancer.com").WithSetIdentifier("test-set-3"),
+			newEndpointWithOwnedRecord("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\"").WithSetIdentifier("test-set-3"),
+
+			// EP3
+			newEndpointWithOwnerResource("example", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("cname-example-owner111-txt", endpoint.RecordTypeTXT, "example",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
+
+			// EP4
+			newEndpointWithOwnerResource("*.wildcard.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("cname-wildcard-owner111-txt.wildcard.test-zone.example.org", endpoint.RecordTypeTXT, "*.wildcard.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress\""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-foobar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwnerAndOwnedRecord("cname-multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-1"),
+			// EP5
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
+			newEndpointWithOwnedRecord("cname-foobar-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "foobar.test-zone.example.org"),
+
+			// EP6
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb1.loadbalancer.com").WithSetIdentifier("test-set-1"),
+			newEndpointWithOwnedRecord("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org").WithSetIdentifier("test-set-1"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwnerResource("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2"),
-			newEndpointWithOwnerAndOwnedRecord("cname-tar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, "", "tar.test-zone.example.org"),
-			newEndpointWithOwnerResource("multiple.test-zone.example.org", "new.loadbalancer.com", endpoint.RecordTypeCNAME, "owner", "ingress/default/my-ingress-2").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwnerAndOwnedRecord("cname-multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner,external-dns/resource=ingress/default/my-ingress-2\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-2"),
+			// EP7
+			newEndpointWithOwnerResource("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new-tar.loadbalancer.com"),
+			newEndpointWithOwnedRecord("cname-tar-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "tar.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress-2\""),
+
+			// EP8
+			newEndpointWithOwnerResource("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "ingress/default/my-ingress-2", "new.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwnedRecord("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org",
+				"\"heritage=external-dns,external-dns/resource=ingress/default/my-ingress-2\"").WithSetIdentifier("test-set-2"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-tar-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "tar.test-zone.example.org"),
-			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "owner").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwnerAndOwnedRecord("cname-multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "multiple.test-zone.example.org").WithSetIdentifier("test-set-2"),
+			// EP9
+			newEndpointWithOwner("tar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "tar.loadbalancer.com"),
+			newEndpointWithOwnedRecord("cname-tar-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "tar.test-zone.example.org"),
+
+			// EP10
+			newEndpointWithOwner("multiple.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "lb2.loadbalancer.com").WithSetIdentifier("test-set-2"),
+			newEndpointWithOwnedRecord("cname-multiple-owner111-txt.test-zone.example.org", endpoint.RecordTypeTXT, "multiple.test-zone.example.org").WithSetIdentifier("test-set-2"),
 		},
 	}
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
@@ -835,43 +999,51 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	}
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			// EP4
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "\"\""),
 		},
 	})
-	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
+	// Update registry with content of the zone (create request above)
+	// otherwise will be creating exising TXT records
+	_, _ = r.Records(ctx)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("new-alias.test-zone.example.org", "my-domain.com", endpoint.RecordTypeA, "").WithProviderSpecific("alias", "true"),
+			// EP1 - new cname
+			newEndpointWithOwner("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
+			// EP2 - new cname outside zone
+			newEndpointWithOwner("example", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
+			// EP3 - new cname with alial
+			newEndpointWithOwner("new-alias.test-zone.example.org", endpoint.RecordTypeA, "owner111", "my-domain.com").WithProviderSpecific("alias", "true"),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			// EP4 - delete cname
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
 		},
 		UpdateNew: []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
-			newEndpointWithOwner("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-example", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "example"),
-			newEndpointWithOwner("new-alias.test-zone.example.org", "my-domain.com", endpoint.RecordTypeA, "owner").WithProviderSpecific("alias", "true"),
+			// EP1
+			newEndpointWithOwner("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("owner111-cname-new-record-1.test-zone.example.org", endpoint.RecordTypeTXT, "new-record-1.test-zone.example.org"),
+
+			// EP2
+			newEndpointWithOwner("example", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("owner111-cname-example", endpoint.RecordTypeTXT, "example"),
+
+			// EP3
+			newEndpointWithOwner("new-alias.test-zone.example.org", endpoint.RecordTypeA, "owner111", "my-domain.com").WithProviderSpecific("alias", "true"),
 			// TODO: It's not clear why the TXT registry copies ProviderSpecificProperties to ownership records; that doesn't seem correct.
-			newEndpointWithOwnerAndOwnedRecord("cname-new-alias.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "new-alias.test-zone.example.org").WithProviderSpecific("alias", "true"),
+			newEndpointWithOwnedRecord("owner111-cname-new-alias.test-zone.example.org", endpoint.RecordTypeTXT, "new-alias.test-zone.example.org").WithProviderSpecific("alias", "true"),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
+			// EP4
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
+			newEndpointWithOwnedRecord("owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "foobar.test-zone.example.org"),
 		},
 		UpdateNew: []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
@@ -907,30 +1079,47 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("oldformat.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("oldformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("oldformat2.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("oldformat2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("newformat.test-zone.example.org", "foobar.nameserver.com", endpoint.RecordTypeNS, ""),
-			newEndpointWithOwner("ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=otherowner\"", endpoint.RecordTypeTXT, ""),
+			// EP1 - old (V1) format cname
+			endpoint.NewEndpoint("v1format.test-zone.example.org", endpoint.RecordTypeCNAME, "foo.loadbalancer.com"),
+			endpoint.NewEndpoint("v1format.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner111\""),
+
+			// EP2 - old (V2) format A record
+			endpoint.NewEndpoint("v2format.test-zone.example.org", endpoint.RecordTypeA, "bar.loadbalancer.com"),
+			endpoint.NewEndpoint("a-v2format.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner111\""),
+
+			// EP3 - new (V3) format ns recod
+			endpoint.NewEndpoint("newformat.test-zone.example.org", endpoint.RecordTypeNS, "foobar.nameserver.com"),
+			endpoint.NewEndpoint("owner111-ns-newformat.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP4 - txt record of new format (V3) that has no endpoint associated - should not be returned
+			endpoint.NewEndpoint("newformat.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP5 - txt record with invalid heritage - will be returned
+			endpoint.NewEndpoint("noheritage.test-zone.example.org", endpoint.RecordTypeTXT, "random"),
+
+			// EP6 - old (V2) format with a different owner
+			endpoint.NewEndpoint("oldformat-otherowner.test-zone.example.org", endpoint.RecordTypeA, "bar.loadbalancer.com"),
+			endpoint.NewEndpoint("a-oldformat-otherowner.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner222\""),
+
+			// EP7 - unmanaged A record
 			endpoint.NewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
+
+			// EP8 - unmanaged cname
 			endpoint.NewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
-			newEndpointWithOwner("this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+
+			// EP9 - long cname
+			endpoint.NewEndpoint("llong-63-characters-label-that-we-expect-to-work.test-zone.example.org", endpoint.RecordTypeCNAME, "foo.loadbalancer.com"),
+			endpoint.NewEndpoint("owner111-cname-llong-63-characters-label-that-we-expect-to-work.test-zone.example.org", endpoint.RecordTypeTXT),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
+		// EP1
 		{
-			DNSName:    "oldformat.test-zone.example.org",
+			DNSName:    "v1format.test-zone.example.org",
 			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				// owner was added from the TXT record's target
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 			ProviderSpecific: []endpoint.ProviderSpecificProperty{
 				{
@@ -939,12 +1128,13 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 				},
 			},
 		},
+		// EP2
 		{
-			DNSName:    "oldformat2.test-zone.example.org",
+			DNSName:    "v2format.test-zone.example.org",
 			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 			ProviderSpecific: []endpoint.ProviderSpecificProperty{
 				{
@@ -953,57 +1143,64 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 				},
 			},
 		},
+		// EP3
 		{
 			DNSName:    "newformat.test-zone.example.org",
 			Targets:    endpoint.Targets{"foobar.nameserver.com"},
 			RecordType: endpoint.RecordTypeNS,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 		},
-		// Only TXT records with the wrong heritage are returned by Records()
+		// EP5
 		{
 			DNSName:    "noheritage.test-zone.example.org",
 			Targets:    endpoint.Targets{"random"},
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				// No owner because it's not external-dns heritage
-				endpoint.OwnerLabelKey: "",
-			},
+			Labels:     endpoint.NewLabels(), // No owner because it's not external-dns heritage
+
 		},
+		// EP6
 		{
 			DNSName:    "oldformat-otherowner.test-zone.example.org",
 			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
 				// Records() retrieves all the records of the zone, no matter the owner
-				endpoint.OwnerLabelKey: "otherowner",
+				// the labes is of the old format as this record is not with current owner
+				"": endpoint.OwnerLabelKey + "=owner222",
 			},
 		},
+		// EP7
 		{
 			DNSName:    "unmanaged1.test-zone.example.org",
 			Targets:    endpoint.Targets{"unmanaged1.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeA,
+			Labels:     endpoint.NewLabels(),
 		},
+		// EP8
 		{
 			DNSName:    "unmanaged2.test-zone.example.org",
 			Targets:    endpoint.Targets{"unmanaged2.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     endpoint.NewLabels(),
 		},
+		// EP9
 		{
-			DNSName:    "this-is-a-63-characters-long-label-that-we-do-expect-will-work.test-zone.example.org",
+			DNSName:    "llong-63-characters-label-that-we-expect-to-work.test-zone.example.org",
 			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 		},
 	}
 
-	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "wc", []string{endpoint.RecordTypeCNAME, endpoint.RecordTypeA, endpoint.RecordTypeNS}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner111", time.Hour, "wc", []string{endpoint.RecordTypeCNAME, endpoint.RecordTypeA, endpoint.RecordTypeNS}, []string{}, false, nil)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 }
 
 func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
@@ -1012,30 +1209,53 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("oldformat.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.oldformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("oldformat2.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("txt.oldformat2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("newformat.test-zone.example.org", "foobar.nameserver.com", endpoint.RecordTypeNS, ""),
-			newEndpointWithOwner("txt.ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("oldformat3.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.oldformat3.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
-			newEndpointWithOwner("txt.oldformat-otherowner.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=otherowner\"", endpoint.RecordTypeTXT, ""),
+			// EP1 - old (v1) format cname
+			endpoint.NewEndpoint("v1format.test-zone.example.org", endpoint.RecordTypeCNAME, "foo.loadbalancer.com"),
+			endpoint.NewEndpoint("txt.v1format.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner111\""),
+
+			// EP2 - old (V2) format a record
+			endpoint.NewEndpoint("v2format2.test-zone.example.org", endpoint.RecordTypeA, "bar.loadbalancer.com"),
+			endpoint.NewEndpoint("txt.a-v2format2.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner111\""),
+
+			// EP3 - new (V3) format ns record
+			endpoint.NewEndpoint("newformat.test-zone.example.org", endpoint.RecordTypeNS, "foobar.nameserver.com"),
+			endpoint.NewEndpoint("txt.owner111-ns-newformat.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP4 - TXT record with invalid herritage will be returned
+			endpoint.NewEndpoint("oldformat3.test-zone.example.org", endpoint.RecordTypeTXT, "random"),
+
+			// EP5 - TXT record of old (V1) format with no endpoint - not returned
+			endpoint.NewEndpoint("txt.oldformat3.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner111\""),
+
+			// EP6 - TXT record of old (V2) format with no endpoint - not returned
+			endpoint.NewEndpoint("txt.cname-oldformat3.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner111\""),
+
+			// EP7 - TXT record of new format (V3) with no endpoin - not returned
+			endpoint.NewEndpoint("txt.newformat.test-zone.example.org", endpoint.RecordTypeTXT),
+
+			// EP8 - TXT record with invalid heritage - returned
+			endpoint.NewEndpoint("noheritage.test-zone.example.org", endpoint.RecordTypeTXT, "random"),
+
+			// EP9 - old format (V1) a record
+			endpoint.NewEndpoint("oldformat-otherowner.test-zone.example.org", endpoint.RecordTypeA, "bar.loadbalancer.com"),
+			endpoint.NewEndpoint("txt.oldformat-otherowner.test-zone.example.org", endpoint.RecordTypeTXT, "\"heritage=external-dns,external-dns/owner=owner222\""),
+
+			// EP10 - unmanaged a record
 			endpoint.NewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
+
+			// EP11 - unmanaged cname record
 			endpoint.NewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
+		// EP1
 		{
-			DNSName:    "oldformat.test-zone.example.org",
+			DNSName:    "v1format.test-zone.example.org",
 			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				// owner was added from the TXT record's target
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 			ProviderSpecific: []endpoint.ProviderSpecificProperty{
 				{
@@ -1044,12 +1264,13 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 				},
 			},
 		},
+		// EP2
 		{
-			DNSName:    "oldformat2.test-zone.example.org",
+			DNSName:    "v2format2.test-zone.example.org",
 			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 			ProviderSpecific: []endpoint.ProviderSpecificProperty{
 				{
@@ -1058,71 +1279,78 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 				},
 			},
 		},
-		{
-			DNSName:    "oldformat3.test-zone.example.org",
-			Targets:    endpoint.Targets{"random"},
-			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
-			ProviderSpecific: []endpoint.ProviderSpecificProperty{
-				{
-					Name:  "txt/force-update",
-					Value: "true",
-				},
-			},
-		},
+		// EP3
 		{
 			DNSName:    "newformat.test-zone.example.org",
 			Targets:    endpoint.Targets{"foobar.nameserver.com"},
 			RecordType: endpoint.RecordTypeNS,
 			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
+				"owner111": "",
 			},
 		},
+		// EP4
+		{
+			DNSName:    "oldformat3.test-zone.example.org",
+			Targets:    endpoint.Targets{"random"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				"owner111": "",
+			},
+			ProviderSpecific: []endpoint.ProviderSpecificProperty{
+				{
+					Name:  "txt/force-update",
+					Value: "true",
+				},
+			},
+		},
+		// EP8
 		{
 			DNSName:    "noheritage.test-zone.example.org",
 			Targets:    endpoint.Targets{"random"},
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				// No owner because it's not external-dns heritage
-				endpoint.OwnerLabelKey: "",
-			},
+			Labels:     endpoint.NewLabels(), // No owner because it's not external-dns heritage
 		},
+		// EP9
 		{
 			DNSName:    "oldformat-otherowner.test-zone.example.org",
 			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeA,
 			Labels: map[string]string{
 				// All the records of the zone are retrieved, no matter the owner
-				endpoint.OwnerLabelKey: "otherowner",
+				// old format of the labes since we don't manage this record
+				"": endpoint.OwnerLabelKey + "=owner222",
 			},
 		},
+		// EP10
 		{
 			DNSName:    "unmanaged1.test-zone.example.org",
 			Targets:    endpoint.Targets{"unmanaged1.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeA,
+			Labels:     endpoint.NewLabels(),
 		},
+		// EP11
 		{
 			DNSName:    "unmanaged2.test-zone.example.org",
 			Targets:    endpoint.Targets{"unmanaged2.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
+			Labels:     endpoint.NewLabels(),
 		},
 	}
 
-	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner", time.Hour, "wc", []string{endpoint.RecordTypeCNAME, endpoint.RecordTypeA, endpoint.RecordTypeNS, endpoint.RecordTypeTXT}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner111", time.Hour, "wc", []string{endpoint.RecordTypeCNAME, endpoint.RecordTypeA, endpoint.RecordTypeNS, endpoint.RecordTypeTXT}, []string{}, false, nil)
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 }
 
 func TestCacheMethods(t *testing.T) {
 	cache := []*endpoint.Endpoint{
-		newEndpointWithOwner("thing.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing1.com", "1.2.3.6", "A", "owner"),
-		newEndpointWithOwner("thing2.com", "1.2.3.4", "CNAME", "owner"),
-		newEndpointWithOwner("thing3.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing4.com", "1.2.3.4", "A", "owner"),
+		newEndpointWithOwner("thing.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing1.com", "A", "owner", "1.2.3.6"),
+		newEndpointWithOwner("thing2.com", "CNAME", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing3.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing4.com", "A", "owner", "1.2.3.4"),
 	}
 	registry := &TXTRegistry{
 		recordsCache:  cache,
@@ -1130,249 +1358,56 @@ func TestCacheMethods(t *testing.T) {
 	}
 
 	expectedCacheAfterAdd := []*endpoint.Endpoint{
-		newEndpointWithOwner("thing.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing1.com", "1.2.3.6", "A", "owner"),
-		newEndpointWithOwner("thing2.com", "1.2.3.4", "CNAME", "owner"),
-		newEndpointWithOwner("thing3.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing4.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing4.com", "2001:DB8::1", "AAAA", "owner"),
-		newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"),
+		newEndpointWithOwner("thing.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing1.com", "A", "owner", "1.2.3.6"),
+		newEndpointWithOwner("thing2.com", "CNAME", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing3.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing4.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing4.com", "AAAA", "owner", "2001:DB8::1"),
+		newEndpointWithOwner("thing5.com", "A", "owner", "1.2.3.5"),
 	}
 
 	expectedCacheAfterUpdate := []*endpoint.Endpoint{
-		newEndpointWithOwner("thing1.com", "1.2.3.6", "A", "owner"),
-		newEndpointWithOwner("thing2.com", "1.2.3.4", "CNAME", "owner"),
-		newEndpointWithOwner("thing3.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing4.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"),
-		newEndpointWithOwner("thing.com", "1.2.3.6", "A", "owner2"),
-		newEndpointWithOwner("thing4.com", "2001:DB8::2", "AAAA", "owner"),
+		newEndpointWithOwner("thing1.com", "A", "owner", "1.2.3.6"),
+		newEndpointWithOwner("thing2.com", "CNAME", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing3.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing4.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing5.com", "A", "owner", "1.2.3.5"),
+		newEndpointWithOwner("thing.com", "A", "owner2", "1.2.3.6"),
+		newEndpointWithOwner("thing4.com", "AAAA", "owner", "2001:DB8::2"),
 	}
 
 	expectedCacheAfterDelete := []*endpoint.Endpoint{
-		newEndpointWithOwner("thing1.com", "1.2.3.6", "A", "owner"),
-		newEndpointWithOwner("thing2.com", "1.2.3.4", "CNAME", "owner"),
-		newEndpointWithOwner("thing3.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing4.com", "1.2.3.4", "A", "owner"),
-		newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"),
+		newEndpointWithOwner("thing1.com", "A", "owner", "1.2.3.6"),
+		newEndpointWithOwner("thing2.com", "CNAME", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing3.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing4.com", "A", "owner", "1.2.3.4"),
+		newEndpointWithOwner("thing5.com", "A", "owner", "1.2.3.5"),
 	}
 	// test add cache
-	registry.addToCache(newEndpointWithOwner("thing4.com", "2001:DB8::1", "AAAA", "owner"))
-	registry.addToCache(newEndpointWithOwner("thing5.com", "1.2.3.5", "A", "owner"))
+	registry.addToCache(newEndpointWithOwner("thing4.com", "AAAA", "owner", "2001:DB8::1"))
+	registry.addToCache(newEndpointWithOwner("thing5.com", "A", "owner", "1.2.3.5"))
 
 	if !reflect.DeepEqual(expectedCacheAfterAdd, registry.recordsCache) {
 		t.Fatalf("expected endpoints should match endpoints from cache: expected %v, but got %v", expectedCacheAfterAdd, registry.recordsCache)
 	}
 
 	// test update cache
-	registry.removeFromCache(newEndpointWithOwner("thing.com", "1.2.3.4", "A", "owner"))
-	registry.addToCache(newEndpointWithOwner("thing.com", "1.2.3.6", "A", "owner2"))
-	registry.removeFromCache(newEndpointWithOwner("thing4.com", "2001:DB8::1", "AAAA", "owner"))
-	registry.addToCache(newEndpointWithOwner("thing4.com", "2001:DB8::2", "AAAA", "owner"))
+	registry.removeFromCache(newEndpointWithOwner("thing.com", "A", "owner", "1.2.3.4"))
+	registry.addToCache(newEndpointWithOwner("thing.com", "A", "owner2", "1.2.3.6"))
+	registry.removeFromCache(newEndpointWithOwner("thing4.com", "AAAA", "owner", "2001:DB8::1"))
+	registry.addToCache(newEndpointWithOwner("thing4.com", "AAAA", "owner", "2001:DB8::2"))
 	// ensure it was updated
 	if !reflect.DeepEqual(expectedCacheAfterUpdate, registry.recordsCache) {
 		t.Fatalf("expected endpoints should match endpoints from cache: expected %v, but got %v", expectedCacheAfterUpdate, registry.recordsCache)
 	}
 
 	// test deleting a record
-	registry.removeFromCache(newEndpointWithOwner("thing.com", "1.2.3.6", "A", "owner2"))
-	registry.removeFromCache(newEndpointWithOwner("thing4.com", "2001:DB8::2", "AAAA", "owner"))
+	registry.removeFromCache(newEndpointWithOwner("thing.com", "A", "owner2", "1.2.3.6"))
+	registry.removeFromCache(newEndpointWithOwner("thing4.com", "AAAA", "owner", "2001:DB8::2"))
 	// ensure it was deleted
 	if !reflect.DeepEqual(expectedCacheAfterDelete, registry.recordsCache) {
 		t.Fatalf("expected endpoints should match endpoints from cache: expected %v, but got %v", expectedCacheAfterDelete, registry.recordsCache)
-	}
-}
-
-func TestDropPrefix(t *testing.T) {
-	mapper := newaffixNameMapper("foo-%{record_type}-", "", "")
-	expectedOutput := "test.example.com"
-
-	tests := []string{
-		"foo-cname-test.example.com",
-		"foo-a-test.example.com",
-		"foo--test.example.com",
-	}
-
-	for _, tc := range tests {
-		t.Run(tc, func(t *testing.T) {
-			actualOutput, _ := mapper.dropAffixExtractType(tc)
-			assert.Equal(t, expectedOutput, actualOutput)
-		})
-	}
-}
-
-func TestDropSuffix(t *testing.T) {
-	mapper := newaffixNameMapper("", "-%{record_type}-foo", "")
-	expectedOutput := "test.example.com"
-
-	tests := []string{
-		"test-a-foo.example.com",
-		"test--foo.example.com",
-	}
-
-	for _, tc := range tests {
-		t.Run(tc, func(t *testing.T) {
-			r := strings.SplitN(tc, ".", 2)
-			rClean, _ := mapper.dropAffixExtractType(r[0])
-			actualOutput := rClean + "." + r[1]
-			assert.Equal(t, expectedOutput, actualOutput)
-		})
-	}
-}
-
-func TestExtractRecordTypeDefaultPosition(t *testing.T) {
-	tests := []struct {
-		input        string
-		expectedName string
-		expectedType string
-	}{
-		{
-			input:        "ns-zone.example.com",
-			expectedName: "zone.example.com",
-			expectedType: "NS",
-		},
-		{
-			input:        "aaaa-zone.example.com",
-			expectedName: "zone.example.com",
-			expectedType: "AAAA",
-		},
-		{
-			input:        "ptr-zone.example.com",
-			expectedName: "ptr-zone.example.com",
-			expectedType: "",
-		},
-		{
-			input:        "zone.example.com",
-			expectedName: "zone.example.com",
-			expectedType: "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			actualName, actualType := extractRecordTypeDefaultPosition(tc.input)
-			assert.Equal(t, tc.expectedName, actualName)
-			assert.Equal(t, tc.expectedType, actualType)
-		})
-	}
-}
-
-func TestToEndpointNameNewTXT(t *testing.T) {
-	tests := []struct {
-		name       string
-		mapper     affixNameMapper
-		domain     string
-		txtDomain  string
-		recordType string
-	}{
-		{
-			name:       "prefix",
-			mapper:     newaffixNameMapper("foo", "", ""),
-			domain:     "example.com",
-			recordType: "A",
-			txtDomain:  "fooa-example.com",
-		},
-		{
-			name:       "suffix",
-			mapper:     newaffixNameMapper("", "foo", ""),
-			domain:     "example.com",
-			recordType: "AAAA",
-			txtDomain:  "aaaa-examplefoo.com",
-		},
-		{
-			name:       "prefix with dash",
-			mapper:     newaffixNameMapper("foo-", "", ""),
-			domain:     "example.com",
-			recordType: "A",
-			txtDomain:  "foo-a-example.com",
-		},
-		{
-			name:       "suffix with dash",
-			mapper:     newaffixNameMapper("", "-foo", ""),
-			domain:     "example.com",
-			recordType: "CNAME",
-			txtDomain:  "cname-example-foo.com",
-		},
-		{
-			name:       "prefix with dot",
-			mapper:     newaffixNameMapper("foo.", "", ""),
-			domain:     "example.com",
-			recordType: "CNAME",
-			txtDomain:  "foo.cname-example.com",
-		},
-		{
-			name:       "suffix with dot",
-			mapper:     newaffixNameMapper("", ".foo", ""),
-			domain:     "example.com",
-			recordType: "CNAME",
-			txtDomain:  "cname-example.foo.com",
-		},
-		{
-			name:       "prefix with multiple dots",
-			mapper:     newaffixNameMapper("foo.bar.", "", ""),
-			domain:     "example.com",
-			recordType: "CNAME",
-			txtDomain:  "foo.bar.cname-example.com",
-		},
-		{
-			name:       "suffix with multiple dots",
-			mapper:     newaffixNameMapper("", ".foo.bar.test", ""),
-			domain:     "example.com",
-			recordType: "CNAME",
-			txtDomain:  "cname-example.foo.bar.test.com",
-		},
-		{
-			name:       "templated prefix",
-			mapper:     newaffixNameMapper("%{record_type}-foo", "", ""),
-			domain:     "example.com",
-			recordType: "A",
-			txtDomain:  "a-fooexample.com",
-		},
-		{
-			name:       "templated suffix",
-			mapper:     newaffixNameMapper("", "foo-%{record_type}", ""),
-			domain:     "example.com",
-			recordType: "A",
-			txtDomain:  "examplefoo-a.com",
-		},
-		{
-			name:       "templated prefix with dot",
-			mapper:     newaffixNameMapper("%{record_type}foo.", "", ""),
-			domain:     "example.com",
-			recordType: "CNAME",
-			txtDomain:  "cnamefoo.example.com",
-		},
-		{
-			name:       "templated suffix with dot",
-			mapper:     newaffixNameMapper("", ".foo%{record_type}", ""),
-			domain:     "example.com",
-			recordType: "A",
-			txtDomain:  "example.fooa.com",
-		},
-		{
-			name:       "templated prefix with multiple dots",
-			mapper:     newaffixNameMapper("bar.%{record_type}.foo.", "", ""),
-			domain:     "example.com",
-			recordType: "CNAME",
-			txtDomain:  "bar.cname.foo.example.com",
-		},
-		{
-			name:       "templated suffix with multiple dots",
-			mapper:     newaffixNameMapper("", ".foo%{record_type}.bar", ""),
-			domain:     "example.com",
-			recordType: "A",
-			txtDomain:  "example.fooa.bar.com",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			txtDomain := tc.mapper.toNewTXTName(tc.domain, tc.recordType)
-			assert.Equal(t, tc.txtDomain, txtDomain)
-
-			domain, _ := tc.mapper.toEndpointName(txtDomain)
-			assert.Equal(t, tc.domain, domain)
-		})
 	}
 }
 
@@ -1386,41 +1421,40 @@ func TestNewTXTScheme(t *testing.T) {
 	}
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			// EP3
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			endpoint.NewEndpoint("owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "\"\""),
 		},
 	})
-	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, ""),
+			// EP1
+			newEndpointWithOwner("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
+			// EP2
+			newEndpointWithOwner("example", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			// EP3
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
 		},
 		UpdateNew: []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "new-record-1.test-zone.example.org"),
-			newEndpointWithOwner("example", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-example", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "example"),
+			// EP1
+			newEndpointWithOwner("new-record-1.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("owner111-cname-new-record-1.test-zone.example.org", endpoint.RecordTypeTXT, "new-record-1.test-zone.example.org"),
+			// EP2
+			newEndpointWithOwner("example", endpoint.RecordTypeCNAME, "owner111", "new-loadbalancer-1.lb.com"),
+			newEndpointWithOwnedRecord("owner111-cname-example", endpoint.RecordTypeTXT, "example"),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
+			// EP3
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
+			newEndpointWithOwnedRecord("owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "foobar.test-zone.example.org"),
 		},
 		UpdateNew: []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
@@ -1446,11 +1480,11 @@ func TestNewTXTScheme(t *testing.T) {
 }
 
 func TestGenerateTXT(t *testing.T) {
-	record := newEndpointWithOwner("foo.test-zone.example.org", "new-foo.loadbalancer.com", endpoint.RecordTypeCNAME, "owner")
+	record := newEndpointWithOwner("foo.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "new-foo.loadbalancer.com")
 	expectedTXT := []*endpoint.Endpoint{
 		{
-			DNSName:    "cname-foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			DNSName:    "owner111-cname-foo.test-zone.example.org",
+			Targets:    endpoint.Targets{"\"\""},
 			RecordType: endpoint.RecordTypeTXT,
 			Labels: map[string]string{
 				endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
@@ -1459,17 +1493,17 @@ func TestGenerateTXT(t *testing.T) {
 	}
 	p := inmemory.NewInMemoryProvider()
 	p.CreateZone(testZone)
-	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
 	gotTXT := r.generateTXTRecord(record)
 	assert.Equal(t, expectedTXT, gotTXT)
 }
 
 func TestGenerateTXTForAAAA(t *testing.T) {
-	record := newEndpointWithOwner("foo.test-zone.example.org", "2001:DB8::1", endpoint.RecordTypeAAAA, "owner")
+	record := newEndpointWithOwner("foo.test-zone.example.org", endpoint.RecordTypeAAAA, "owner111", "2001:DB8::1")
 	expectedTXT := []*endpoint.Endpoint{
 		{
-			DNSName:    "aaaa-foo.test-zone.example.org",
-			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			DNSName:    "owner111-aaaa-foo.test-zone.example.org",
+			Targets:    endpoint.Targets{"\"\""},
 			RecordType: endpoint.RecordTypeTXT,
 			Labels: map[string]string{
 				endpoint.OwnedRecordLabelKey: "foo.test-zone.example.org",
@@ -1478,7 +1512,7 @@ func TestGenerateTXTForAAAA(t *testing.T) {
 	}
 	p := inmemory.NewInMemoryProvider()
 	p.CreateZone(testZone)
-	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
 	gotTXT := r.generateTXTRecord(record)
 	assert.Equal(t, expectedTXT, gotTXT)
 }
@@ -1495,7 +1529,7 @@ func TestFailGenerateTXT(t *testing.T) {
 	expectedTXT := []*endpoint.Endpoint{}
 	p := inmemory.NewInMemoryProvider()
 	p.CreateZone(testZone)
-	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "", "", "owner111", time.Hour, "", []string{}, []string{}, false, nil)
 	gotTXT := r.generateTXTRecord(cnameRecord)
 	assert.Equal(t, expectedTXT, gotTXT)
 }
@@ -1508,12 +1542,15 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-foobar.test-zone.example.org", "\"h8UQ6jelUFUsEIn7SbFktc2MYXPx/q8lySqI4VwfVtVaIbb2nkHWV/88KKbuLtu7fJNzMir8ELVeVnRSY01KdiIuj7ledqZe5ailEjQaU5Z6uEKd5pgs6sH8\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "foobar.loadbalancer.com"),
+			// joined target:
+			// key: value
+			// txt-encryption-nonce: bqnDtPa1Eo9P4xsu
+			newEndpointWithOwnedRecord("txt.owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "foobar.test-zone.example.org", "\"bqnDtPa1Eo9P4xsu1Qo+YZJ1sD+VoEvSVYD/l8sYGtdl25Rg7bffPWJxIS0DexvjY2ykzIOTpSQKad4sdX8C0XVB9hxZgajQ7KPb8JEKN+5Z1rLofdxFiMURnA==\""),
 		},
 	})
 
-	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner", time.Hour, "", []string{}, []string{}, true, []byte("12345678901234567890123456789012"))
+	r, _ := NewTXTRegistry(context.Background(), p, "txt.", "", "owner111", time.Hour, "", []string{}, []string{}, true, []byte("12345678901234567890123456789012"))
 	records, _ := r.Records(ctx)
 	changes := &plan.Changes{
 		Delete: records,
@@ -1522,8 +1559,9 @@ func TestTXTRegistryApplyChangesEncrypt(t *testing.T) {
 	// ensure that encryption nonce gets reused when deleting records
 	expected := &plan.Changes{
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwnerAndOwnedRecord("txt.cname-foobar.test-zone.example.org", "\"h8UQ6jelUFUsEIn7SbFktc2MYXPx/q8lySqI4VwfVtVaIbb2nkHWV/88KKbuLtu7fJNzMir8ELVeVnRSY01KdiIuj7ledqZe5ailEjQaU5Z6uEKd5pgs6sH8\"", endpoint.RecordTypeTXT, "", "foobar.test-zone.example.org"),
+			newEndpointWithOwner("foobar.test-zone.example.org", endpoint.RecordTypeCNAME, "owner111", "foobar.loadbalancer.com"),
+			// should not be split into two targets - second label is a nonce
+			newEndpointWithOwnedRecord("txt.owner111-cname-foobar.test-zone.example.org", endpoint.RecordTypeTXT, "foobar.test-zone.example.org", "\"bqnDtPa1Eo9P4xsu1Qo+YZJ1sD+VoEvSVYD/l8sYGtdl25Rg7bffPWJxIS0DexvjY2ykzIOTpSQKad4sdX8C0XVB9hxZgajQ7KPb8JEKN+5Z1rLofdxFiMURnA==\""),
 		},
 	}
 
@@ -1554,12 +1592,12 @@ func TestMultiClusterDifferentRecordTypeOwnership(t *testing.T) {
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			// records on cluster using A record for ingress address
-			newEndpointWithOwner("bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=cat,external-dns/resource=ingress/default/foo\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "1.2.3.4", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", endpoint.RecordTypeTXT, "", "\"heritage=external-dns,external-dns/owner=cat11111,external-dns/resource=ingress/default/foo\""),
+			newEndpointWithOwner("bar.test-zone.example.org", endpoint.RecordTypeA, "", "1.2.3.4"),
 		},
 	})
 
-	r, _ := NewTXTRegistry(context.Background(), p, "_owner.", "", "bar", time.Hour, "", []string{}, []string{}, false, nil)
+	r, _ := NewTXTRegistry(context.Background(), p, "_owner.", "", "bar11111", time.Hour, "", []string{}, []string{}, false, nil)
 	records, _ := r.Records(ctx)
 
 	// new cluster has same ingress host as other cluster and uses CNAME ingress address
@@ -1609,26 +1647,49 @@ helper methods
 
 */
 
-func newEndpointWithOwner(dnsName, target, recordType, ownerID string) *endpoint.Endpoint {
-	return newEndpointWithOwnerAndLabels(dnsName, target, recordType, ownerID, nil)
+func newEndpointWithOwner(dnsName, recordType, ownerID string, targets ...string) *endpoint.Endpoint {
+	return newEndpointWithOwnerAndLabels(dnsName, recordType, ownerID, nil, targets...)
 }
 
-func newEndpointWithOwnerAndOwnedRecord(dnsName, target, recordType, ownerID, ownedRecord string) *endpoint.Endpoint {
-	return newEndpointWithOwnerAndLabels(dnsName, target, recordType, ownerID, endpoint.Labels{endpoint.OwnedRecordLabelKey: ownedRecord})
+func newEndpointWithOwnedRecord(dnsName, recordType, ownedRecord string, targets ...string) *endpoint.Endpoint {
+	return newEndpointWithLabels(dnsName, recordType, endpoint.Labels{endpoint.OwnedRecordLabelKey: ownedRecord}, targets...)
 }
 
-func newEndpointWithOwnerAndLabels(dnsName, target, recordType, ownerID string, labels endpoint.Labels) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, recordType, target)
-	e.Labels[endpoint.OwnerLabelKey] = ownerID
+func newEndpointWithOwnerAndLabels(dnsName, recordType, ownerID string, labels endpoint.Labels, targets ...string) *endpoint.Endpoint {
+	if len(targets) == 0 {
+		targets = append(targets, "\"\"")
+	}
+	e := endpoint.NewEndpoint(dnsName, recordType, targets...)
+	for k, v := range labels {
+		e.Labels[k] = v
+	}
+	e.Labels = NewTXTLabelsPacker().PackLabels(map[string]endpoint.Labels{
+		ownerID: e.Labels,
+	})
+	return e
+}
+
+func newEndpointWithLabels(dnsName, recordType string, labels endpoint.Labels, targets ...string) *endpoint.Endpoint {
+	if len(targets) == 0 {
+		targets = append(targets, "\"\"")
+	}
+	e := endpoint.NewEndpoint(dnsName, recordType, targets...)
 	for k, v := range labels {
 		e.Labels[k] = v
 	}
 	return e
 }
 
-func newEndpointWithOwnerResource(dnsName, target, recordType, ownerID, resource string) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, recordType, target)
-	e.Labels[endpoint.OwnerLabelKey] = ownerID
+func newEndpointWithOwnerResource(dnsName, recordType, ownerID, resource string, targets ...string) *endpoint.Endpoint {
+	e := newEndpointWithResource(dnsName, recordType, resource, targets...)
+	return e
+}
+
+func newEndpointWithResource(dnsName, recordType, resource string, targets ...string) *endpoint.Endpoint {
+	if len(targets) == 0 {
+		targets = append(targets, "\"\"")
+	}
+	e := endpoint.NewEndpoint(dnsName, recordType, targets...)
 	e.Labels[endpoint.ResourceLabelKey] = resource
 	return e
 }

--- a/internal/external-dns/registry/types.go
+++ b/internal/external-dns/registry/types.go
@@ -1,0 +1,21 @@
+package registry
+
+import "sigs.k8s.io/external-dns/endpoint"
+
+type LabelsPacker interface {
+	PackLabels(labelsPerOwner map[string]endpoint.Labels) endpoint.Labels
+	UnpackLabels(labels endpoint.Labels) map[string]endpoint.Labels
+	LabelsPacked(labels endpoint.Labels) (bool, error)
+}
+
+type nameMapper interface {
+	toEndpointName(txtDNSName string) (endpointName, recordType, ownerID string)
+	toTXTName(string, string, string) string
+	recordTypeInAffix() bool
+}
+
+type Registry interface {
+	OwnerID() string
+	GetLabelsPacker() LabelsPacker
+	FilterEndpointsByOwnerID(ownerID string, list []*endpoint.Endpoint) []*endpoint.Endpoint
+}

--- a/internal/external-dns/testutils/endpoint.go
+++ b/internal/external-dns/testutils/endpoint.go
@@ -19,6 +19,7 @@ package testutils
 import (
 	"reflect"
 	"sort"
+	"strings"
 
 	"sigs.k8s.io/external-dns/endpoint"
 )
@@ -59,10 +60,11 @@ func (b byAllFields) Less(i, j int) bool {
 // SameEndpoint returns true if two endpoints are same
 // considers example.org. and example.org DNSName/Target as different endpoints
 func SameEndpoint(a, b *endpoint.Endpoint) bool {
-	return a.DNSName == b.DNSName && a.Targets.Same(b.Targets) && a.RecordType == b.RecordType && a.SetIdentifier == b.SetIdentifier &&
-		a.Labels[endpoint.OwnerLabelKey] == b.Labels[endpoint.OwnerLabelKey] && a.RecordTTL == b.RecordTTL &&
-		a.Labels[endpoint.ResourceLabelKey] == b.Labels[endpoint.ResourceLabelKey] &&
-		a.Labels[endpoint.OwnedRecordLabelKey] == b.Labels[endpoint.OwnedRecordLabelKey] &&
+	return a.DNSName == b.DNSName &&
+		a.Targets.Same(b.Targets) &&
+		a.RecordType == b.RecordType &&
+		a.SetIdentifier == b.SetIdentifier &&
+		a.RecordTTL == b.RecordTTL &&
 		SameProviderSpecific(a.ProviderSpecific, b.ProviderSpecific)
 }
 
@@ -101,8 +103,35 @@ func SameEndpointLabels(a, b []*endpoint.Endpoint) bool {
 	sort.Sort(byAllFields(sb))
 
 	for i := range sa {
-		if !reflect.DeepEqual(sa[i].Labels, sb[i].Labels) {
+		labelsA := sa[i].Labels
+		labelsB := sb[i].Labels
+
+		if len(labelsA) != len(labelsB) {
 			return false
+		}
+		for keyA, valueA := range labelsA {
+			valueB, ok := labelsB[keyA]
+			if !ok {
+				return false
+			}
+			if valueA != valueB {
+				valueAS := strings.Split(valueA, ",")
+				valueBS := strings.Split(valueB, ",")
+				if len(valueAS) != len(valueBS) {
+					return false
+				}
+
+				mapA := make(map[string]struct{}, len(valueAS))
+				for _, vas := range valueAS {
+					mapA[vas] = struct{}{}
+				}
+				for _, vab := range valueBS {
+					if _, ok = mapA[vab]; !ok {
+						return false
+					}
+				}
+				return true
+			}
 		}
 	}
 	return true

--- a/test/e2e/fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml
+++ b/test/e2e/fixtures/healthcheck_test/geo-dnsrecord-healthchecks.yaml
@@ -44,5 +44,5 @@ spec:
         - eu.klb.${testHostname}
   providerRef:
     name: ${TEST_DNS_PROVIDER_SECRET_NAME}
-  ownerID: 2bq03i
+  ownerID: 2bq03i12
   rootHost: ${testHostname}

--- a/test/e2e/multi_record_test.go
+++ b/test/e2e/multi_record_test.go
@@ -189,16 +189,17 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				}
 				for _, owner := range allOwners {
 					allOwnerMatcher = append(allOwnerMatcher, ContainSubstring(owner))
+
+					expectedElementMatchers = append(expectedElementMatchers,
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-" + owner + "-a-" + testHostname),
+							"Targets":       ConsistOf("\"\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						})),
+					)
 				}
-				expectedElementMatchers = append(expectedElementMatchers,
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-a-" + testHostname),
-						"Targets":       ContainElement(And(allOwnerMatcher...)),
-						"RecordType":    Equal("TXT"),
-						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-					})),
-				)
 			}
 
 			Expect(zoneEndpoints).To(HaveLen(len(expectedElementMatchers)))
@@ -259,8 +260,9 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			if txtRegistryEnabled {
 				expectedElementMatchers = append(expectedElementMatchers,
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-a-" + testHostname),
-						"Targets":       Not(ContainElement(ContainSubstring(recordToDelete.record.Status.OwnerID))),
+						// if we are deleting record we should not have txt record for it
+						"DNSName":       Not(Equal("kuadrant-" + recordToDelete.record.Status.OwnerID + "-a-" + testHostname)),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -484,6 +486,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
 			Expect(err).NotTo(HaveOccurred())
 			var expectedEndpointsLen int
+			var expectedTXTrecordsLen int
 			if testDNSProvider == provider.DNSProviderGCP.String() {
 				expectedEndpointsLen = (2 + len(testGeoRecords) + len(testRecords)) * 2
 				Expect(zoneEndpoints).To(HaveLen(expectedEndpointsLen))
@@ -491,8 +494,15 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				expectedEndpointsLen = (2 + len(testGeoRecords) + len(testRecords)) * 2
 				Expect(zoneEndpoints).To(HaveLen(expectedEndpointsLen))
 			} else if testDNSProvider == provider.DNSProviderAWS.String() {
-				expectedEndpointsLen = (2 + len(testGeoRecords) + (len(testRecords) * 2)) * 2
-				Expect(zoneEndpoints).To(HaveLen(expectedEndpointsLen))
+				// to avoid npe if test runs with no records to test
+				if len(testRecords) > 0 {
+					// assuming all records have the same number of EPs
+					expectedTXTrecordsLen = len(testRecords) * len(testRecords[0].record.Spec.Endpoints)
+					// we create TXT for each endpoint, but we will not create two shared endpoints:
+					// the root hostname and default lb
+					expectedEndpointsLen = expectedTXTrecordsLen - 2
+				}
+				Expect(zoneEndpoints).To(HaveLen(expectedTXTrecordsLen + expectedEndpointsLen))
 			} else if testDNSProvider == provider.DNSProviderCoreDNS.String() {
 				expectedEndpointsLen = 1 + len(testGeoRecords) + (len(testRecords) * 2)
 				Expect(zoneEndpoints).To(HaveLen(expectedEndpointsLen))
@@ -513,25 +523,14 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 
 			var totalEndpointsChecked = 0
 
-			var allOwnerMatcher = []types.GomegaMatcher{
-				ContainSubstring("heritage=external-dns,external-dns/owner="),
-			}
 			var geoOwners = map[string][]string{}
 			var geoKlbHostname = map[string]string{}
-			var geoOwnerMatcher = map[string][]types.GomegaMatcher{}
 			for i := range testRecords {
 				underTest := testRecords[i]
 				ownerID := underTest.record.Status.OwnerID
-				allOwnerMatcher = append(allOwnerMatcher, ContainSubstring(ownerID))
 				geoCode := testRecords[i].config.testGeoCode
 				geoOwners[geoCode] = append(geoOwners[geoCode], ownerID)
 				geoKlbHostname[geoCode] = testRecords[i].config.hostnames.geoKlb
-				if _, ok := geoOwnerMatcher[geoCode]; !ok {
-					geoOwnerMatcher[geoCode] = []types.GomegaMatcher{
-						ContainSubstring("heritage=external-dns,external-dns/owner="),
-					}
-				}
-				geoOwnerMatcher[geoCode] = append(geoOwnerMatcher[geoCode], ContainSubstring(ownerID))
 			}
 
 			By("[Common] checking common endpoints")
@@ -545,16 +544,19 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 			}))))
 			totalEndpointsChecked++
+			// common endpoint should be owner by all owners - check for txt record per owner
 			if txtRegistryEnabled {
-				By("[Common] checking " + testHostname + " TXT owner endpoint")
-				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-					"DNSName":       Equal("kuadrant-cname-" + testHostname),
-					"Targets":       ContainElement(And(allOwnerMatcher...)),
-					"RecordType":    Equal("TXT"),
-					"SetIdentifier": Equal(""),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-				}))))
-				totalEndpointsChecked++
+				for _, owner := range allOwners {
+					By("[Common] checking " + testHostname + " TXT endpoint for owner " + owner)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-" + owner + "-cname-" + testHostname),
+						"Targets":       ConsistOf("\"\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					totalEndpointsChecked++
+				}
 			}
 
 			By("[Geo] checking geo endpoints")
@@ -587,15 +589,17 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"ProviderSpecific": ContainElements(gcpGeoProps),
 				}))))
 				totalEndpointsChecked++
-				By("[Geo] checking " + klbHostName + " TXT owner endpoint")
-				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-					"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-					"Targets":       ContainElement(And(allOwnerMatcher...)),
-					"RecordType":    Equal("TXT"),
-					"SetIdentifier": Equal(""),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-				}))))
-				totalEndpointsChecked++
+				for _, owner := range allOwners {
+					By("[Common] checking " + testHostname + " TXT endpoint for owner " + owner)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-" + owner + "-cname-" + testHostname),
+						"Targets":       ConsistOf("\"\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					totalEndpointsChecked++
+				}
 			}
 			if testDNSProvider == provider.DNSProviderGCP.String() {
 				// A CNAME record for klbHostName should always exist, be owned by all endpoints and target all geo hostnames
@@ -620,15 +624,17 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"ProviderSpecific": ContainElements(gcpGeoProps),
 				}))))
 				totalEndpointsChecked++
-				By("[Geo] checking " + klbHostName + " TXT owner endpoint")
-				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-					"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-					"Targets":       ContainElement(And(allOwnerMatcher...)),
-					"RecordType":    Equal("TXT"),
-					"SetIdentifier": Equal(""),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-				}))))
-				totalEndpointsChecked++
+				for _, owner := range allOwners {
+					By("[Common] checking " + testHostname + " TXT endpoint for owner " + owner)
+					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-" + owner + "-cname-" + testHostname),
+						"Targets":       ConsistOf("\"\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+					totalEndpointsChecked++
+				}
 			}
 			if testDNSProvider == provider.DNSProviderAWS.String() {
 				// A CNAME record for klbHostName should exist for each geo and be owned by all endpoints in that geo
@@ -656,22 +662,38 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 						}),
 					}))))
 					totalEndpointsChecked++
-					By("[Geo] checking " + klbHostName + " -> " + geoCode + " - TXT owner endpoint")
-					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-						"Targets":       ContainElement(And(geoOwnerMatcher[geoCode]...)),
-						"RecordType":    Equal("TXT"),
-						"SetIdentifier": Equal(geoCode),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
-							{Name: awsGeoCodeKey, Value: awsGeoCodeValue},
-						}),
-					}))))
-					totalEndpointsChecked++
+					// for each owner in this geo there should be a TXT record
+					for _, geoOwner := range geoOwners[geoCode] {
+						By("[Geo] checking " + klbHostName + " -> " + geoCode + " - TXT endpoint for owner " + geoOwner)
+						Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-" + geoOwner + "-cname-" + klbHostName),
+							"Targets":       ConsistOf("\"\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal(geoCode),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+							"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+								{Name: awsGeoCodeKey, Value: awsGeoCodeValue},
+							}),
+						}))))
+						totalEndpointsChecked++
+
+						// and there should be one default record for each owner
+						By("[Geo] checking " + klbHostName + " -> default - TXT endpoint for owner " + geoOwner)
+						Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-" + geoOwner + "-cname-" + klbHostName),
+							"Targets":       ConsistOf("\"\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal("default"),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+							"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+								{Name: "aws/geolocation-country-code", Value: "*"},
+							}),
+						}))))
+						totalEndpointsChecked++
+					}
 				}
 
 				defaultGeoKlbHostName := testRecords[0].config.hostnames.defaultGeoKlb
-				defaultGeoCode := testRecords[0].config.testDefaultGeoCode
 
 				By("[Geo] checking endpoint " + klbHostName + " -> default")
 				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -682,18 +704,6 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 						{Name: "alias", Value: "false"},
-						{Name: "aws/geolocation-country-code", Value: "*"},
-					}),
-				}))))
-				totalEndpointsChecked++
-				By("[Geo] checking " + klbHostName + " -> default - TXT owner endpoint")
-				Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-					"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-					"Targets":       ContainElement(And(geoOwnerMatcher[defaultGeoCode]...)),
-					"RecordType":    Equal("TXT"),
-					"SetIdentifier": Equal("default"),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-					"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 						{Name: "aws/geolocation-country-code", Value: "*"},
 					}),
 				}))))
@@ -753,15 +763,18 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 						"ProviderSpecific": ContainElements(gcpWeightProps),
 					}))))
 					totalEndpointsChecked++
-					By("[Weight] checking " + geoKlbHostName + " TXT owner endpoint")
-					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + geoKlbHostName),
-						"Targets":       ContainElement(And(geoOwnerMatcher[geoCode]...)),
-						"RecordType":    Equal("TXT"),
-						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-					}))))
-					totalEndpointsChecked++
+					// for each owner in this geo there should be a TXT record
+					for _, geoOwner := range geoOwners[geoCode] {
+						By("[Weight] checking " + geoKlbHostName + " TXT endpoint for owner " + geoOwner)
+						Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-" + geoOwner + "-cname-" + geoKlbHostName),
+							"Targets":       Equal("\"\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						}))))
+						totalEndpointsChecked++
+					}
 				}
 			}
 			if testDNSProvider == provider.DNSProviderGCP.String() {
@@ -789,15 +802,18 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 						"ProviderSpecific": ContainElements(gcpWeightProps),
 					}))))
 					totalEndpointsChecked++
-					By("[Weight] checking " + geoKlbHostName + " TXT owner endpoint")
-					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + geoKlbHostName),
-						"Targets":       ContainElement(And(geoOwnerMatcher[geoCode]...)),
-						"RecordType":    Equal("TXT"),
-						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-					}))))
-					totalEndpointsChecked++
+					// for each owner in this geo there should be a TXT record
+					for _, geoOwner := range geoOwners[geoCode] {
+						By("[Weight] checking " + geoKlbHostName + " TXT endpoint for owner " + geoOwner)
+						Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":       Equal("kuadrant-" + geoOwner + "-cname-" + geoKlbHostName),
+							"Targets":       ConsistOf("\"\""),
+							"RecordType":    Equal("TXT"),
+							"SetIdentifier": Equal(""),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						}))))
+						totalEndpointsChecked++
+					}
 				}
 			}
 			if testDNSProvider == provider.DNSProviderAWS.String() {
@@ -822,8 +838,8 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 						totalEndpointsChecked++
 						By("[Weight] checking " + geoKlbHostName + " -> " + clusterKlbHostName + " -> " + ownerID + " TXT owner endpoint")
 						Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-							"DNSName":       Equal("kuadrant-cname-" + geoKlbHostName),
-							"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + ownerID + "\""),
+							"DNSName":       Equal("kuadrant-" + ownerID + "-cname-" + geoKlbHostName),
+							"Targets":       ConsistOf("\"\""),
 							"RecordType":    Equal("TXT"),
 							"SetIdentifier": Equal(clusterKlbHostName),
 							"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -875,8 +891,8 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				if txtRegistryEnabled {
 					By("[Cluster] checking " + clusterKlbHostName + " TXT owner endpoint")
 					Expect(zoneEndpoints).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-a-" + clusterKlbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + ownerID + "\""),
+						"DNSName":       Equal("kuadrant-" + ownerID + "-a-" + clusterKlbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -886,7 +902,8 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 			}
 
 			By("checking all endpoints were validated")
-			Expect(totalEndpointsChecked).To(Equal(expectedEndpointsLen))
+			// we will not
+			Expect(totalEndpointsChecked).To(Equal(expectedEndpointsLen + expectedTXTrecordsLen))
 
 			By("deleting all remaining dns records")
 			for _, tr := range testRecords {

--- a/test/e2e/provider_errors_test.go
+++ b/test/e2e/provider_errors_test.go
@@ -251,7 +251,7 @@ var _ = Describe("DNSRecord Provider Errors", Labels{"provider_errors"}, func() 
 			invalidEndpoint,
 		}
 
-		dnsRecord = testBuildDNSRecord(testID, testDNSProviderSecret.Namespace, testDNSProviderSecret.Name, "test-owner", testHostname)
+		dnsRecord = testBuildDNSRecord(testID, testDNSProviderSecret.Namespace, testDNSProviderSecret.Name, "owner111", testHostname)
 		dnsRecord.Spec.Endpoints = testEndpoints
 
 		By("creating dnsrecord " + dnsRecord.Name + " with invalid weight endpoint")

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -171,15 +171,15 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 		if txtRegistryEnabled {
 			expectedElementMatchers = append(expectedElementMatchers,
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"DNSName":       Equal("kuadrant-a-wildcard." + testHostname),
-					"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+					"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-a-wildcard." + testHostname),
+					"Targets":       ConsistOf("\"\""),
 					"RecordType":    Equal("TXT"),
 					"SetIdentifier": Equal(""),
 					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"DNSName":       Equal("kuadrant-a-" + testHostname2),
-					"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+					"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-a-" + testHostname2),
+					"Targets":       ConsistOf("\"\""),
 					"RecordType":    Equal("TXT"),
 					"SetIdentifier": Equal(""),
 					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -260,8 +260,8 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 			if txtRegistryEnabled {
 				expectedElementMatchers = append(expectedElementMatchers,
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-a-" + testHostname),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-a-" + testHostname),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -451,29 +451,29 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + testHostname),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + testHostname),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + geo1KlbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + geo1KlbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -524,32 +524,32 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + testHostname),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + testHostname),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + geo1KlbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + geo1KlbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -606,22 +606,22 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + testHostname),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + testHostname),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + geo1KlbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + geo1KlbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(cluster1KlbHostName),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -630,8 +630,8 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(geoCode),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
@@ -640,8 +640,8 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"DNSName":       Equal("kuadrant-" + dnsRecord.Status.OwnerID + "-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal("default"),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),


### PR DESCRIPTION
Before, we would create TXT records per [DNSName+recordType](https://github.com/Kuadrant/dns-operator/blob/main/internal/external-dns/registry/txt.go#L241)

Now we have a record per DNSName + record type + ownerID. 
This means that we can have multiple TXTs for the same dnsName, so the changes include: 
1. Change the registry to generate more TXT records 
2. Change to the Endpoint's labels - the keys are now always ownersID, and we aren't using the owner as a separate label 
3. The tool to "unpack" and pack labels - depending on each individual use case, we might want to know if other owners specify the same label. For example, with health checks, we would like to know what other owners think of the health of specific endpoints. 
4. Change to the plan: adapting for the changed structure of labels 
5. Update to e2e tests since TXT records are not using their target to signify ownership. In our cases, it means that targets are empty 
6. Introduction of the interface that every registry must implement - depending on the registry we will need tools to pack and filter labels 

The PR is ready for a review, but there will still be more to this task:
1. Create an `.md` file with the explanation of how the registry works 
2. Make code more readable and friendly for others to look at 
