### PR TITLE
chore: Create operator resources during local-setup

### DIFF
--- a/config/local-setup/dns-operator/cluster-scoped/kustomization.yaml
+++ b/config/local-setup/dns-operator/cluster-scoped/kustomization.yaml
@@ -1,0 +1,18 @@
+resources:
+  - ../../../deploy/local
+
+patches:
+  - patch: |-
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: dns-operator-controller-manager
+        namespace: dns-operator-system
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: dns-operator-controller-manager-metrics-service
+        namespace: dns-operator-system

--- a/config/local-setup/dns-operator/namespace-scoped/kustomization.yaml
+++ b/config/local-setup/dns-operator/namespace-scoped/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-  - ../../deploy/local
+  - ../../../deploy/local
 
 patches:
   - patch: |-

--- a/make/kustomize_overlays.mk
+++ b/make/kustomize_overlays.mk
@@ -57,7 +57,7 @@ generate-operator-deployment-overlay: ## Generate a DNS Operator deployment over
 	mkdir -p $(CLUSTER_OVERLAY_DIR)/$(CLUSTER_NAME)/dns-operator
 	cd $(CLUSTER_OVERLAY_DIR)/$(CLUSTER_NAME)/dns-operator && \
 	touch kustomization.yaml && \
-	$(KUSTOMIZE) edit add resource $(call config_path_for,"config/local-setup/dns-operator",$(CLUSTER_OVERLAY_DIR)/$(CLUSTER_NAME)/dns-operator)
+	$(KUSTOMIZE) edit add resource $(call config_path_for,"config/local-setup/dns-operator/namespace-scoped",$(CLUSTER_OVERLAY_DIR)/$(CLUSTER_NAME)/dns-operator)
 
 	# Generate coredns deployment overlay
 	mkdir -p $(CLUSTER_OVERLAY_DIR)/$(CLUSTER_NAME)/coredns


### PR DESCRIPTION
Updates the local-setup logic to always apply operator resources (rbac, service accounts etc..) from the default kustomization to all clusters. When DEPLOY=false and DEPLOYMENT_SCOPE=cluster (defaults), the manager Deployment and metrics Service resources are removed to allow local development to continue as normal using `make run`.

Note: This is required to support future work where we need access to an sa in a known namespace for local development as it would be in production.