### PR TITLE
Fix kind-load-image target for podman compatibility

### DIFF
--- a/make/kind.mk
+++ b/make/kind.mk
@@ -20,4 +20,9 @@ kind-delete-all-clusters: kind ## Delete the all "kuadrant-dns-local*" kind clus
 
 .PHONY: kind-load-image
 kind-load-image: kind ## Load image to "kuadrant-dns-local" kind cluster.
-	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
+	$(eval TMP_DIR := $(shell mktemp -d))
+	$(CONTAINER_TOOL) save -o $(TMP_DIR)/image.tar $(IMG) \
+	   && KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_TOOL) $(KIND) load image-archive $(TMP_DIR)/image.tar $(IMG) --name $(KIND_CLUSTER_NAME) ; \
+	   EXITVAL=$$? ; \
+	   rm -rf $(TMP_DIR) ; \
+	   exit $${EXITVAL}


### PR DESCRIPTION

# Problem
The make kind-load-image target was failing when using podman as the CONTAINER_TOOL. The existing implementation used kind load docker-image, which only works with Docker-created images and doesn't support images created by podman.

# Solution
This change updates the kind-load-image make target to use kind load image-archive instead of kind load docker-image. The new approach:
1. Creates a temporary directory for the image archive
2. Saves the container image to a tar file using the configured CONTAINER_TOOL (works with both docker and podman)
3. Loads the image archive into the kind cluster using KIND_EXPERIMENTAL_PROVIDER
4. Properly handles cleanup of temporary files and exit codes

# Benefits
✅ Universal compatibility: Works with both Docker and Podman
✅ Maintains existing functionality: No breaking changes for Docker users
✅ Robust error handling: Proper cleanup even if the operation fails
✅ Follows best practices: Uses temporary directories and proper exit code propagation

# Technical Details
- Uses $(CONTAINER_TOOL) save instead of relying on kind's docker-specific commands
- Leverages KIND_EXPERIMENTAL_PROVIDER to ensure compatibility
- Ensures temporary directory cleanup regardless of success/failure