### PR TITLE
fix: panic when using default secret

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -105,7 +105,7 @@ type DNSRecordSpec struct {
 
 	// ProviderRef is a reference to a provider secret.
 	// +optional
-	ProviderRef *ProviderRef `json:"providerRef"`
+	ProviderRef *ProviderRef `json:"providerRef,omitempty"`
 
 	// endpoints is a list of endpoints that will be published into the dns provider.
 	// +kubebuilder:validation:MinItems=1

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -417,7 +417,7 @@ func (r *DNSRecordReconciler) SetupWithManager(mgr ctrl.Manager, maxRequeue, val
 				return toReconcile
 			}
 			for _, record := range records.Items {
-				if record.Spec.ProviderRef.Name == o.GetName() {
+				if record.Status.ProviderRef.Name == o.GetName() {
 					logger.Info("secret updated", "secret", o.GetNamespace()+"/"+o.GetName(), "enqueuing dnsrecord ", record.GetName())
 					toReconcile = append(toReconcile, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&record)})
 				}


### PR DESCRIPTION
The spec providerRef can be nil and the watch on secrets was incorrectly still using the spec value instead of the one set in the status.

Would cause a panic if you had a secret labelled as default and a record with no provider ref. 