### PR TITLE
ci: Allow tests to be skipped only on PRs

### DIFF
--- a/.github/workflows/ci-e2e-0.yaml
+++ b/.github/workflows/ci-e2e-0.yaml
@@ -65,6 +65,7 @@ jobs:
         with:
           cancel_others: false
           paths_ignore: '["**/*.md", "**/*.adoc", "LICENSE"]'
+          do_not_skip: '["push", "merge_group", "workflow_dispatch", "schedule"]'
   e2e-test-suite:
     name: E2E Test Suite
     if: needs.pre-job.outputs.should_skip != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           cancel_others: false
           paths_ignore: '["**/*.md", "**/*.adoc", "LICENSE"]'
+          do_not_skip: '["push", "merge_group", "workflow_dispatch", "schedule"]'
   lint:
     name: lint
     if: needs.pre-job.outputs.should_skip != 'true'


### PR DESCRIPTION
Update the skip options for the CI and CI-E2E-0 to only skip checks on pull request triggers. These tests should always execute on push and merge group to ensure complete testing of all commits going back to main.