### PR TITLE
tests(e2e): Allow multiple records to be created in each namespace

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -26,43 +26,66 @@ Deploy the operator on a single kind cluster with one operator instance watching
 make local-setup DEPLOY=true
 ```
 
-### Namespace scoped on single cluster
+The above will create a single dns operator and CoreDNS deployment on the kind cluster configured to watch all namespaces, with the development provider secrets (Assuming you have configured them locally) created in the "dnstest" namespace.
 
-> Note currently doesn't work with core dns
+DNS Operator Deployments:
+```shell
+kubectl get deployments -l app.kubernetes.io/part-of=dns-operator -l app.kubernetes.io/name=coredns -A
+NAMESPACE             NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
+dns-operator-system   dns-operator-controller-manager   1/1     1            1           17s
+```
+
+CoreDNS Deployments:
+```shell
+kubectl get deployments -l app.kubernetes.io/name=coredns -A
+NAMESPACE          NAME               READY   UP-TO-DATE   AVAILABLE   AGE
+kuadrant-coredns   kuadrant-coredns   1/1     1            1           96s
+```
+
+DNS Provider Secrets:
+```shell
+kubectl get secrets -l app.kubernetes.io/part-of=dns-operator -A
+NAMESPACE   NAME                                TYPE                   DATA   AGE
+dnstest     dns-provider-credentials-aws        kuadrant.io/aws        3      115s
+dnstest     dns-provider-credentials-azure      kuadrant.io/azure      1      114s
+dnstest     dns-provider-credentials-coredns    kuadrant.io/coredns    2      114s
+dnstest     dns-provider-credentials-gcp        kuadrant.io/gcp        2      115s
+dnstest     dns-provider-credentials-inmemory   kuadrant.io/inmemory   1      114s
+```
+
+### Namespace scoped on single cluster
 
 Deploy the operator on a single kind cluster with two operator instances in two namespaces watching their own namespace only:
 ```shell
 make local-setup DEPLOY=true DEPLOYMENT_SCOPE=namespace DEPLOYMENT_COUNT=2
 ```
 
-
-The above will create two dns operator deployments on the kind cluster, each configured to watch its own namespace, with the development provider secrets (Assuming you have configured them locally) created in each deployment namespace.
+The above will create two dns operator and CoreDNS deployments on the kind cluster, each configured to watch its own namespace, with the development provider secrets (Assuming you have configured them locally) created in each deployment namespace.
 
 DNS Operator Deployments:
 ```shell
 kubectl get deployments -l app.kubernetes.io/part-of=dns-operator -A
-NAMESPACE        NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
-dns-operator-1   dns-operator-controller-manager-1   1/1     1            1           21s
-dns-operator-2   dns-operator-controller-manager-2   1/1     1            1           21s
+NAMESPACE                 NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
+kuadrant-dns-operator-1   dns-operator-controller-manager-1   1/1     1            1           3m35s
+kuadrant-dns-operator-1   kuadrant-coredns-1                  1/1     1            1           3m35s
+kuadrant-dns-operator-2   dns-operator-controller-manager-2   1/1     1            1           3m35s
+kuadrant-dns-operator-2   kuadrant-coredns-2                  1/1     1            1           3m35s
 ```
 
 DNS Provider Secrets:
 ```shell
 kubectl get secrets -l app.kubernetes.io/part-of=dns-operator -A
-NAMESPACE        NAME                                TYPE                            DATA   AGE
-dns-operator-1   dns-provider-credentials-aws        kuadrant.io/aws                 5      21s
-dns-operator-1   dns-provider-credentials-azure      kuadrant.io/azure               3      21s
-dns-operator-1   dns-provider-credentials-gcp        kuadrant.io/gcp                 4      21s
-dns-operator-1   dns-provider-credentials-inmemory   kuadrant.io/inmemory            0      21s
-dns-operator-2   dns-provider-credentials-aws        kuadrant.io/aws                 5      21s
-dns-operator-2   dns-provider-credentials-azure      kuadrant.io/azure               3      21s
-dns-operator-2   dns-provider-credentials-gcp        kuadrant.io/gcp                 4      21s
-dns-operator-2   dns-provider-credentials-inmemory   kuadrant.io/inmemory            0      21s
-dnstest          dns-provider-core-dns               kuadrant.io/coredns             5      68s
-dnstest          dns-provider-credentials-aws        kuadrant.io/aws                 5      68s
-dnstest          dns-provider-credentials-azure      kuadrant.io/azure               3      68s
-dnstest          dns-provider-credentials-gcp        kuadrant.io/gcp                 4      68s
-dnstest          dns-provider-credentials-inmemory   kuadrant.io/inmemory            0      68s
+NAMESPACE                 NAME                                TYPE                   DATA   AGE
+kuadrant-dns-operator-1   dns-provider-credentials-aws        kuadrant.io/aws        3      3m57s
+kuadrant-dns-operator-1   dns-provider-credentials-azure      kuadrant.io/azure      1      3m57s
+kuadrant-dns-operator-1   dns-provider-credentials-coredns    kuadrant.io/coredns    2      3m57s
+kuadrant-dns-operator-1   dns-provider-credentials-gcp        kuadrant.io/gcp        2      3m57s
+kuadrant-dns-operator-1   dns-provider-credentials-inmemory   kuadrant.io/inmemory   1      3m57s
+kuadrant-dns-operator-2   dns-provider-credentials-aws        kuadrant.io/aws        3      3m57s
+kuadrant-dns-operator-2   dns-provider-credentials-azure      kuadrant.io/azure      1      3m57s
+kuadrant-dns-operator-2   dns-provider-credentials-coredns    kuadrant.io/coredns    2      3m57s
+kuadrant-dns-operator-2   dns-provider-credentials-gcp        kuadrant.io/gcp        2      3m57s
+kuadrant-dns-operator-2   dns-provider-credentials-inmemory   kuadrant.io/inmemory   1      3m57s
 ```
 
 ### Cluster scoped on multiple clusters
@@ -71,8 +94,6 @@ Deploy the operator on two kind clusters each with one operator instance watchin
 ```shell
 make local-setup DEPLOY=true CLUSTER_COUNT=2
 ```
-
->Note for coredns, you will need to run the `make local-setup-coredns-credentials TARGET_NAMESPACE=dnstest COREDNS_NAMESERVERS="coredns-service-ip1,corends-ip2"`
 
 ### Namespace scoped on multiple clusters
 


### PR DESCRIPTION
Updates the multi record tests to allow multiple DNSRecords to be created in each test namespace. Uses the already existing "TEST_DNS_CONCURRENT_RECORDS" environment variable to control this, default is 1.

Note: CoreDNS does not currently support this and will error out if "TEST_DNS_CONCURRENT_RECORDS" is set to anything but 1.

Example (TEST_DNS_CONCURRENT_RECORDS=2):

```
make local-setup DEPLOY=true
make test-e2e-multi TEST_DNS_ZONE_DOMAIN_NAME=mn.hcpapps.net TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-aws TEST_DNS_NAMESPACES=dnstest **TEST_DNS_CONCURRENT_RECORDS=2**
/home/mnairn/go/src/github.com/kuadrant/dns-operator/bin/ginkgo -v -tags=e2e --label-filter=multi_record ./test/e2e                                                                                                                                                                                                           
Running Suite: E2E Tests Suite - /home/mnairn/go/src/github.com/kuadrant/dns-operator/test/e2e                                                                                                                                                                                                                                
==============================================================================================                                                                                                                                                                                                                                
Random Seed: 1744375697                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
Will run 2 of 9 specs 

