### PR TITLE
tests: Update loadbalanced single record e2e test

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -57,6 +57,7 @@ dns-operator-2   dns-provider-credentials-gcp        kuadrant.io/gcp            
 dns-operator-2   dns-provider-credentials-inmemory   kuadrant.io/inmemory            0      21s
 dnstest          dns-provider-credentials-aws        kuadrant.io/aws                 5      68s
 dnstest          dns-provider-credentials-azure      kuadrant.io/azure               3      68s
+dnstest          dns-provider-credentials-coredns    kuadrant.io/coredns             5      68s
 dnstest          dns-provider-credentials-gcp        kuadrant.io/gcp                 4      68s
 dnstest          dns-provider-credentials-inmemory   kuadrant.io/inmemory            0      68s
 ```

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -36,7 +36,8 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 
 	var k8sClient client.Client
 	var testDNSProviderSecret *v1.Secret
-	var geoCode string
+	var geoCode1 string
+	var geoCode2 string
 
 	var dnsRecord *v1alpha1.DNSRecord
 	var dnsRecords []*v1alpha1.DNSRecord
@@ -48,11 +49,14 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 		k8sClient = testClusters[0].k8sClient
 		testDNSProviderSecret = testClusters[0].testDNSProviderSecrets[0]
 		if testDNSProvider == "google" {
-			geoCode = "us-east1"
+			geoCode1 = "us-east1"
+			geoCode2 = "europe-west1"
 		} else if testDNSProvider == "azure" {
-			geoCode = "GEO-NA"
+			geoCode1 = "GEO-NA"
+			geoCode2 = "GEO-EU"
 		} else {
-			geoCode = "US"
+			geoCode1 = "US"
+			geoCode2 = "GEO-EU"
 		}
 	})
 
@@ -259,11 +263,14 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 
 	Context("loadbalanced", Labels{"loadbalanced"}, func() {
 		It("makes available a hostname that can be resolved", Labels{"happy"}, func(ctx SpecContext) {
-			testTargetIP := "127.0.0.1"
+			testTargetIP1 := "127.0.0.1"
+			testTargetIP2 := "127.0.0.2"
 
 			klbHostName := "klb." + testHostname
-			geo1KlbHostName := strings.ToLower(geoCode) + "." + klbHostName
+			geo1KlbHostName := strings.ToLower(geoCode1) + "." + klbHostName
+			geo2KlbHostName := strings.ToLower(geoCode2) + "." + klbHostName
 			cluster1KlbHostName := "cluster1." + klbHostName
+			cluster2KlbHostName := "cluster2." + klbHostName
 
 			dnsRecord = &v1alpha1.DNSRecord{
 				ObjectMeta: metav1.ObjectMeta{
@@ -279,7 +286,15 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						{
 							DNSName: cluster1KlbHostName,
 							Targets: []string{
-								testTargetIP,
+								testTargetIP1,
+							},
+							RecordType: "A",
+							RecordTTL:  60,
+						},
+						{
+							DNSName: cluster2KlbHostName,
+							Targets: []string{
+								testTargetIP2,
 							},
 							RecordType: "A",
 							RecordTTL:  60,
@@ -308,17 +323,47 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 							},
 						},
 						{
+							DNSName: geo2KlbHostName,
+							Targets: []string{
+								cluster2KlbHostName,
+							},
+							RecordType:    "CNAME",
+							RecordTTL:     60,
+							SetIdentifier: cluster2KlbHostName,
+							ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+								{
+									Name:  "weight",
+									Value: "200",
+								},
+							},
+						},
+						{
 							DNSName: klbHostName,
 							Targets: []string{
 								geo1KlbHostName,
 							},
 							RecordType:    "CNAME",
 							RecordTTL:     300,
-							SetIdentifier: geoCode,
+							SetIdentifier: geoCode1,
 							ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 								{
 									Name:  "geo-code",
-									Value: geoCode,
+									Value: geoCode1,
+								},
+							},
+						},
+						{
+							DNSName: klbHostName,
+							Targets: []string{
+								geo2KlbHostName,
+							},
+							RecordType:    "CNAME",
+							RecordTTL:     300,
+							SetIdentifier: geoCode2,
+							ProviderSpecific: externaldnsendpoint.ProviderSpecific{
+								{
+									Name:  "geo-code",
+									Value: geoCode2,
 								},
 							},
 						},
@@ -369,11 +414,18 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 			zoneEndpoints, err := EndpointsForHost(ctx, testProvider, testHostname)
 			Expect(err).NotTo(HaveOccurred())
 			if testDNSProvider == "google" {
-				Expect(zoneEndpoints).To(HaveLen(8))
+				Expect(zoneEndpoints).To(HaveLen(12))
 				Expect(zoneEndpoints).To(ContainElements(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(cluster1KlbHostName),
-						"Targets":       ConsistOf(testTargetIP),
+						"Targets":       ConsistOf(testTargetIP1),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(cluster2KlbHostName),
+						"Targets":       ConsistOf(testTargetIP2),
 						"RecordType":    Equal("A"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
@@ -397,18 +449,37 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(geo2KlbHostName),
+						"Targets":       ConsistOf(cluster2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "routingpolicy", Value: "weighted"},
+							{Name: cluster2KlbHostName, Value: "200"},
+						}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(klbHostName),
-						"Targets":       ConsistOf(geo1KlbHostName),
+						"Targets":       ConsistOf(geo1KlbHostName, geo2KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+						"ProviderSpecific": ContainElements([]externaldnsendpoint.ProviderSpecificProperty{
 							{Name: "routingpolicy", Value: "geo"},
-							{Name: geo1KlbHostName, Value: geoCode},
+							{Name: geo1KlbHostName, Value: geoCode1},
+							{Name: geo2KlbHostName, Value: geoCode2},
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-a-" + cluster2KlbHostName),
 						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
@@ -429,6 +500,13 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geo2KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
 						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
 						"RecordType":    Equal("TXT"),
@@ -438,11 +516,19 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 				))
 			}
 			if testDNSProvider == "azure" {
-				Expect(zoneEndpoints).To(HaveLen(8))
+				Expect(zoneEndpoints).To(HaveLen(12))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(cluster1KlbHostName),
-						"Targets":       ConsistOf(testTargetIP),
+						"Targets":       ConsistOf(testTargetIP1),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					}))))
+				Expect(zoneEndpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(cluster2KlbHostName),
+						"Targets":       ConsistOf(testTargetIP2),
 						"RecordType":    Equal("A"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
@@ -469,19 +555,40 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(geo2KlbHostName),
+						"Targets":       ConsistOf(cluster2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "routingpolicy", Value: "Weighted"},
+							{Name: cluster2KlbHostName, Value: "200"},
+						}),
+					}))))
+				Expect(zoneEndpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(klbHostName),
-						"Targets":       ConsistOf(geo1KlbHostName),
+						"Targets":       ConsistOf(geo1KlbHostName, geo2KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
-						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+						"ProviderSpecific": ContainElements([]externaldnsendpoint.ProviderSpecificProperty{
 							{Name: "routingpolicy", Value: "Geographic"},
 							{Name: geo1KlbHostName, Value: "WORLD"},
+							{Name: geo2KlbHostName, Value: "GEO-EU"},
 						}),
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+				Expect(zoneEndpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-a-" + cluster2KlbHostName),
 						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
@@ -505,6 +612,14 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geo2KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					}))))
+				Expect(zoneEndpoints).To(ContainElement(
+					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
 						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
 						"RecordType":    Equal("TXT"),
@@ -513,11 +628,18 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 					}))))
 			}
 			if testDNSProvider == "aws" {
-				Expect(zoneEndpoints).To(HaveLen(10))
+				Expect(zoneEndpoints).To(HaveLen(16))
 				Expect(zoneEndpoints).To(ContainElements(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(cluster1KlbHostName),
-						"Targets":       ConsistOf(testTargetIP),
+						"Targets":       ConsistOf(testTargetIP1),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(cluster2KlbHostName),
+						"Targets":       ConsistOf(testTargetIP2),
 						"RecordType":    Equal("A"),
 						"SetIdentifier": Equal(""),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
@@ -541,14 +663,36 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(geo2KlbHostName),
+						"Targets":       ConsistOf(cluster2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(cluster2KlbHostName),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: "aws/weight", Value: "200"},
+						}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(klbHostName),
 						"Targets":       ConsistOf(geo1KlbHostName),
 						"RecordType":    Equal("CNAME"),
-						"SetIdentifier": Equal(geoCode),
+						"SetIdentifier": Equal(geoCode1),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "alias", Value: "false"},
 							{Name: "aws/geolocation-country-code", Value: "US"},
+						}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(klbHostName),
+						"Targets":       ConsistOf(geo2KlbHostName),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(geoCode2),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "alias", Value: "false"},
+							{Name: "aws/geolocation-continent-code", Value: "EU"},
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -564,6 +708,13 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal("kuadrant-a-" + cluster1KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-a-" + cluster2KlbHostName),
 						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
 						"RecordType":    Equal("TXT"),
 						"SetIdentifier": Equal(""),
@@ -587,13 +738,33 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + geo2KlbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(cluster2KlbHostName),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "aws/weight", Value: "200"},
+						}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
 						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
 						"RecordType":    Equal("TXT"),
-						"SetIdentifier": Equal(geoCode),
+						"SetIdentifier": Equal(geoCode1),
 						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "aws/geolocation-country-code", Value: "US"},
+						}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal("kuadrant-cname-" + klbHostName),
+						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + "\""),
+						"RecordType":    Equal("TXT"),
+						"SetIdentifier": Equal(geoCode2),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
+							{Name: "aws/geolocation-continent-code", Value: "EU"},
 						}),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -633,7 +804,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 				}
 				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("[debug] ips: %v\n", ips)
-				g.Expect(ips).To(Or(ContainElements(testTargetIP)))
+				g.Expect(ips).To(Or(ContainElement(testTargetIP1), ContainElement(testTargetIP2)))
 			}, 300*time.Second, 10*time.Second, ctx).Should(Succeed())
 		})
 


### PR DESCRIPTION
Updates the e2e test for a loadbalanced recordset created for a single DNSRecord (it contains endpoints for multiple geos and clusters), all providers should be able to handle this.

Note: These tests will fail for the [coredns provider](https://github.com/Kuadrant/dns-operator/pull/421)  currently, if we don't intend this to work initially for CoreDNS we should hold off on merging this. 