### PR TITLE
Add provider label to DNSrecord

### DIFF
--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -1,0 +1,25 @@
+package common
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// MergeLabels combines the map of labels to the existing labels on an object
+func MergeLabels(object metav1.Object, labels map[string]string) bool {
+	objLabels := object.GetLabels()
+
+	if objLabels == nil {
+		object.SetLabels(labels)
+		return true
+	}
+
+	updated := false
+	for key, value := range labels {
+		label, exists := objLabels[key]
+		if !exists || label != value {
+			objLabels[key] = value
+			updated = true
+		}
+	}
+
+	object.SetLabels(objLabels)
+	return updated
+}

--- a/internal/common/labels_test.go
+++ b/internal/common/labels_test.go
@@ -1,0 +1,68 @@
+//go:build unit
+
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+)
+
+func Test_MergeLabels(t *testing.T) {
+	RegisterTestingT(t)
+
+	scenarios := []struct {
+		Name      string
+		DNSRecord *v1alpha1.DNSRecord
+		labels    map[string]string
+		expect    bool
+	}{
+		{
+			Name:      "Empty object labels",
+			DNSRecord: &v1alpha1.DNSRecord{},
+			labels:    map[string]string{"default": "value"},
+			expect:    true,
+		},
+		{
+			Name:      "label needs updating",
+			DNSRecord: &v1alpha1.DNSRecord{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{"default": "wrong value"}}},
+			labels:    map[string]string{"default": "value"},
+			expect:    true,
+		},
+		{
+			Name:      "Add label to existing",
+			DNSRecord: &v1alpha1.DNSRecord{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{"default1": "other value"}}},
+			labels:    map[string]string{"default": "value"},
+			expect:    true,
+		},
+		{
+			Name:      "Upate label in existing labels",
+			DNSRecord: &v1alpha1.DNSRecord{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{"default1": "other value", "default": "wrong value"}}},
+			labels:    map[string]string{"default": "value"},
+			expect:    true,
+		},
+		{
+			Name:      "No update required",
+			DNSRecord: &v1alpha1.DNSRecord{ObjectMeta: v1.ObjectMeta{Labels: map[string]string{"default1": "other value", "default": "value"}}},
+			labels:    map[string]string{"default": "value"},
+			expect:    false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			result := MergeLabels(scenario.DNSRecord, scenario.labels)
+			Expect(result).To(Equal(scenario.expect))
+			labels := scenario.DNSRecord.GetLabels()
+			for key, value := range scenario.labels {
+				label, exists := labels[key]
+				Expect(exists).To(Equal(true))
+				Expect(label).To(Equal(value))
+			}
+		})
+	}
+}

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -316,6 +316,15 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.updateStatus(ctx, previous, dnsRecord, probes, false, []string{}, err)
 	}
 
+	if common.MergeLabels(dnsRecord, dnsProvider.Labels()) {
+		logger.Info("Adding provider labels")
+		err = r.Update(ctx, dnsRecord)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: randomizedValidationRequeue}, nil
+	}
+
 	if probesEnabled {
 		if err = r.ReconcileHealthChecks(ctx, dnsRecord, allowInsecureCert); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -189,6 +189,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 		Eventually(func(g Gomega) {
 			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
 			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Status.Conditions).To(
 				ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -221,6 +222,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 		Eventually(func(g Gomega) {
 			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord2), dnsRecord2)
 			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord2.Status.Conditions).To(
 				ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -272,6 +274,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			g.Expect(k8sClient.Update(ctx, dnsProviderSecret)).To(Succeed())
 
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)).To(Succeed())
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Status.Conditions).To(
 				ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -304,6 +307,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			g.Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, dnsRecord))).To(Succeed())
 
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)).To(Succeed())
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Status.Conditions).To(
 				ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -328,6 +332,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					"ObservedGeneration": Equal(dnsRecord.Generation),
 				})),
 			)
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName))
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
@@ -357,6 +362,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					"ObservedGeneration": Equal(dnsRecord.Generation),
 				})),
 			)
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.WriteCounter).To(BeZero())
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
@@ -382,6 +388,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					"ObservedGeneration": Equal(dnsRecord.Generation),
 				})),
 			)
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.WriteCounter).To(BeZero())
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
@@ -424,6 +431,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					"ObservedGeneration": Equal(dnsRecord.Generation),
 				})),
 			)
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
 			g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName))
