### PR TITLE
chore: remove forward directive from coredns examples

### DIFF
--- a/config/coredns/Corefile
+++ b/config/coredns/Corefile
@@ -1,6 +1,10 @@
 kdrnt {
     debug
     errors
+    health {
+        lameduck 5s
+    }
+    ready
     log
     transfer {
         to *
@@ -21,17 +25,4 @@ k.example.com {
     }
     kuadrant
     prometheus 0.0.0.0:9153
-}
-. {
-    errors
-    health {
-        lameduck 5s
-    }
-    ready
-    prometheus 0.0.0.0:9153
-    forward . /etc/resolv.conf
-    cache 30
-    loop
-    reload
-    log
 }

--- a/coredns/examples/Corefile
+++ b/coredns/examples/Corefile
@@ -9,6 +9,3 @@ k.example.com {
    }
    kuadrant
 }
-. {
-   forward . /etc/resolv.conf
-}

--- a/coredns/plugin/README.md
+++ b/coredns/plugin/README.md
@@ -140,9 +140,6 @@ k.example.com {
       kubeconfig <path to kubeconfig>/.kube/config
    }
 }
-. {
-   forward . /etc/resolv.conf
-}
 ```
 
 Run Kuadrant build of CoreDNS locally:

--- a/docs/coredns/README.md
+++ b/docs/coredns/README.md
@@ -34,14 +34,6 @@ Tail CoreDNS logs
 kubectl logs -f deployments/kuadrant-coredns -n kuadrant-coredns
 ```
 
-Use DNS Server:
-```shell
-DNS_SRV=`kubectl get service/kuadrant-coredns -n kuadrant-coredns -o yaml | yq '.status.loadBalancer.ingress[0].ip'`
-echo $DNS_SRV
-echo "Dig command: dig @$DNS_SRV google.com"
-dig @$DNS_SRV google.com
-```
-
 #### Enable Monitoring:
 
 Monitoring is not enabled by default, if you configured the observability stack above, the CoreDNS instance can be  updated to enable it with:
@@ -95,8 +87,6 @@ Install CoreDNS Multi POC Setup
 ```shell
 (cd ../.. && make install-coredns-multi)
 ```
-
-[//]: # (ToDo The following won't work until the DNS Operatro chnages are merged!!)
 
 Create coredns provider secrets:
 ```shell


### PR DESCRIPTION
closes #439 

Removes the forward directive from all Corefile examples to avoid confusion. We will only ever be using the CoreDNS instances as authoritative name servers which would not expect this option to be used.