### PR TITLE
make providers selectable for e2e workflow

### DIFF
--- a/.github/workflows/ci-e2e-0.yaml
+++ b/.github/workflows/ci-e2e-0.yaml
@@ -26,6 +26,22 @@ on:
         description: Flags to pass directly to the ginkgo command
         default: "-v"
         type: string
+      testAWS:
+        description: Run tests with AWS provider
+        default: true
+        type: boolean
+      testGCP:
+        description: Run tests with GCP provider
+        default: true
+        type: boolean
+      testAzure:
+        description: Run tests with Azure provider
+        default: true
+        type: boolean
+      testCoreDNS:
+        description: Run tests with CoreDNS provider
+        default: true
+        type: boolean
   merge_group:
     types: [ checks_requested ]
 
@@ -80,6 +96,7 @@ jobs:
           kubectl -n ${{ env.TEST_NAMESPACE }} get secret/dns-provider-credentials-azure
           kubectl -n ${{ env.TEST_NAMESPACE }} get secret/dns-provider-credentials-coredns
       - name: Run suite AWS
+        if: ${{ inputs.testAWS }}
         run: |
           export TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-aws
           export TEST_DNS_ZONE_DOMAIN_NAME=e2e.hcpapps.net
@@ -87,6 +104,7 @@ jobs:
           export TEST_DNS_CONCURRENT_RECORDS=${{ env.TEST_RECORDS_COUNT }}
           make test-e2e
       - name: Run suite GCP
+        if: ${{ inputs.testGCP }}
         run: |
           export TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-gcp
           export TEST_DNS_ZONE_DOMAIN_NAME=e2e.google.hcpapps.net
@@ -94,7 +112,7 @@ jobs:
           export TEST_DNS_CONCURRENT_RECORDS=${{ env.TEST_RECORDS_COUNT }}
           make test-e2e
       - name: Run suite Azure
-        if: (github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release-')) || github.event_name == 'workflow_dispatch')
+        if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release-')) || github.event_name == 'workflow_dispatch') && inputs.testAzure }}
         run: |
           export TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-azure
           export TEST_DNS_ZONE_DOMAIN_NAME=e2e.azure.hcpapps.net
@@ -102,6 +120,7 @@ jobs:
           export TEST_DNS_CONCURRENT_RECORDS=${{ env.TEST_RECORDS_COUNT }}
           make test-e2e
       - name: Run suite CoreDNS
+        if: ${{ inputs.testCoreDNS }}
         run: |
           export TEST_DNS_PROVIDER_SECRET_NAME=dns-provider-credentials-coredns
           export TEST_DNS_ZONE_DOMAIN_NAME=k.example.com


### PR DESCRIPTION
Make it possible to select providers for an E2E run. 
I used [act](https://github.com/nektos/act?tab=readme-ov-file) to test it out locally. Seems to be working fine 