...

Multi Record Test simple creates and deletes distributed dns records [multi_record, simple]                                                                                                                                                                                                                                   
/home/mnairn/go/src/github.com/kuadrant/dns-operator/test/e2e/multi_record_test.go:81                                                                                                                                                                                                                                         
  STEP: creating 2 simple dnsrecords accross 1 clusters each with 1 namespaces containing 2 records @ 04/11/25 13:48:20.661                                                                                                                                                                                                   
  STEP: creating dns record [name: `t-multi-falling-river-1`, namespace: `dnstest`, secret: `dns-provider-credentials-aws`, endpoint: [dnsname: `t-multi-falling-river.dns-op-e2e-billowing-darkness.mn.hcpapps.net`, target: `127.1.1.1`]] on cluster [name: `current`] @ 04/11/25 13:48:20.661                              
  STEP: creating dns record [name: `t-multi-falling-river-2`, namespace: `dnstest`, secret: `dns-provider-credentials-aws`, endpoint: [dnsname: `t-multi-falling-river.dns-op-e2e-billowing-darkness.mn.hcpapps.net`, target: `127.1.1.2`]] on cluster [name: `current`] @ 04/11/25 13:48:20.671                              
  STEP: checking all dns records become ready within 1m0s @ 04/11/25 13:48:20.679                                                                                                                                                                                                                                             
  [debug] all records became ready in 15.024766134s                                                                                                                                                                                                                                                                           
  STEP: checking each record has all(2) domain owners present within 1m0s @ 04/11/25 13:48:35.703

....

Multi Record Test loadbalanced creates and deletes distributed dns records [multi_record, loadbalanced]                                                                                                                                                                                                                       
/home/mnairn/go/src/github.com/kuadrant/dns-operator/test/e2e/multi_record_test.go:331                                                                                                                                                                                                                                        
  STEP: creating 2 loadbalanced dnsrecords accross 1 clusters each with 1 namespaces containing 2 records @ 04/11/25 13:48:53.088                                                                                                                                                                                             
  **STEP: creating dns record [name: `t-multi-shy-sun-1`, namespace: `dnstest`, secret: `dns-provider-credentials-aws`, endpoint: [dnsname: `t-multi-shy-sun.dns-op-e2e-billowing-darkness.mn.hcpapps.net`, target: `127.1.1.1`, geoCode: `US`]] on cluster [name: `current`] @ 04/11/25 13:48:53.089                           
  STEP: creating dns record [name: `t-multi-shy-sun-2`, namespace: `dnstest`, secret: `dns-provider-credentials-aws`, endpoint: [dnsname: `t-multi-shy-sun.dns-op-e2e-billowing-darkness.mn.hcpapps.net`, target: `127.1.1.2`, geoCode: `GEO-EU`]] on cluster [name: `current`] @ 04/11/25 13:48:53.098**                       
  STEP: checking all dns records become ready within 1m0s @ 04/11/25 13:48:53.103                                                                                                                                                                                                                                             
  [debug] all records became ready in 10.026532456s                                                                                                                                                                                                                                                                           
  STEP: checking provider zone records are created as expected @ 04/11/25 13:49:03.13                                                                                                                                                                                                                                         
  [debug] records from zone count: 19                                                                                                                                                                                                                                                                                         
  STEP: checking each record has all(2) domain owners present within 1m0s

....

Ran 2 of 9 Specs in 54.132 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 7 Skipped
PASS

Ginkgo ran 1 suite in 57.172791845s
Test Suite Passed
```
