### PR TITLE
ci: Rename CI-E2E job and update triggers

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -1,4 +1,4 @@
-name: CI-E2E
+name: CI-E2E-0
 
 on:
   push:
@@ -8,10 +8,6 @@ on:
       - "ci_*"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-  pull_request_target:
-    branches:
-      - main
-      - "release-*"
   workflow_dispatch:
     inputs:
       testRecordsCount:


### PR DESCRIPTION
* Removing the `pull_request_target` trigger for the CI-E2E job.
* Renamed CI-E2E -> CI-E2E-0 to allow disabling the original in GH more easily.