### PR TITLE
Update finalizer removal logic to check status condition for "ProviderEndpointsRemoved"

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -6,6 +6,8 @@ type ConditionReason string
 const ConditionTypeReady ConditionType = "Ready"
 const ConditionReasonProviderSuccess ConditionReason = "ProviderSuccess"
 const ConditionReasonAwaitingValidation ConditionReason = "AwaitingValidation"
+const ConditionReasonProviderEndpointsRemoved ConditionReason = "ProviderEndpointsRemoved"
+const ConditionReasonProviderEndpointsDeletion ConditionReason = "ProviderEndpointsDeletion"
 
 const ConditionTypeHealthy ConditionType = "Healthy"
 const ConditionReasonHealthy ConditionReason = "AllChecksPassed"

--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 
@@ -157,6 +158,24 @@ type DNSRecordStatus struct {
 
 	// zoneDomainName is the domain name of the zone that the dns record is publishing endpoints
 	ZoneDomainName string `json:"zoneDomainName,omitempty"`
+}
+
+// ProviderEndpointsRemoved return true if the ready status condition has the reason set to "ProviderEndpointsRemoved"
+func (s *DNSRecordStatus) ProviderEndpointsRemoved() bool {
+	readyCond := meta.FindStatusCondition(s.Conditions, string(ConditionTypeReady))
+	if readyCond != nil && readyCond.Reason == string(ConditionReasonProviderEndpointsRemoved) {
+		return true
+	}
+	return false
+}
+
+// ProviderEndpointsDeletion return true if the ready status condition has the reason set to "ProviderEndpointsDeletion"
+func (s *DNSRecordStatus) ProviderEndpointsDeletion() bool {
+	readyCond := meta.FindStatusCondition(s.Conditions, string(ConditionTypeReady))
+	if readyCond != nil && readyCond.Reason == string(ConditionReasonProviderEndpointsDeletion) {
+		return true
+	}
+	return false
 }
 
 //+kubebuilder:object:root=true


### PR DESCRIPTION

Fixes: #487

# Summary
This PR updates the DNSRecord finalizer removal logic to check for the ProviderEndpointsRemoved status condition reason before removing the finalizer. This change supports multi-cluster reconciliation of DNS records by ensuring that finalizers are only removed when DNS endpoints have been successfully removed from the provider.

# Changes Made
## API Changes

Added new condition reasons:
- ConditionReasonProviderEndpointsRemoved: Indicates DNS records have been successfully removed from the provider
- ConditionReasonProviderEndpointsDeletion: Indicates DNS records are currently being deleted from the provider

Added status helper methods:
- DNSRecordStatus.ProviderEndpointsRemoved(): Returns true if the ready condition has reason "ProviderEndpointsRemoved"
- DNSRecordStatus.ProviderEndpointsDeletion(): Returns true if the ready condition has reason "ProviderEndpointsDeletion"

## Controller Logic Changes
Finalizer removal logic:
- Finalizer removal is now outside the deletion timestamp logic 
- Finalizer is now removed only when ProviderEndpointsRemoved() returns true
- Finalizer can be removed in a multi cluster setup by the primary updating the resource status
- Locic add to stop requeue loops when endpoints are already removed when there are secondary finalizers on the resource

Deletion workflow:
- Sets status to ProviderEndpointsDeletion when deletion begins
- Existing DNS record cleanup remains on changed
- Sets status to ProviderEndpointsRemoved when cleanup completes
- Clears zone-related status fields (endpoints, domain name, zone ID, owner ID)
- Finalizer removal is handled separately based on status condition

# Verification 

- Install this branch.
- Create a valid DNSrecord resource.
- Add a second finalizer, stops removal of record allowing the confirmation of status
e.g. `kubectl patch dnsrecord echo.apps.hcpapps.net -n dnstest --type='merge' -p '{"metadata":{"finalizers":["user-applied"]}}'`
- Set up a watch of the DNSrecord status
- Wait for condition to be in a ready state
- Delete the DNSrecord.
- **Expect:** During DNS provider records removal ready condition should be false with a reason of `ProviderEndpointsDeletion`
- Once DNS provider records have being removed
- **Expect:** ready condition to be `ProviderEndpointsRemoved`
- **Expect:** Finalizer `kuadrant.io/dns-record` to be removed from the resource