@@ -606,6 +614,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					"ObservedGeneration": Equal(dnsRecord.Generation),
 				})),
 			)
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
 			g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName))
@@ -697,6 +706,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					"ObservedGeneration": Equal(dnsRecord.Generation),
 				})),
 			)
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
 			g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName))
@@ -760,6 +770,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					"ObservedGeneration": Equal(dnsRecord.Generation),
 				})),
 			)
+			g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
 			g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID))
 			g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName))
@@ -980,6 +991,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
 				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 				g.Expect(dnsRecord.Status.ZoneID).To(Equal(testZoneID2))
 				g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName2))
 				g.Expect(dnsRecord.Status.Conditions).To(

--- a/internal/provider/aws/aws.go
+++ b/internal/provider/aws/aws.go
@@ -65,6 +65,12 @@ func (*Route53DNSProvider) Name() provider.DNSProviderName {
 	return provider.DNSProviderAWS
 }
 
+func (p *Route53DNSProvider) Labels() map[string]string {
+	return map[string]string{
+		provider.DNSProviderLabel: p.Name().String(),
+	}
+}
+
 func NewProviderFromSecret(ctx context.Context, s *v1.Secret, c provider.Config) (provider.Provider, error) {
 	config := aws.NewConfig()
 

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -39,6 +39,12 @@ func (*AzureProvider) Name() provider.DNSProviderName {
 	return provider.DNSProviderAzure
 }
 
+func (p *AzureProvider) Labels() map[string]string {
+	return map[string]string{
+		provider.DNSProviderLabel: p.Name().String(),
+	}
+}
+
 func NewAzureProviderFromSecret(ctx context.Context, s *v1.Secret, c provider.Config) (provider.Provider, error) {
 	if string(s.Data[v1alpha1.AzureJsonKey]) == "" {
 		return nil, fmt.Errorf("the Azure provider credentials is empty")

--- a/internal/provider/coredns/coredns.go
+++ b/internal/provider/coredns/coredns.go
@@ -99,6 +99,12 @@ func (p CoreDNSProvider) Name() provider.DNSProviderName {
 	return provider.DNSProviderCoreDNS
 }
 
+func (p *CoreDNSProvider) Labels() map[string]string {
+	return map[string]string{
+		provider.DNSProviderLabel: p.Name().String(),
+	}
+}
+
 // DNSZones returns a list of dns zones accessible for this provider
 func (p *CoreDNSProvider) DNSZones(ctx context.Context) ([]provider.DNSZone, error) {
 	zones := []provider.DNSZone{}

--- a/internal/provider/endpoint/endpoint.go
+++ b/internal/provider/endpoint/endpoint.go
@@ -157,6 +157,12 @@ func (p *EndpointProvider) Name() provider.DNSProviderName {
 	return provider.DNSProviderEndpoint
 }
 
+func (p *EndpointProvider) Labels() map[string]string {
+	return map[string]string{
+		provider.DNSProviderLabel: p.Name().String(),
+	}
+}
+
 // AdjustEndpoints nothing to do here
 func (p *EndpointProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
 	var retEndpoints []*endpoint.Endpoint

--- a/internal/provider/google/google.go
+++ b/internal/provider/google/google.go
@@ -122,6 +122,12 @@ func (p *GoogleDNSProvider) Name() provider.DNSProviderName {
 	return provider.DNSProviderGCP
 }
 
+func (p *GoogleDNSProvider) Labels() map[string]string {
+	return map[string]string{
+		provider.DNSProviderLabel: p.Name().String(),
+	}
+}
+
 func NewProviderFromSecret(ctx context.Context, s *corev1.Secret, c provider.Config) (provider.Provider, error) {
 	if string(s.Data[v1alpha1.GoogleJsonKey]) == "" || string(s.Data[v1alpha1.GoogleProjectIDKey]) == "" {
 		return nil, fmt.Errorf("GCP Provider credentials is empty")

--- a/internal/provider/inmemory/inmemory.go
+++ b/internal/provider/inmemory/inmemory.go
@@ -40,6 +40,12 @@ func (p *InMemoryDNSProvider) Name() provider.DNSProviderName {
 	return provider.DNSProviderInMem
 }
 
+func (p *InMemoryDNSProvider) Labels() map[string]string {
+	return map[string]string{
+		provider.DNSProviderLabel: p.Name().String(),
+	}
+}
+
 func NewProviderFromSecret(ctx context.Context, s *v1.Secret, c provider.Config) (provider.Provider, error) {
 	logger := log.FromContext(ctx).WithName("inmemory-dns")
 	ctx = log.IntoContext(ctx, logger)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,6 +31,8 @@ var (
 	DNSProviderInMem    DNSProviderName = "inmemory"
 	DNSProviderEndpoint DNSProviderName = "endpoint"
 
+	DNSProviderLabel = "kuadrant.io/dns-provider-name"
+
 	CoreDNSRecordZoneLabel = "kuadrant.io/coredns-zone-name"
 	CoreDNSRecordTypeLabel = "kuadrant.io/type"
 
@@ -54,6 +56,8 @@ type Provider interface {
 	ProviderSpecific() ProviderSpecificLabels
 
 	Name() DNSProviderName
+
+	Labels() map[string]string
 }
 
 type Config struct {

--- a/test/e2e/multi_record_test.go
+++ b/test/e2e/multi_record_test.go
@@ -189,6 +189,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
+					g.Expect(tr.record.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", testDNSProvider))
 					allOwners = append(allOwners, tr.record.GetUIDHash())
 					allTargetIps = append(allTargetIps, tr.config.testTargetIP)
 					if txtRegistryEnabled {
@@ -517,6 +518,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
+					g.Expect(tr.record.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", testDNSProvider))
 					allOwners = append(allOwners, tr.record.GetUIDHash())
 					if txtRegistryEnabled {
 						g.Expect(tr.record.Status.DomainOwners).NotTo(BeEmpty())

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -285,6 +285,9 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 			Expect(dnsRecord.Status.OwnerID).ToNot(BeEmpty())
 			Expect(dnsRecord.Status.OwnerID).To(Equal(dnsRecord.GetUIDHash()))
 
+			By("checking dns provider label 'kuadrant.io/dns-provider-name=" + testDNSProvider + "' is set correctly")
+			Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", testDNSProvider))
+
 			By("ensuring zone records are created as expected")
 			testProvider, err := ProviderForDNSRecord(ctx, dnsRecord, k8sClient, dynamicClient)
 			Expect(err).NotTo(HaveOccurred())
@@ -451,6 +454,9 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 			Expect(dnsRecord.Spec.OwnerID).To(BeEmpty())
 			Expect(dnsRecord.Status.OwnerID).ToNot(BeEmpty())
 			Expect(dnsRecord.Status.OwnerID).To(Equal(dnsRecord.GetUIDHash()))
+
+			By("checking dns provider label 'kuadrant.io/dns-provider-name=" + testDNSProvider + "' is set correctly")
+			Expect(dnsRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", testDNSProvider))
 
 			By("ensuring zone records are created as expected")
 			testProvider, err := ProviderForDNSRecord(ctx, dnsRecord, k8sClient, dynamicClient)


### PR DESCRIPTION
This PR updates the provider interface with a `.Labels()` that returns a map of expected labels for the provider. Currently the providers are only returning a default name label. It is expect these labels will be extended later.

Closes: #506 