### PR TITLE
coreds(deployment): Update namespaced deployments to include coredns

### DIFF
--- a/hack/coredns-server-list.sh
+++ b/hack/coredns-server-list.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Queries currently running clusters for coredns instances and returns a comma seperated string of their addresses.
+#
+# Example:
+# ./hack/coredns-server-list.sh kind-kuadrant-dns-local 2
+# 172.18.0.16:53,172.18.0.17:53,172.18.0.32:53,172.18.0.33:53
+
+set -euo pipefail
+
+CONTEXT=${1}
+CLUSTER_COUNT=${2:-1}
+labels=${3:-app.kubernetes.io/name=coredns,app.kubernetes.io/component!=metrics}
+
+ns=()
+for i in $(seq $CLUSTER_COUNT); do
+  ns+=("$(kubectl --context ${CONTEXT}-${i} get service -A -l ${labels} -o json | jq -r '[.items[] | (.status.loadBalancer.ingress[].ip + ":53")] | join(",")')")
+done
+echo "$(IFS=, ; echo "${ns[*]}")"

--- a/make/dnsproviders.mk
+++ b/make/dnsproviders.mk
@@ -62,10 +62,10 @@ $(LOCAL_SETUP_AZURE_CREDS):
 	$(call ndef,KUADRANT_AZURE_CREDENTIALS)
 	$(call patch-config,${LOCAL_SETUP_AZURE_CREDS}.template,${LOCAL_SETUP_AZURE_CREDS})
 
-.PHONY: local-setup-coredns-generate-from-cluster
-local-setup-coredns-generate-from-cluster: export COREDNS_NAMESERVERS=$(shell $(KUBECTL) get service kuadrant-coredns -n kuadrant-coredns -o=jsonpath={.status.loadBalancer.ingress[0].ip}):53
-local-setup-coredns-generate-from-cluster: export COREDNS_ZONES=k.example.com
-local-setup-coredns-generate-from-cluster: local-setup-coredns-clean local-setup-coredns-generate ## Generate CoreDNS DNS Provider credentials for local-setup from the running coredns service on cluster(kuadrant-coredns)
+.PHONY: local-setup-coredns-generate-from-clusters
+local-setup-coredns-generate-from-clusters: export COREDNS_NAMESERVERS=$(shell hack/coredns-server-list.sh kind-${KIND_CLUSTER_NAME_PREFIX} ${CLUSTER_COUNT} || echo "")
+local-setup-coredns-generate-from-clusters: export COREDNS_ZONES=k.example.com
+local-setup-coredns-generate-from-clusters: local-setup-coredns-clean local-setup-coredns-generate ## Generate CoreDNS DNS Provider credentials for local-setup from the running coredns services on local kind clusters
 
 .PHONY: local-setup-coredns-generate
 local-setup-coredns-generate: local-setup-coredns-credentials ## Generate CoreDNS DNS Provider credentials for local-setup

--- a/make/misc.mk
+++ b/make/misc.mk
@@ -5,11 +5,13 @@
 
 .PHONY: install-metallb
 install-metallb: SUBNET_OFFSET=1
+install-metallb: CIDR=28
+install-metallb: NUM_IPS=16
 install-metallb: yq ## Install the metallb load balancer allowing use of a LoadBalancer type service
 	kubectl apply --server-side -k config/metallb
 	kubectl -n metallb-system wait --for=condition=Available=True deployments controller --timeout=300s
 	kubectl -n metallb-system wait --for=condition=ready pod --selector=app=metallb --timeout=60s
-	curl -s https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/heads/main/utils/docker-network-ipaddresspool.sh | bash -s kind $(YQ) ${SUBNET_OFFSET} | kubectl apply -n metallb-system -f -
+	curl -s https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/heads/main/utils/docker-network-ipaddresspool.sh | bash -s kind $(YQ) ${SUBNET_OFFSET} ${CIDR} ${NUM_IPS} | kubectl apply -n metallb-system -f -
 
 .PHONY: install-observability
 install-observability: ## Install the kuadrant observability stack


### PR DESCRIPTION
Updates the local-setup namespaced deployments to include a per dns operator namespaced scoped instance of coredns (deployed in the same operator ns).
The coredns configuration requires all clusters and coredns instances to be running to retrieve the required dns server list, in order to achieve this during local-setup the dns provider setup is also moved to a separate task that can be executed after the cluster creation.

Update metallb task to allow subnet to be specified, required when creating more than one cluster (CLUSTER_COUNT > 1)

```
make local-setup DEPLOY=true DEPLOYMENT_SCOPE=namespace DEPLOYMENT_COUNT=2 CLUSTER_COUNT=2
```

```
$ kubectl get deployments -l app.kubernetes.io/name=coredns -A --context kind-kuadrant-dns-local-2
NAMESPACE                 NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
kuadrant-dns-operator-1   kuadrant-coredns-1   1/1     1            1           14m
kuadrant-dns-operator-2   kuadrant-coredns-2   1/1     1            1           14m
$ kubectl get deployments -l app.kubernetes.io/name=coredns -A --context kind-kuadrant-dns-local-1
NAMESPACE                 NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
kuadrant-dns-operator-1   kuadrant-coredns-1   1/1     1            1           15m
kuadrant-dns-operator-2   kuadrant-coredns-2   1/1     1            1           15m
```

