### PR TITLE
lint: Add loggercheck linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   enable:
     - misspell
+    - loggercheck
   disable:
     - staticcheck
   exclusions:

--- a/internal/provider/coredns/coredns.go
+++ b/internal/provider/coredns/coredns.go
@@ -216,7 +216,7 @@ func (p *CoreDNSProvider) mergeDNSEndpoints(rr dns.RR, endpoints []*endpoint.End
 		ep.RecordType = "TXT"
 		ep.Targets = rec.Txt
 	default:
-		p.logger.Info("not handling record of type %v ", rec)
+		p.logger.Info("record type not supported", "type", rec)
 	}
 
 	alreadyExists := false


### PR DESCRIPTION
Adds the `loggercheck` linter to detect issues with log statements, in particular to catch issues like "odd number of arguments passed as key-value pairs" which currently cause a panic when hit.

https://golangci-lint.run/usage/linters/#loggercheck