### PR TITLE
chore: Build and load coredns image in local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,8 @@ local-setup-cluster: $(KIND) ## Setup local development kind cluster, dependenci
 	@$(MAKE) -s install-bind9
 
 	if [ ${DEPLOYMENT_SCOPE} = "cluster" ]; then\
-    	$(MAKE) -s install-coredns-unmonitored ;\
+    	$(MAKE) -s coredns-docker-build coredns-kind-load-image;\
+    	$(MAKE) -s install-coredns COREDNS_KUSTOMIZATION=config/local-setup/coredns ;\
     fi ;\
 
 	@if [ ${DEPLOY} = "true" ]; then\

--- a/config/coredns/Corefile
+++ b/config/coredns/Corefile
@@ -2,6 +2,9 @@ kdrnt {
     debug
     errors
     log
+    transfer {
+        to *
+    }
     kuadrant
     prometheus 0.0.0.0:9153
 }
@@ -13,6 +16,9 @@ k.example.com {
         edns-subnet
     }
     metadata
+    transfer {
+        to *
+    }
     kuadrant
     prometheus 0.0.0.0:9153
 }

--- a/config/local-setup/coredns/deployment_config_patch.yaml
+++ b/config/local-setup/coredns/deployment_config_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuadrant-coredns
+  namespace: kuadrant-coredns
+spec:
+  template:
+    spec:
+      containers:
+        - name: coredns
+          imagePullPolicy: IfNotPresent

--- a/config/local-setup/coredns/kustomization.yaml
+++ b/config/local-setup/coredns/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../coredns-unmonitored
+
+patches:
+  - path: deployment_config_patch.yaml

--- a/make/coredns.mk
+++ b/make/coredns.mk
@@ -37,3 +37,7 @@ coredns-docker-run: ## Build docker image and run coredns in a container.
 .PHONY: coredns-generate-demo-geo-db
 coredns-generate-demo-geo-db: ## Generate demo geo db embedded in coredns image.
 	cd ${COREDNS_PLUGIN_DIR} && $(MAKE) generate-demo-geo-db
+
+.PHONY: coredns-kind-load-image
+coredns-kind-load-image: ## Load image to kind cluster.
+	$(MAKE) kind-load-image IMG=quay.io/kuadrant/coredns-kuadrant:latest


### PR DESCRIPTION
Build and load the coredns docker image into the kind cluster during local-setup in order to ensure that the current version of the kuadrant coredns plugin is being used.

Adds transfer directive to default deployment Corefile

```
$ kubectl get service -A -l app.kubernetes.io/name=coredns,app.kubernetes.io/component!=metrics -o json | jq -r '[.items[] | (.status.loadBalancer.ingress[].ip)][0]'
     
172.18.0.17

$ dig @172.18.0.17 -t AXFR k.example.com.

; <<>> DiG 9.18.28 <<>> @172.18.0.17 -t AXFR k.example.com.
; (1 server found)
;; global options: +cmd
k.example.com.          60      IN      SOA     ns1.k.example.com. hostmaster.k.example.com. 12345 7200 1800 86400 60
k.example.com.          60      IN      NS      ns1.k.example.com.
k.example.com.          60      IN      SOA     ns1.k.example.com. hostmaster.k.example.com. 12345 7200 1800 86400 60
;; Query time: 1 msec
;; SERVER: 172.18.0.17#53(172.18.0.17) (TCP)
;; WHEN: Fri May 09 15:04:14 IST 2025
;; XFR size: 3 records (messages 1, bytes 278)
```