### PR TITLE
prevent index out of range in plan

### DIFF
--- a/internal/external-dns/plan/plan.go
+++ b/internal/external-dns/plan/plan.go
@@ -538,8 +538,9 @@ func (e *managedRecordSetChanges) calculateDesired(update *endpointUpdate) {
 		// If a target is managed:
 		// - If after the update the dnsName will no longer be owned by this endpoint(update.desired), remove it from the list of targets.
 		// - If after the update the dnsName will have no owners (it's going to be deleted), remove it from the list of targets.
-		for idx := range desiredCopy.Targets {
-			t := desiredCopy.Targets[idx]
+		desiredTargets := desiredCopy.Targets.DeepCopy()
+		for idx := range desiredTargets {
+			t := desiredTargets[idx]
 			tDNSName := normalizeDNSName(t)
 			e.logger.V(1).Info(fmt.Sprintf("checking target %s owners", t))
 			if tOwners, tIsManaged := e.dnsNameOwners[tDNSName]; tIsManaged {


### PR DESCRIPTION
fixes #https://github.com/Kuadrant/dns-operator/issues/325

Fixes a bug in the modified external-dns plan logic when manipulating endpoint target values. 