### PR TITLE
Add delegation role controller option

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -53,7 +53,11 @@ import (
 )
 
 const (
-	DNSRecordFinalizer        = "kuadrant.io/dns-record"
+	DNSRecordFinalizer = "kuadrant.io/dns-record"
+
+	DelegationRolePrimary   = "primary"
+	DelegationRoleSecondary = "secondary"
+
 	validationRequeueVariance = 0.5
 
 	txtRegistryPrefix              = "kuadrant-"
@@ -80,6 +84,7 @@ type DNSRecordReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	ProviderFactory provider.Factory
+	DelegationRole  string
 	remoteClient    bool
 }
 
@@ -90,6 +95,14 @@ func postReconcile(ctx context.Context, name, ns string) {
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnsrecords,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnsrecords/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnsrecords/finalizers,verbs=update
+
+func (r *DNSRecordReconciler) IsPrimary() bool {
+	return r.DelegationRole == DelegationRolePrimary
+}
+
+func (r *DNSRecordReconciler) IsSecondary() bool {
+	return r.DelegationRole == DelegationRoleSecondary
+}
 
 func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// Keep a reference to the initial logger(baseLogger) so we can update it throughout the reconcile

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -109,6 +109,8 @@ var _ = BeforeSuite(func() {
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: providerFactory,
+		DelegationRole:  DelegationRolePrimary,
+		remoteClient:    false,
 	}).SetupWithManager(mgr, RequeueDuration, ValidityDuration, DefaultValidationDuration, true, true)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
closes #507

Adds a controller option "--delegation-role=[primary|secondary]" that depending on the value will initiate the controller in different "modes".

A role of "secondary" indicates that it will have limited responsibilities when reconciling DNSRecords that are delegated, in this mode the controller will not start the multi cluster reocnciler and cluster secrets will not be processed.A role of "primary" is the default and indicates it should start with multicluster features enabled(current behaviour) and will process delegated records (future work).

**Verification**

```
make local-setup
```

**primary**
```
make run-primary
```

Verify the multicluster controller is started (check the logs)

**secondary**
```
make run-secondary
```

Verify the multicluster controller is not started  (check the logs)

Notes:

* We need to look into how we are going to run integration test suites with different roles set.
* Follow on work needs to allow the setup of local clusters to take a role and not install "primary" specific components (coredns, bind9 etc..) when role is "secondary" 