### PR TITLE
coredns(plugin): Implement Transfer interface

### DIFF
--- a/coredns/examples/Corefile
+++ b/coredns/examples/Corefile
@@ -4,6 +4,9 @@ k.example.com {
    log
    geoip GeoLite2-City-demo.mmdb
    metadata
+   transfer {
+     to *
+   }
    kuadrant
 }
 . {

--- a/coredns/plugin/README.md
+++ b/coredns/plugin/README.md
@@ -49,6 +49,8 @@ kuadrant [ZONES...] {
 * `kubeconfig` **KUBECONFIG [CONTEXT]** authenticates the connection to a remote k8s cluster using a kubeconfig file.
   **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used.
 
+For enabling zone transfers look at the *transfer* plugin.
+
 ## Examples
 
 Load the `example.org` zone from DNSRecord resources on cluster with the label `kuadrant.io/coredns-zone-name: example.org`

--- a/coredns/plugin/cmd/plugin/plugin.go
+++ b/coredns/plugin/cmd/plugin/plugin.go
@@ -5,6 +5,7 @@ package plugin
 // Note: Any plugin removed here should have it's Directive removed also.
 
 import (
+	_ "github.com/coredns/coredns/plugin/acl"
 	_ "github.com/coredns/coredns/plugin/cache"
 	_ "github.com/coredns/coredns/plugin/cancel"
 	_ "github.com/coredns/coredns/plugin/debug"
@@ -27,8 +28,10 @@ import (
 	_ "github.com/coredns/coredns/plugin/reload"
 	_ "github.com/coredns/coredns/plugin/rewrite"
 	_ "github.com/coredns/coredns/plugin/root"
+	_ "github.com/coredns/coredns/plugin/secondary"
 	_ "github.com/coredns/coredns/plugin/timeouts"
 	_ "github.com/coredns/coredns/plugin/tls"
+	_ "github.com/coredns/coredns/plugin/transfer"
 	_ "github.com/coredns/coredns/plugin/view"
 	_ "github.com/coredns/coredns/plugin/whoami"
 )
@@ -40,6 +43,7 @@ import (
 // feel the effects of all other plugin below
 // (after) them during a request, but they must not
 // care what plugin above them are doing.
+// Cut down version of https://github.com/coredns/coredns/blob/master/core/dnsserver/zdirectives.go
 var Directives = []string{
 	"root",
 	"metadata",
@@ -57,13 +61,16 @@ var Directives = []string{
 	"errors",
 	"log",
 	"local",
+	"acl",
 	"cache",
 	"rewrite",
 	"header",
 	"minimal",
+	"transfer",
 	"hosts",
 	"kuadrant",
 	"file",
+	"secondary",
 	"loop",
 	"forward",
 	"whoami",

--- a/coredns/plugin/go.mod
+++ b/coredns/plugin/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
+	github.com/infobloxopen/go-trees v0.0.0-20200715205103-96a057b8dfb9 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/martinlindhe/base36 v1.1.1 // indirect

--- a/coredns/plugin/go.sum
+++ b/coredns/plugin/go.sum
@@ -62,6 +62,8 @@ github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/infobloxopen/go-trees v0.0.0-20200715205103-96a057b8dfb9 h1:w66aaP3c6SIQ0pi3QH1Tb4AMO3aWoEPxd1CNvLphbkA=
+github.com/infobloxopen/go-trees v0.0.0-20200715205103-96a057b8dfb9/go.mod h1:BaIJzjD2ZnHmx2acPF6XfGLPzNCMiBbMRqJr+8/8uRI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -211,6 +213,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/coredns/plugin/kuadrant.go
+++ b/coredns/plugin/kuadrant.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/file"
+	"github.com/coredns/coredns/plugin/transfer"
 	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"
 )
@@ -93,6 +94,15 @@ func (k *Kuadrant) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 func (k *Kuadrant) Name() string {
 	return pluginName
+}
+
+// Transfer implements the transfer.Transfer interface.
+func (k *Kuadrant) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+	z, ok := k.Z[zone]
+	if !ok || z == nil {
+		return nil, transfer.ErrNotAuthoritative
+	}
+	return z.file.Transfer(serial)
 }
 
 // Strips the closing dot unless it's "."


### PR DESCRIPTION
Implements the transfer.Transfer interface required for zone transfers using the "transfer" plugin.

Enables the "transfer" plugin in the kuadrant build of CoreDNS along with complementary plugins "acl" and "secondary".

https://coredns.io/plugins/transfer/

**Corefile:**
```
k.example.com {
   debug
   errors
   log
   geoip geoip/GeoLite2-City-demo.mmdb {
      edns-subnet
   }
   metadata
   transfer {
      to *
   }
   kuadrant {
      kubeconfig /home/mnairn/.kube/config
   }
}
```

**Verify:**
```
$ make coredns-run 

$ dig @127.0.0.1 -p 1053 -t AXFR k.example.com

; <<>> DiG 9.18.28 <<>> @127.0.0.1 -p 1053 -t AXFR k.example.com
; (1 server found)
;; global options: +cmd
k.example.com.          60      IN      SOA     ns1.k.example.com. hostmaster.k.example.com. 12345 7200 1800 86400 60
k.example.com.          60      IN      NS      ns1.k.example.com.
k.example.com.          60      IN      SOA     ns1.k.example.com. hostmaster.k.example.com. 12345 7200 1800 86400 60
;; Query time: 0 msec
;; SERVER: 127.0.0.1#1053(127.0.0.1) (TCP)
;; WHEN: Thu Apr 17 17:22:56 IST 2025
;; XFR size: 3 records (messages 1, bytes 278)

$ kubectl apply -f coredns/examples/dnsrecord-api-k-example-com_geo_weight.yaml -n dnstest
$ kubectl label dnsrecord/api-k-example-com kuadrant.io/coredns-zone-name=k.example.com -n dnstest

$ dig @127.0.0.1 -p 1053 -t AXFR k.example.com

; <<>> DiG 9.18.28 <<>> @127.0.0.1 -p 1053 -t AXFR k.example.com
; (1 server found)
;; global options: +cmd
k.example.com.          60      IN      SOA     ns1.k.example.com. hostmaster.k.example.com. 12345 7200 1800 86400 60
k.example.com.          60      IN      NS      ns1.k.example.com.
api.k.example.com.      300     IN      CNAME   klb.api.k.example.com.
*.api.k.example.com.    60      IN      A       9.9.9.9
klb.api.k.example.com.  300     IN      CNAME   geo-eu.klb.api.k.example.com.
klb.api.k.example.com.  300     IN      CNAME   geo-us.klb.api.k.example.com.
cluster1.klb.api.k.example.com. 60 IN   A       127.0.0.1
cluster2.klb.api.k.example.com. 60 IN   A       127.0.0.2
cluster3.klb.api.k.example.com. 60 IN   A       127.0.0.3
geo-eu.klb.api.k.example.com. 60 IN     CNAME   cluster2.klb.api.k.example.com.
geo-eu.klb.api.k.example.com. 60 IN     CNAME   cluster3.klb.api.k.example.com.
geo-us.klb.api.k.example.com. 60 IN     CNAME   cluster1.klb.api.k.example.com.
k.example.com.          60      IN      SOA     ns1.k.example.com. hostmaster.k.example.com. 12345 7200 1800 86400 60
;; Query time: 1 msec
;; SERVER: 127.0.0.1#1053(127.0.0.1) (TCP)
;; WHEN: Thu Apr 17 17:23:46 IST 2025
;; XFR size: 13 records (messages 1, bytes 845)
```

