### PR TITLE
Coredns provider and test updates

### DIFF
--- a/internal/provider/coredns/coredns.go
+++ b/internal/provider/coredns/coredns.go
@@ -159,7 +159,7 @@ func (p *CoreDNSProvider) recordsForHost(host string) ([]*endpoint.Endpoint, err
 		nsAnswer, err := p.DNSQueryFunc(hosts, *nServer)
 		if err != nil {
 			//TODO prob need to handle dns errors better here
-			continue
+			return endpoints, err
 		}
 		answers[*nServer] = nsAnswer
 	}
@@ -348,7 +348,7 @@ func (p *CoreDNSProvider) dnsQuery(hosts []string, nameserver string) (map[strin
 		if err != nil {
 			return answers, fmt.Errorf("%w failed to do dns exchange with nameserver %s ", err, nameserver)
 		}
-		p.logger.Info("got answer for dns query ", "fqdn", fqdn, "answer", msg, "err", err)
+		p.logger.Info("got answer for dns query ", "fqdn", fqdn, "nameserver", nameserver, "answer", msg, "err", err)
 		answers[key] = msg
 
 	}


### PR DESCRIPTION
[fix coredns(provider): break on dns query error](https://github.com/Kuadrant/dns-operator/commit/982fe59b2fdf7b0185394f1802d2753d51d224ce)

Adding back the return statement to break out of the loop and return an
error if any of the configured coredns nameservers can't be accessed.

Note: This doesn't break the tests since an NXDOMAIN response doesn't
result in an error.

[tests: Move logic for getting resolvers to the helper](https://github.com/Kuadrant/dns-operator/commit/731c3fa972113bbe74f5f1443d9744ccfca5733f)

Moves more of the logic for getting resolvers for queries into the
common helper and removes some duplication.
