### PR TITLE
watch default secrets

### DIFF
--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -209,7 +209,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 	It("uses default provider secret", func(ctx SpecContext) {
 		// remove provider ref to force default secret
-		dnsRecord.Spec.ProviderRef.Name = ""
+		dnsRecord.Spec.ProviderRef = nil
 		Expect(k8sClient.Create(ctx, dnsRecord)).To(Succeed())
 
 		// can't find secret - no label


### PR DESCRIPTION
Improve watch to queue records with no provider ref on update event to the default provider secret.
Also, updating a test to set provider ref to `nil` instead of an empty string to test for #500 bug