### PR TITLE
feat: multicluster dnsrecord delegation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
+ifeq ($(DELEGATION_MODE), secondary)
+deploy: DEPLOY_KUSTOMIZATION=config/local-setup/dns-operator/secondary
+else
 deploy: DEPLOY_KUSTOMIZATION=config/deploy/local
+endif
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build ${DEPLOY_KUSTOMIZATION} | $(KUBECTL) apply -f -

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -13,3 +13,6 @@ const ConditionTypeHealthy ConditionType = "Healthy"
 const ConditionReasonHealthy ConditionReason = "AllChecksPassed"
 const ConditionReasonPartiallyHealthy ConditionReason = "SomeChecksPassed"
 const ConditionReasonUnhealthy ConditionReason = "HealthChecksFailed"
+
+const ConditionTypeReadyForDelegation ConditionType = "ReadyForDelegation"
+const ConditionReasonFinalizersSet ConditionReason = "FinalizersSet"

--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -171,10 +171,18 @@ type DNSRecordStatus struct {
 	ZoneDomainName string `json:"zoneDomainName,omitempty"`
 }
 
+func (s *DNSRecordStatus) ReadyForDelegation() bool {
+	delegationReadyCond := meta.FindStatusCondition(s.Conditions, string(ConditionTypeReadyForDelegation))
+	if delegationReadyCond != nil && delegationReadyCond.Status == metav1.ConditionTrue {
+		return true
+	}
+	return false
+}
+
 // ProviderEndpointsRemoved return true if the ready status condition has the reason set to "ProviderEndpointsRemoved"
 func (s *DNSRecordStatus) ProviderEndpointsRemoved() bool {
 	readyCond := meta.FindStatusCondition(s.Conditions, string(ConditionTypeReady))
-	if readyCond != nil && readyCond.Reason == string(ConditionReasonProviderEndpointsRemoved) {
+	if readyCond == nil || readyCond.Reason == string(ConditionReasonProviderEndpointsRemoved) {
 		return true
 	}
 	return false
@@ -183,7 +191,7 @@ func (s *DNSRecordStatus) ProviderEndpointsRemoved() bool {
 // ProviderEndpointsDeletion return true if the ready status condition has the reason set to "ProviderEndpointsDeletion"
 func (s *DNSRecordStatus) ProviderEndpointsDeletion() bool {
 	readyCond := meta.FindStatusCondition(s.Conditions, string(ConditionTypeReady))
-	if readyCond != nil && readyCond.Reason == string(ConditionReasonProviderEndpointsDeletion) {
+	if readyCond == nil || readyCond.Reason == string(ConditionReasonProviderEndpointsDeletion) {
 		return true
 	}
 	return false
@@ -290,4 +298,8 @@ func (s *DNSRecord) GetRootHost() string {
 
 func init() {
 	SchemeBuilder.Register(&DNSRecord{}, &DNSRecordList{})
+}
+
+func (s *DNSRecord) IsDeleting() bool {
+	return s.DeletionTimestamp != nil && !s.DeletionTimestamp.IsZero()
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -232,6 +232,7 @@ func main() {
 
 	dnsRecordController := &controller.DNSRecordReconciler{
 		Client:          mgr.GetClient(),
+		LocalClient:     mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: providerFactory,
 		DelegationRole:  delegationRole,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -170,6 +170,7 @@ func main() {
 	var mgr ctrl.Manager
 	var mcmgr mcmanager.Manager
 	var err error
+	setupLog.Info("using delegation role: ", "delegationRole", delegationRole)
 	if delegationRole == controller.DelegationRoleSecondary {
 		setupLog.Info("Creating manager")
 		// Use the normal controller runtime manager when running with the secondary delegation role

--- a/config/local-setup/dns-operator/secondary/kustomization.yaml
+++ b/config/local-setup/dns-operator/secondary/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+  - ../../../deploy/local
+
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --delegation-role=secondary
+    target:
+      kind: Deployment

--- a/internal/common/helper.go
+++ b/internal/common/helper.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -26,4 +27,17 @@ func RandomizeDuration(variance, duration float64) time.Duration {
 	return time.Millisecond * time.Duration(rand.Int63nRange(
 		int64(lowerLimit),
 		int64(upperLimit)))
+}
+
+func FormatRootHost(rootHost string) string {
+	formatted := strings.Replace(rootHost, "*", "w", 1)
+	if len([]byte(formatted)) > 63 {
+		formatted = string([]byte(formatted)[:63])
+	}
+
+	for []byte(formatted)[len([]byte(formatted))-1] == []byte(".")[0] {
+		formatted = string([]byte(formatted)[:len([]byte(formatted))-2])
+	}
+
+	return formatted
 }

--- a/internal/common/helper.go
+++ b/internal/common/helper.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/kuadrant/dns-operator/internal/common/hash"
 )
 
 // RandomizeValidationDuration randomizes duration for a given variance with a min value of 1 sec
@@ -29,15 +30,7 @@ func RandomizeDuration(variance, duration float64) time.Duration {
 		int64(upperLimit)))
 }
 
-func FormatRootHost(rootHost string) string {
-	formatted := strings.Replace(rootHost, "*", "w", 1)
-	if len([]byte(formatted)) > 63 {
-		formatted = string([]byte(formatted)[:63])
-	}
-
-	for []byte(formatted)[len([]byte(formatted))-1] == []byte(".")[0] {
-		formatted = string([]byte(formatted)[:len([]byte(formatted))-2])
-	}
-
-	return formatted
+// HashRootHost generates a hash value of the given root host with a fixed length of 8
+func HashRootHost(rootHost string) string {
+	return hash.ToBase36HashLen(rootHost, 8)
 }

--- a/internal/common/helper_test.go
+++ b/internal/common/helper_test.go
@@ -5,6 +5,8 @@ package common
 import (
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestRandomizeDuration(t *testing.T) {
@@ -30,6 +32,59 @@ func TestRandomizeDuration(t *testing.T) {
 				}
 				i++
 			}
+		})
+	}
+}
+
+func Test_FormatRootHost(t *testing.T) {
+	RegisterTestingT(t)
+
+	scenarios := []struct {
+		Name     string
+		RootHost string
+		Verify   func(formatted string)
+	}{
+		{
+			Name:     "regular host is not altered",
+			RootHost: "pb.com",
+			Verify: func(formatted string) {
+				Expect(formatted).To(Equal("pb.com"))
+			},
+		},
+		{
+			Name:     "long host is shortened",
+			RootHost: "123456789-123456789-123456789-123456789-123456789-123456789-123456789-",
+			Verify: func(formatted string) {
+				Expect(formatted).To(Equal("123456789-123456789-123456789-123456789-123456789-123456789-123"))
+			},
+		},
+		{
+			Name:     "wildcards are replace with 'w'",
+			RootHost: "*.pb.com",
+			Verify: func(formatted string) {
+				Expect(formatted).To(Equal("w.pb.com"))
+			},
+		},
+		{
+			Name:     "long host with wildcard, wildcard is replaced and host is shortened",
+			RootHost: "*.123456789-123456789-123456789-123456789-123456789-123456789-123456789-",
+			Verify: func(formatted string) {
+				Expect(formatted).To(Equal("w.123456789-123456789-123456789-123456789-123456789-123456789-1"))
+			},
+		},
+		{
+			Name:     "long host with wildcard, wildcard is replaced and host is shortened and trailing periods removed",
+			RootHost: "*.123456789.......................................................",
+			Verify: func(formatted string) {
+				Expect(formatted).To(Equal("w.123456789"))
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			scenario.Verify(FormatRootHost(scenario.RootHost))
+
 		})
 	}
 }

--- a/internal/common/helper_test.go
+++ b/internal/common/helper_test.go
@@ -5,8 +5,6 @@ package common
 import (
 	"testing"
 	"time"
-
-	. "github.com/onsi/gomega"
 )
 
 func TestRandomizeDuration(t *testing.T) {
@@ -36,55 +34,28 @@ func TestRandomizeDuration(t *testing.T) {
 	}
 }
 
-func Test_FormatRootHost(t *testing.T) {
-	RegisterTestingT(t)
-
-	scenarios := []struct {
-		Name     string
-		RootHost string
-		Verify   func(formatted string)
+func TestFormatRootHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		rootHost string
+		want     string
 	}{
 		{
-			Name:     "regular host is not altered",
-			RootHost: "pb.com",
-			Verify: func(formatted string) {
-				Expect(formatted).To(Equal("pb.com"))
-			},
+			name:     "converts short root host to hash with length 8",
+			rootHost: "pb.com",
+			want:     "jsys0tw1",
 		},
 		{
-			Name:     "long host is shortened",
-			RootHost: "123456789-123456789-123456789-123456789-123456789-123456789-123456789-",
-			Verify: func(formatted string) {
-				Expect(formatted).To(Equal("123456789-123456789-123456789-123456789-123456789-123456789-123"))
-			},
-		},
-		{
-			Name:     "wildcards are replace with 'w'",
-			RootHost: "*.pb.com",
-			Verify: func(formatted string) {
-				Expect(formatted).To(Equal("w.pb.com"))
-			},
-		},
-		{
-			Name:     "long host with wildcard, wildcard is replaced and host is shortened",
-			RootHost: "*.123456789-123456789-123456789-123456789-123456789-123456789-123456789-",
-			Verify: func(formatted string) {
-				Expect(formatted).To(Equal("w.123456789-123456789-123456789-123456789-123456789-123456789-1"))
-			},
-		},
-		{
-			Name:     "long host with wildcard, wildcard is replaced and host is shortened and trailing periods removed",
-			RootHost: "*.123456789.......................................................",
-			Verify: func(formatted string) {
-				Expect(formatted).To(Equal("w.123456789"))
-			},
+			name:     "converts long root host to hash with length 8",
+			rootHost: "123456789-123456789-123456789-123456789-123456789-123456789-123456789-123456789.pb.com",
+			want:     "d4ns4xlx",
 		},
 	}
-
-	for _, scenario := range scenarios {
-		t.Run(scenario.Name, func(t *testing.T) {
-			scenario.Verify(FormatRootHost(scenario.RootHost))
-
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HashRootHost(tt.rootHost); got != tt.want {
+				t.Errorf("HashRootHost() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/internal/controller/dnsrecord_controller_delegation_test.go
+++ b/internal/controller/dnsrecord_controller_delegation_test.go
@@ -1,0 +1,887 @@
+//go:build integration
+
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gstruct"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common"
+	"github.com/kuadrant/dns-operator/pkg/builder"
+)
+
+var _ = Describe("DNSRecordReconciler", func() {
+	// Delegation specific test cases
+	Describe("Delegation", Labels{"delegation"}, func() {
+		var (
+			// buffer containing all the log entries added during the current spec execution
+			logBuffer *gbytes.Buffer
+
+			primaryDNSRecord *v1alpha1.DNSRecord
+
+			dnsProviderSecret *v1.Secret
+			testNamespace     string
+			// testZoneDomainName generated domain for this test e.g. xyz.example.com
+			testZoneDomainName string
+			// testZoneID generated zoneID for this test. Currently, the same as testZoneDomainName for inmemory provider.
+			testZoneID string
+			// testHostname generated host for this test e.g. foo.xyz.example.com
+			testHostname string
+		)
+
+		BeforeEach(func() {
+			logBuffer = gbytes.NewBuffer()
+			GinkgoWriter.TeeTo(logBuffer)
+
+			testNamespace = generateTestNamespaceName()
+
+			By(fmt.Sprintf("creating '%s' test namespace on the primary", testNamespace))
+			CreateNamespace(testNamespace, primaryK8sClient)
+
+			testZoneDomainName = strings.Join([]string{GenerateName(), "example.com"}, ".")
+			testHostname = strings.Join([]string{"foo", testZoneDomainName}, ".")
+			// In memory provider currently uses the same value for domain and id
+			// Issue here to change this https://github.com/Kuadrant/dns-operator/issues/208
+			testZoneID = testZoneDomainName
+
+			By(fmt.Sprintf("creating inmemory dns provider in the '%s' test namespace on the primary", testNamespace))
+			dnsProviderSecret = builder.NewProviderBuilder("inmemory-credentials", testNamespace).
+				For(v1alpha1.SecretTypeKuadrantInmemory).
+				WithZonesInitialisedFor(testZoneDomainName).
+				Build()
+			Expect(primaryK8sClient.Create(ctx, dnsProviderSecret)).To(Succeed())
+
+			primaryDNSRecord = &v1alpha1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testHostname,
+					Namespace: testNamespace,
+				},
+				Spec: v1alpha1.DNSRecordSpec{
+					RootHost: testHostname,
+					Endpoints: []*externaldnsendpoint.Endpoint{
+						{
+							DNSName:          testHostname,
+							Targets:          []string{"127.0.0.1"},
+							RecordType:       "A",
+							RecordTTL:        60,
+							Labels:           nil,
+							ProviderSpecific: nil,
+						},
+					},
+					Delegate: true,
+				},
+			}
+		})
+
+		It("should default to false if not specified", func(ctx SpecContext) {
+			By("creating a dnsrecord with not delegate field")
+			primaryDNSRecord.Spec = v1alpha1.DNSRecordSpec{
+				RootHost: testHostname,
+				ProviderRef: &v1alpha1.ProviderRef{
+					Name: dnsProviderSecret.Name,
+				},
+				Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
+			}
+			By("verifying created record has delegating=false")
+			Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(primaryDNSRecord.IsDelegating()).To(BeFalse())
+			}, TestTimeoutMedium, time.Second).Should(Succeed())
+		})
+
+		It("should create authoritative record on the primary for delegating record on the primary", Labels{"primary"}, func(ctx SpecContext) {
+			var authRecord *v1alpha1.DNSRecord
+
+			By("creating delegating dnsrecord on the primary")
+			Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+
+			By("verifying the status of the primary record")
+			Eventually(func(g Gomega) {
+				// Find the record
+				g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)).To(Succeed())
+				// Verify the expected state of the record
+				g.Expect(primaryDNSRecord.Status.Conditions).To(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":             Equal(metav1.ConditionTrue),
+						"Reason":             Equal("ProviderSuccess"),
+						"Message":            Equal("Provider ensured the dns record"),
+						"ObservedGeneration": Equal(primaryDNSRecord.Generation),
+					})),
+				)
+				//ToDo is this right?
+				g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+					})),
+				)
+				g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+				g.Expect(primaryDNSRecord.IsDelegating()).To(BeTrue())
+				g.Expect(primaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash()))
+				g.Expect(primaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "endpoint"))
+			}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+			By("verifying the authoritative record exists and has the correct spec and status")
+			Eventually(func(g Gomega) {
+				// Find the authoritative record
+				authRecords := &v1alpha1.DNSRecordList{}
+				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+				g.Expect(authRecords.Items).To(HaveLen(1))
+				authRecord = &authRecords.Items[0]
+
+				// Verify the expected state of the authoritative record
+				g.Expect(authRecord.IsDelegating()).To(BeFalse())
+				g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
+				// no default secret yet
+				g.Expect(authRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+				g.Expect(authRecord.Status.Conditions).To(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":  Equal(metav1.ConditionFalse),
+						"Reason":  Equal("DNSProviderError"),
+						"Message": Equal("No default provider secret labeled kuadrant.io/default-provider was found"),
+					})),
+				)
+				g.Expect(authRecord.Status.Conditions).ToNot(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+					})),
+				)
+				//authoritative record should contain the expected endpoint and registry record
+				g.Expect(authRecord.Spec.Endpoints).To(HaveLen(2))
+				g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":    Equal(testHostname),
+						"Targets":    ConsistOf("127.0.0.1"),
+						"RecordType": Equal("A"),
+						"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":    HaveSuffix(testHostname),
+						"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+						"RecordType": Equal("TXT"),
+						"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+					})),
+				))
+			}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+			By("verifying the primary record status references the authoritative record")
+			// Verify record status has authoritative record referenced
+			Expect(primaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+			Expect(primaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+
+			By(fmt.Sprintf("setting the inmemory dns provider as the default in the '%s' test namespace", testNamespace))
+			// Set the default-provider label on the provider secret
+			labels := dnsProviderSecret.GetLabels()
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			labels[v1alpha1.DefaultProviderSecretLabel] = "true"
+			dnsProviderSecret.SetLabels(labels)
+			Expect(primaryK8sClient.Update(ctx, dnsProviderSecret)).To(Succeed())
+
+			By("verifying authoritative record becomes ready")
+			Eventually(func(g Gomega) {
+				// Get the authoritative record
+				g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
+				// Verify the authoritative record becomes ready
+				g.Expect(authRecord.Status.Conditions).To(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal("ProviderSuccess"),
+						"Message": Equal("Provider ensured the dns record"),
+					})),
+				)
+				// Verify the authoritative record has the expected provider label
+				g.Expect(authRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
+			}, TestTimeoutMedium, time.Second).Should(Succeed())
+		})
+
+		Context("with secondary", Labels{"multicluster"}, func() {
+			var (
+				secondaryDNSRecord     *v1alpha1.DNSRecord
+				secondaryClusterSecret *v1.Secret
+			)
+
+			BeforeEach(func() {
+				By("creating kubeconfig secret for secondary cluster on the primary")
+				secondaryClusterSecret = &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secondary-cluster-1",
+						Namespace: testDefaultClusterSecretNamespace,
+						Labels: map[string]string{
+							testDefaultClusterSecretLabel: "true",
+						},
+					},
+					StringData: map[string]string{
+						"kubeconfig": string(secondaryKubeconfig),
+					},
+				}
+				createClusterKubeconfigSecret(primaryK8sClient, secondaryClusterSecret, logBuffer)
+
+				By(fmt.Sprintf("creating '%s' test namespace on the secondary", testNamespace))
+				CreateNamespace(testNamespace, secondaryK8sClient)
+
+				secondaryDNSRecord = &v1alpha1.DNSRecord{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testHostname,
+						Namespace: testNamespace,
+					},
+					Spec: v1alpha1.DNSRecordSpec{
+						RootHost: testHostname,
+						Endpoints: []*externaldnsendpoint.Endpoint{
+							{
+								DNSName:          testHostname,
+								Targets:          []string{"127.0.0.2"},
+								RecordType:       "A",
+								RecordTTL:        60,
+								Labels:           nil,
+								ProviderSpecific: nil,
+							},
+						},
+						Delegate: true,
+					},
+				}
+			})
+
+			AfterEach(func() {
+				if secondaryClusterSecret != nil {
+					Expect(client.IgnoreNotFound(primaryK8sClient.Delete(ctx, secondaryClusterSecret))).To(Succeed())
+				}
+				GinkgoWriter.ClearTeeWriters()
+			})
+
+			It("should add the correct status to a secondary cluster record that is not delegating", Labels{"secondary"}, func(ctx SpecContext) {
+				By(fmt.Sprintf("creating inmemory dns provider in the '%s' test namespace on the secondary", testNamespace))
+				dnsProviderSecret = builder.NewProviderBuilder("inmemory-credentials", testNamespace).
+					For(v1alpha1.SecretTypeKuadrantInmemory).
+					WithZonesInitialisedFor(testZoneDomainName).
+					Build()
+				Expect(secondaryK8sClient.Create(ctx, dnsProviderSecret)).To(Succeed())
+
+				By("creating non delegating dnsrecord on the secondary")
+				secondaryDNSRecord.Spec = v1alpha1.DNSRecordSpec{
+					RootHost: testHostname,
+					ProviderRef: &v1alpha1.ProviderRef{
+						Name: dnsProviderSecret.Name,
+					},
+					Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
+					Delegate:  false,
+				}
+				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
+					g.Expect(secondaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(secondaryDNSRecord.Generation),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
+					g.Expect(secondaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(secondaryDNSRecord.Status.WriteCounter).To(BeZero())
+					g.Expect(secondaryDNSRecord.Status.ZoneID).To(Equal(testZoneID))
+					g.Expect(secondaryDNSRecord.Status.ZoneDomainName).To(Equal(testZoneDomainName))
+					g.Expect(secondaryDNSRecord.Status.DomainOwners).To(ConsistOf(secondaryDNSRecord.GetUIDHash()))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+			})
+
+			It("primary cluster should skip reconciliation of a secondary cluster record that is not delegating", Labels{"primary", "secondary"}, func(ctx SpecContext) {
+				secondaryDNSRecord.Spec = v1alpha1.DNSRecordSpec{
+					RootHost: testHostname,
+					ProviderRef: &v1alpha1.ProviderRef{
+						Name: dnsProviderSecret.Name,
+					},
+					Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
+					Delegate:  false,
+				}
+
+				By("creating non delegating dnsrecord on the secondary")
+				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
+
+				By("verifying primary cluster skips the reconciliation of the secondary record")
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.dnsrecord_controller\".+\"msg\":\"skipping reconciliation of remote record that is not delegating\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+			})
+
+			It("should create authoritative record on the primary for delegating record on the secondary", Labels{"primary", "secondary"}, func(ctx SpecContext) {
+				var authRecord *v1alpha1.DNSRecord
+
+				By("creating delegating dnsrecord on the secondary")
+				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
+
+				By("verifying the status of the secondary record")
+				Eventually(func(g Gomega) {
+					// Find the record
+					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
+					// Verify the expected state of the record
+					g.Expect(secondaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(secondaryDNSRecord.Generation),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(secondaryDNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(secondaryDNSRecord.Status.DomainOwners).To(ConsistOf(secondaryDNSRecord.GetUIDHash()))
+					g.Expect(secondaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "endpoint"))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the authoritative record exists and has the correct spec and status")
+				Eventually(func(g Gomega) {
+					// Find the authoritative record on the primary
+					authRecords := &v1alpha1.DNSRecordList{}
+					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+					g.Expect(authRecords.Items).To(HaveLen(1))
+					authRecord = &authRecords.Items[0]
+					// Verify the expected state of the authoritative record
+					g.Expect(authRecord.IsDelegating()).To(BeFalse())
+					g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
+					// no default secret yet
+					g.Expect(authRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					g.Expect(authRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionFalse),
+							"Reason":  Equal("DNSProviderError"),
+							"Message": Equal("No default provider secret labeled kuadrant.io/default-provider was found"),
+						})),
+					)
+					g.Expect(authRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(authRecord.Spec.Endpoints).To(HaveLen(2))
+					g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + secondaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the secondary record status references the authoritative record")
+				// Verify record status has authoritative record referenced
+				Expect(secondaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+				Expect(secondaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+			})
+
+			It("should create authoritative record on primary for delegating records on both the primary and secondary", Labels{"primary", "secondary"}, func(ctx SpecContext) {
+				var authRecord *v1alpha1.DNSRecord
+
+				By("creating delegating dnsrecord on the primary")
+				Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+
+				By("creating delegating dnsrecord on the secondary")
+				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
+
+				By("verifying the status of the primary and secondary records")
+				Eventually(func(g Gomega) {
+					// Find the primary record
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)).To(Succeed())
+					// Find the secondary record
+					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
+					// Verify the expected state of the primary record
+					g.Expect(primaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(primaryDNSRecord.Generation),
+						})),
+					)
+					//ToDo is this right?
+					g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(primaryDNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(primaryDNSRecord.Status.OwnerID).To(Equal(primaryDNSRecord.GetUIDHash()))
+					g.Expect(primaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(primaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "endpoint"))
+
+					// Verify the expected state of the secondary record
+					g.Expect(secondaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(secondaryDNSRecord.Generation),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(secondaryDNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(secondaryDNSRecord.Status.OwnerID).To(Equal(secondaryDNSRecord.GetUIDHash()))
+					g.Expect(secondaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(secondaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "endpoint"))
+				}, TestTimeoutLong, time.Second).Should(Succeed())
+
+				By("verifying the authoritative record exists and has the correct spec and status")
+				Eventually(func(g Gomega) {
+					// Find the authoritative record on the primary
+					authRecords := &v1alpha1.DNSRecordList{}
+					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+					g.Expect(authRecords.Items).To(HaveLen(1))
+					authRecord = &authRecords.Items[0]
+					// Verify the expected state of the authoritative record
+					g.Expect(authRecord.IsDelegating()).To(BeFalse())
+					g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
+					// no default secret yet
+					g.Expect(authRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					g.Expect(authRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionFalse),
+							"Reason":  Equal("DNSProviderError"),
+							"Message": Equal("No default provider secret labeled kuadrant.io/default-provider was found"),
+						})),
+					)
+					g.Expect(authRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(authRecord.Spec.Endpoints).To(HaveLen(3))
+					g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.0.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + secondaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the primary record status references the authoritative record")
+				// Verify the primary record status has the authoritative record referenced
+				Expect(primaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+				Expect(primaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+
+				By("verifying the secondary record status references the authoritative record")
+				// Verify the secondary record status has the authoritative record referenced
+				Expect(secondaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+				Expect(secondaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+			})
+
+			// More comprehensive test that covers the following:
+			// - auth record is created correctly and updated by both the primary and secondary delegating records
+			// - auth record becomes ready when a default provider is added
+			// - auth record is updated correctly on delegating record endpoint updates
+			// - auth record is updated correctly on delegating record endpoint additions
+			// - auth record is updated correctly on delegating record endpoint deletions
+			// - auth record is updated correctly on delegating record deletion
+			It("should handle create, update and deletion of delegating records", Labels{"primary", "secondary"}, func(ctx SpecContext) {
+				var authRecord *v1alpha1.DNSRecord
+
+				By("creating delegating dnsrecord on the primary")
+				Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+
+				By("creating delegating dnsrecord on the secondary")
+				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
+
+				By("verifying the status of the primary and secondary records")
+				Eventually(func(g Gomega) {
+					// Find the primary record
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)).To(Succeed())
+					// Find the secondary record
+					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
+					// Verify the expected state of the primary record
+					g.Expect(primaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(primaryDNSRecord.Generation),
+						})),
+					)
+					//ToDo is this right?
+					g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(primaryDNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(primaryDNSRecord.Status.OwnerID).To(Equal(primaryDNSRecord.GetUIDHash()))
+					g.Expect(primaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(primaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "endpoint"))
+
+					// Verify the expected state of the secondary record
+					g.Expect(secondaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(secondaryDNSRecord.Generation),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+					g.Expect(secondaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(secondaryDNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(secondaryDNSRecord.Status.OwnerID).To(Equal(secondaryDNSRecord.GetUIDHash()))
+					g.Expect(secondaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(secondaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "endpoint"))
+				}, TestTimeoutLong, time.Second).Should(Succeed())
+
+				By("verifying an authoritative record exists for the test host")
+				Eventually(func(g Gomega) {
+					// Find the authoritative record on the primary
+					authRecords := &v1alpha1.DNSRecordList{}
+					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+					g.Expect(authRecords.Items).To(HaveLen(1))
+					authRecord = &authRecords.Items[0]
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the authoritative has the correct spec and status")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on the primary
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
+					// Verify the expected state of the authoritative record
+					g.Expect(authRecord.IsDelegating()).To(BeFalse())
+					g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
+					// no default secret yet
+					g.Expect(authRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					g.Expect(authRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionFalse),
+							"Reason":  Equal("DNSProviderError"),
+							"Message": Equal("No default provider secret labeled kuadrant.io/default-provider was found"),
+						})),
+					)
+					g.Expect(authRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					g.Expect(authRecord.Status.OwnerID).To(Equal(authRecord.GetUIDHash()))
+					//ToDo What should DomainOwners be on the authRecord?
+					//g.Expect(authRecord.Status.DomainOwners).To(ConsistOf(authRecord.GetUIDHash()))
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(authRecord.Spec.Endpoints).To(HaveLen(3))
+					g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.0.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + secondaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the primary record status references the authoritative record")
+				// Verify the primary record status has the authoritative record referenced
+				Expect(primaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+				Expect(primaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+
+				By("verifying the secondary record status references the authoritative record")
+				// Verify the secondary record status has the authoritative record referenced
+				Expect(secondaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+				Expect(secondaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+
+				By(fmt.Sprintf("setting the inmemory dns provider as the default in the primary clusters '%s' test namespace", testNamespace))
+				// Set the default-provider label on the provider secret
+				labels := dnsProviderSecret.GetLabels()
+				if labels == nil {
+					labels = map[string]string{}
+				}
+				labels[v1alpha1.DefaultProviderSecretLabel] = "true"
+				dnsProviderSecret.SetLabels(labels)
+				Expect(primaryK8sClient.Update(ctx, dnsProviderSecret)).To(Succeed())
+
+				By("verifying authoritative record becomes ready")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
+					// Verify the authoritative record becomes ready
+					g.Expect(authRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionTrue),
+							"Reason":  Equal("ProviderSuccess"),
+							"Message": Equal("Provider ensured the dns record"),
+						})),
+					)
+					// Verify the authoritative record has the expected provider label
+					g.Expect(authRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("updating existing endpoint and adding additional endpoint to secondary record")
+				Eventually(func(g Gomega) {
+					// refresh the secondary record
+					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
+					secondaryDNSRecord.Spec.Endpoints = []*externaldnsendpoint.Endpoint{
+						{
+							DNSName:          testHostname,
+							Targets:          []string{"127.0.1.2"},
+							RecordType:       "A",
+							RecordTTL:        60,
+							Labels:           nil,
+							ProviderSpecific: nil,
+						},
+						{
+							DNSName:          "cname." + testHostname,
+							Targets:          []string{testHostname},
+							RecordType:       "CNAME",
+							RecordTTL:        120,
+							Labels:           nil,
+							ProviderSpecific: nil,
+						},
+					}
+					g.Expect(secondaryK8sClient.Update(ctx, secondaryDNSRecord)).To(Succeed())
+				}, TestTimeoutShort, time.Second).Should(Succeed())
+
+				By("verifying the authoritative record endpoints are updated correctly")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on the primary
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(authRecord.Spec.Endpoints).To(HaveLen(5))
+					g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.1.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal("cname." + testHostname),
+							"Targets":    ConsistOf(testHostname),
+							"RecordType": Equal("CNAME"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(120)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + secondaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix("cname." + testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + secondaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("deleting endpoint from the secondary record")
+				Eventually(func(g Gomega) {
+					// refresh the secondary record
+					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
+					secondaryDNSRecord.Spec.Endpoints = []*externaldnsendpoint.Endpoint{
+						{
+							DNSName:          testHostname,
+							Targets:          []string{"127.0.1.2"},
+							RecordType:       "A",
+							RecordTTL:        60,
+							Labels:           nil,
+							ProviderSpecific: nil,
+						},
+					}
+					g.Expect(secondaryK8sClient.Update(ctx, secondaryDNSRecord)).To(Succeed())
+				}, TestTimeoutShort, time.Second).Should(Succeed())
+
+				By("verifying the authoritative record endpoints are updated correctly")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on the primary
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(authRecord.Spec.Endpoints).To(HaveLen(5))
+					g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.1.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + secondaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("deleting the secondary record")
+				Expect(secondaryK8sClient.Delete(ctx, secondaryDNSRecord)).To(Succeed())
+				// both clusters should eventually see the delete event
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary.dnsrecord_controller\".+\"msg\":\"Deleting DNSRecord\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.dnsrecord_controller\".+\"msg\":\"Deleting DNSRecord\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				// primary should eventually say it's removed the records from the zone
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.dnsrecord_controller\".+\"msg\":\"Deleted DNSRecord in zone\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				// secondary should eventually say it removed the finalizer, primary should not
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary.dnsrecord_controller\".+\"msg\":\"Removing Finalizer\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				Consistently(logBuffer, TestTimeoutShort).Should(Not(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.dnsrecord_controller\".+\"msg\":\"Removing Finalizer\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace))))
+				// secondary record should be removed
+				Eventually(func(g Gomega) {
+					err := secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+				By("verifying the authoritative record endpoints are updated correctly")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on the primary
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(authRecord.Spec.Endpoints).To(HaveLen(2))
+					g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("deleting the primary record")
+				Expect(primaryK8sClient.Delete(ctx, primaryDNSRecord)).To(Succeed())
+				// primary record should be removed
+				Eventually(func(g Gomega) {
+					err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+				By("verifying the authoritative record endpoints are empty")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on the primary
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
+					//authoritative record should contain no endpoints
+					g.Expect(authRecord.Spec.Endpoints).To(BeEmpty())
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("deleting the authoritative record")
+				Expect(primaryK8sClient.Delete(ctx, authRecord)).To(Succeed())
+				// primary record should be removed
+				Eventually(func(g Gomega) {
+					err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+			})
+		})
+	})
+
+})

--- a/internal/controller/dnsrecord_controller_delegation_test.go
+++ b/internal/controller/dnsrecord_controller_delegation_test.go
@@ -155,7 +155,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			Eventually(func(g Gomega) {
 				// Find the authoritative record
 				authRecords := &v1alpha1.DNSRecordList{}
-				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.HashRootHost(testHostname)})).To(Succeed())
 				g.Expect(authRecords.Items).To(HaveLen(1))
 				authRecord = &authRecords.Items[0]
 
@@ -379,7 +379,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				Eventually(func(g Gomega) {
 					// Find the authoritative record on the primary
 					authRecords := &v1alpha1.DNSRecordList{}
-					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.HashRootHost(testHostname)})).To(Succeed())
 					g.Expect(authRecords.Items).To(HaveLen(1))
 					authRecord = &authRecords.Items[0]
 					// Verify the expected state of the authoritative record
@@ -488,7 +488,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				Eventually(func(g Gomega) {
 					// Find the authoritative record on the primary
 					authRecords := &v1alpha1.DNSRecordList{}
-					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.HashRootHost(testHostname)})).To(Succeed())
 					g.Expect(authRecords.Items).To(HaveLen(1))
 					authRecord = &authRecords.Items[0]
 					// Verify the expected state of the authoritative record
@@ -615,7 +615,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				Eventually(func(g Gomega) {
 					// Find the authoritative record on the primary
 					authRecords := &v1alpha1.DNSRecordList{}
-					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
+					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.HashRootHost(testHostname)})).To(Succeed())
 					g.Expect(authRecords.Items).To(HaveLen(1))
 					authRecord = &authRecords.Items[0]
 				}, TestTimeoutMedium, time.Second).Should(Succeed())

--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -34,6 +34,7 @@ import (
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common"
 	"github.com/kuadrant/dns-operator/pkg/builder"
 )
 
@@ -1064,7 +1065,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 				// Find the authoritative record
 				authRecords := &v1alpha1.DNSRecordList{}
-				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: testHostname})).To(Succeed())
+				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
 				g.Expect(authRecords.Items).To(HaveLen(1))
 				authRecord = &authRecords.Items[0]
 

--- a/internal/controller/dnsrecord_controller_test.go
+++ b/internal/controller/dnsrecord_controller_test.go
@@ -34,7 +34,6 @@ import (
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
-	"github.com/kuadrant/dns-operator/internal/common"
 	"github.com/kuadrant/dns-operator/pkg/builder"
 )
 
@@ -84,7 +83,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 	})
 
 	// Test cases covering validation of the DNSRecord resource fields
-	Context("validation", func() {
+	Context("validation", Labels{"validation"}, func() {
 		It("should error with no rootHost", func(ctx SpecContext) {
 			testHostname = strings.Join([]string{"bar", testZoneDomainName}, ".")
 			dnsRecord = &v1alpha1.DNSRecord{
@@ -148,13 +147,13 @@ var _ = Describe("DNSRecordReconciler", func() {
 			Expect(err).To(MatchError(ContainSubstring("Failure threshold must be greater than 0")))
 		})
 
-		It("prevents the creation of records with both a providerRef and delegation true", func(ctx SpecContext) {
+		It("prevents the creation of records with both a providerRef and delegation true", Labels{"delegation"}, func(ctx SpecContext) {
 			dnsRecord.Spec.Delegate = true
 			err := primaryK8sClient.Create(ctx, dnsRecord)
 			Expect(err).To(MatchError(ContainSubstring("delegate=true and providerRef are mutually exclusive")))
 		})
 
-		It("prevents delegate being set if it was previously unset", func(ctx SpecContext) {
+		It("prevents delegate being set if it was previously unset", Labels{"delegation"}, func(ctx SpecContext) {
 			Expect(primaryK8sClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Eventually(func(g Gomega) {
@@ -168,7 +167,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 		})
 
-		It("prevents delegate being unset if it was previously set", func(ctx SpecContext) {
+		It("prevents delegate being unset if it was previously set", Labels{"delegation"}, func(ctx SpecContext) {
 			dnsRecord.Spec.ProviderRef = nil
 			dnsRecord.Spec.Delegate = true
 			Expect(primaryK8sClient.Create(ctx, dnsRecord)).To(Succeed())
@@ -1007,134 +1006,6 @@ var _ = Describe("DNSRecordReconciler", func() {
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 		})
 
-	})
-
-	// Delegation specific test cases
-	Context("delegation", func() {
-		It("should default to false if not specified", func(ctx SpecContext) {
-			dnsRecord.Spec = v1alpha1.DNSRecordSpec{
-				RootHost: testHostname,
-				ProviderRef: &v1alpha1.ProviderRef{
-					Name: dnsProviderSecret.Name,
-				},
-				Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
-			}
-			Expect(primaryK8sClient.Create(ctx, dnsRecord)).To(Succeed())
-			Eventually(func(g Gomega) {
-				err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(dnsRecord.IsDelegating()).To(BeFalse())
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-		})
-
-		It("should create authoritative record and assign as zone", Labels{"primary"}, func(ctx SpecContext) {
-			var authRecord *v1alpha1.DNSRecord
-			dnsRecord.Spec = v1alpha1.DNSRecordSpec{
-				RootHost: testHostname,
-				Delegate: true,
-				Endpoints: []*externaldnsendpoint.Endpoint{
-					{
-						DNSName:       testHostname,
-						Targets:       []string{"127.0.0.1"},
-						RecordType:    "A",
-						SetIdentifier: "foo",
-						RecordTTL:     60,
-					},
-				},
-			}
-			Expect(primaryK8sClient.Create(ctx, dnsRecord)).To(Succeed())
-
-			Eventually(func(g Gomega) {
-				// Find the record
-				err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord)
-				g.Expect(err).NotTo(HaveOccurred())
-
-				// Verify the expected state of the record
-				g.Expect(dnsRecord.Status.Conditions).To(
-					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
-						"Status":             Equal(metav1.ConditionTrue),
-						"Reason":             Equal("ProviderSuccess"),
-						"Message":            Equal("Provider ensured the dns record"),
-						"ObservedGeneration": Equal(dnsRecord.Generation),
-					})),
-				)
-				g.Expect(dnsRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
-				g.Expect(dnsRecord.IsDelegating()).To(BeTrue())
-				g.Expect(dnsRecord.Status.DomainOwners).To(ConsistOf(dnsRecord.GetUIDHash()))
-
-				// Find the authoritative record
-				authRecords := &v1alpha1.DNSRecordList{}
-				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(testHostname)})).To(Succeed())
-				g.Expect(authRecords.Items).To(HaveLen(1))
-				authRecord = &authRecords.Items[0]
-
-				// Verify the expected state of the authoritative record
-				g.Expect(authRecord.IsDelegating()).To(BeFalse())
-				g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
-				// no default secret yet
-				g.Expect(authRecord.Status.Conditions).To(
-					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
-						"Status":  Equal(metav1.ConditionFalse),
-						"Reason":  Equal("DNSProviderError"),
-						"Message": Equal("No default provider secret labeled kuadrant.io/default-provider was found"),
-					})),
-				)
-				//authoritative record should contain the expected endpoint and registry record
-				g.Expect(authRecord.Spec.Endpoints).To(HaveLen(2))
-				g.Expect(authRecord.Spec.Endpoints).To(ContainElements(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       Equal(testHostname),
-						"Targets":       ConsistOf("127.0.0.1"),
-						"RecordType":    Equal("A"),
-						"SetIdentifier": Equal("foo"),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
-					})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"DNSName":       HaveSuffix(testHostname),
-						"Targets":       ConsistOf("\"heritage=external-dns,external-dns/owner=" + dnsRecord.Status.OwnerID + ",external-dns/version=1\""),
-						"RecordType":    Equal("TXT"),
-						"SetIdentifier": Equal("foo"),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(0)),
-					})),
-				))
-
-				// Verify record status has authoritative record referenced
-				g.Expect(dnsRecord.Status.ZoneID).To(Equal(authRecord.Name))
-				g.Expect(dnsRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-			Eventually(func(g Gomega) {
-				err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(dnsProviderSecret), dnsProviderSecret)
-				g.Expect(err).NotTo(HaveOccurred())
-
-				// Set the default-provider label on the provider secret
-				labels := dnsProviderSecret.GetLabels()
-				if labels == nil {
-					labels = map[string]string{}
-				}
-				labels[v1alpha1.DefaultProviderSecretLabel] = "true"
-				dnsProviderSecret.SetLabels(labels)
-				err = primaryK8sClient.Update(ctx, dnsProviderSecret)
-				g.Expect(err).NotTo(HaveOccurred())
-
-				// Get the authoritative record
-				err = primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)
-				g.Expect(err).NotTo(HaveOccurred())
-
-				// Verify the authoritative record becomes ready
-				g.Expect(authRecord.Status.Conditions).To(
-					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
-						"Status":  Equal(metav1.ConditionTrue),
-						"Reason":  Equal("ProviderSuccess"),
-						"Message": Equal("Provider ensured the dns record"),
-					})),
-				)
-			}, TestTimeoutMedium, time.Second).Should(Succeed())
-
-		})
 	})
 
 })

--- a/internal/controller/dnsrecord_delegation_helper.go
+++ b/internal/controller/dnsrecord_delegation_helper.go
@@ -33,7 +33,7 @@ func (r *DNSRecordDelegationHelper) EnsureAuthoritativeRecord(ctx context.Contex
 func (r *DNSRecordDelegationHelper) getAuthoritativeRecordFor(ctx context.Context, record v1alpha1.DNSRecord) (*v1alpha1.DNSRecord, error) {
 	aRecords := v1alpha1.DNSRecordList{}
 
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.FormatRootHost(record.Spec.RootHost)))
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.HashRootHost(record.Spec.RootHost)))
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func authoritativeRecordFor(rec v1alpha1.DNSRecord) *v1alpha1.DNSRecord {
 			GenerateName: "delegation-authoritative-record-",
 			Namespace:    rec.Namespace,
 			Labels: map[string]string{
-				v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(rec.Spec.RootHost),
+				v1alpha1.DelegationAuthoritativeRecordLabel: common.HashRootHost(rec.Spec.RootHost),
 			},
 		},
 		Spec: v1alpha1.DNSRecordSpec{

--- a/internal/controller/dnsrecord_delegation_helper.go
+++ b/internal/controller/dnsrecord_delegation_helper.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common"
 )
 
 type DNSRecordDelegationHelper struct {
@@ -32,7 +33,7 @@ func (r *DNSRecordDelegationHelper) EnsureAuthoritativeRecord(ctx context.Contex
 func (r *DNSRecordDelegationHelper) getAuthoritativeRecordFor(ctx context.Context, record v1alpha1.DNSRecord) (*v1alpha1.DNSRecord, error) {
 	aRecords := v1alpha1.DNSRecordList{}
 
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, record.Spec.RootHost))
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.FormatRootHost(record.Spec.RootHost)))
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +65,7 @@ func authoritativeRecordFor(rec v1alpha1.DNSRecord) *v1alpha1.DNSRecord {
 			GenerateName: "delegation-authoritative-record-",
 			Namespace:    rec.Namespace,
 			Labels: map[string]string{
-				v1alpha1.DelegationAuthoritativeRecordLabel: rec.Spec.RootHost,
+				v1alpha1.DelegationAuthoritativeRecordLabel: common.FormatRootHost(rec.Spec.RootHost),
 			},
 		},
 		Spec: v1alpha1.DNSRecordSpec{

--- a/internal/controller/remote_dnsrecord_controller.go
+++ b/internal/controller/remote_dnsrecord_controller.go
@@ -56,6 +56,7 @@ func (r *RemoteDNSRecordReconciler) Reconcile(ctx context.Context, req mcreconci
 
 	reconciler := DNSRecordReconciler{
 		Client:          cl.GetClient(),
+		LocalClient:     r.mgr.GetLocalManager().GetClient(),
 		Scheme:          r.Scheme,
 		ProviderFactory: r.ProviderFactory,
 		remoteClient:    true,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -242,6 +242,7 @@ func setupEnv(delegationRole string) (*envtest.Environment, ctrl.Manager) {
 
 	dnsRecordController := &DNSRecordReconciler{
 		Client:          mgr.GetClient(),
+		LocalClient:     mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: providerFactory,
 		DelegationRole:  delegationRole,

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common"
 )
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
@@ -99,7 +100,7 @@ func (f *factory) ProviderFor(ctx context.Context, pa v1alpha1.ProviderAccessor,
 			},
 			Type: v1alpha1.SecretTypeKuadrantEndpoint,
 			Data: map[string][]byte{
-				v1alpha1.EndpointLabelSelectorKey: []byte(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, pa.GetRootHost())),
+				v1alpha1.EndpointLabelSelectorKey: []byte(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.FormatRootHost(pa.GetRootHost()))),
 			},
 		}
 	} else {

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -100,7 +100,7 @@ func (f *factory) ProviderFor(ctx context.Context, pa v1alpha1.ProviderAccessor,
 			},
 			Type: v1alpha1.SecretTypeKuadrantEndpoint,
 			Data: map[string][]byte{
-				v1alpha1.EndpointLabelSelectorKey: []byte(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.FormatRootHost(pa.GetRootHost()))),
+				v1alpha1.EndpointLabelSelectorKey: []byte(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.HashRootHost(pa.GetRootHost()))),
 			},
 		}
 	} else {

--- a/make/dnsproviders.mk
+++ b/make/dnsproviders.mk
@@ -82,6 +82,10 @@ $(LOCAL_SETUP_COREDNS_CREDS):
 	$(call ndef,COREDNS_ZONES)
 	$(call patch-config,${LOCAL_SETUP_COREDNS_CREDS}.template,${LOCAL_SETUP_COREDNS_CREDS})
 
+.PHONY: local-setup-remove-dns-providers
+local-setup-remove-dns-providers:
+	$(KUBECTL) delete secrets -l app.kubernetes.io/part-of=dns-operator -A
+
 .PHONY: local-setup-dns-providers
 local-setup-dns-providers: TARGET_NAMESPACE=dnstest
 local-setup-dns-providers: kustomize ## Create AWS, Azure, GCP, CoreDNS and Endpoints DNS Providers in the 'TARGET_NAMESPACE' namespace


### PR DESCRIPTION
closes #518

Updates the dns record reconciler to accommodate the required flow when using delegation in a multicluster (primary/secondary) configuration.

Related changes:
 - #519
 - #517 
- #489 

**Verification**

**Terminal 1 (primary)**
```
make multicluster-local-setup DEPLOY=false
kubectl config use-context kind-kuadrant-dns-local-1
make run
```

**Terminal 2 (secondary)**
```
export KUBECONFIG=tmp/kubeconfigs/kuadrant-local-all.kubeconfig
kubectl config use-context kind-kuadrant-dns-local-2
make run-secondary
```

**Terminal 3**

Verify cluster secrets
```
kubectl get secrets -A -l kuadrant.io/multicluster-kubeconfig=true --show-labels --context kind-kuadrant-dns-local-1
```
Expected output:
```
NAMESPACE             NAME                        TYPE     DATA   AGE     LABELS
dns-operator-system   kind-kuadrant-dns-local-2   Opaque   1      2m31s   kuadrant.io/multicluster-kubeconfig=true
kubectl get secrets -A -l kuadrant.io/multicluster-kubeconfig=true --show-labels --context kind-kuadrant-dns-local-2
No resources found
```

Label default provider
```
kubectl label secret/dns-provider-credentials-inmemory -n dnstest kuadrant.io/default-provider=true --context kind-kuadrant-dns-local-1
```

Apply record 1 on cluster 1
```
kubectl apply -f config/local-setup/dnsrecords/delegating/inmem/simple/dnsrecord-simple-inmem-cluster1.yaml -n dnstest --context kind-kuadrant-dns-local-1
```

Verify record
```
kubectl get dnsrecord -o wide -n dnstest --show-labels --context kind-kuadrant-dns-local-1
```
Expected output:
```
NAME                                    READY   HEALTHY   ROOT HOST               OWNER ID   ZONE DOMAIN             ZONE ID                                 LABELS
delegation-authoritative-record-c2ckr   True              simple.kuadrant.local   tp3vumh9   kuadrant.local          kuadrant.local                          kuadrant.io/delegation-authoritative-record=2km2e6b6,kuadrant.io/dns-provider-name=inmemory
dnsrecord-simple-inmem-cluster1         True              simple.kuadrant.local   2a9v835j   simple.kuadrant.local   delegation-authoritative-record-c2ckr   kuadrant.io/dns-provider-name=endpoint
```

Verify auth record contents
```
 kubectl get dnsrecord -A -o json -l kuadrant.io/delegation-authoritative-record=2km2e6b6 | jq -r 
'[.items[].spec.endpoints[] | "dnsName: \(.dnsName), recordType: \(.recordType), targets: \(.targets)"]'
```
Expected output:
```
[
  "dnsName: simple.kuadrant.local, recordType: A, targets: [\"172.18.200.1\"]",
  "dnsName: kuadrant-1kdspvzm-a-simple.kuadrant.local, recordType: TXT, targets: [\"\\\"heritage=external-dns,external-dns/owner=2etov4az,external-dns/version=1\\\"\"]"
]
```

Apply record 2 on cluster 2
```
kubectl apply -f config/local-setup/dnsrecords/delegating/inmem/simple/dnsrecord-simple-inmem-cluster2.yaml -n dnstest --context kind-kuadrant-dns-local-2
```

Verify records on cluster 1
```
kubectl get dnsrecord -o wide -n dnstest --show-labels --context kind-kuadrant-dns-local-1
```
Expected output:
```
NAME                                    READY   HEALTHY   ROOT HOST               OWNER ID   ZONE DOMAIN             ZONE ID                                 LABELS
delegation-authoritative-record-pjpwq   False             simple.kuadrant.local   1a9mdwvb   kuadrant.local          kuadrant.local                          kuadrant.io/delegation-authoritative-record=simple.kuadrant.local
dnsrecord-simple-inmem-cluster1         True              simple.kuadrant.local   2etov4az   simple.kuadrant.local   delegation-authoritative-record-pjpwq   <none>
```
Verify records on cluster 2
```
kubectl get dnsrecord -o wide -n dnstest --show-labels --context kind-kuadrant-dns-local-2
```
Expected output:
```
NAME                              READY   HEALTHY   ROOT HOST               OWNER ID   ZONE DOMAIN             ZONE ID                                 LABELS
dnsrecord-simple-inmem-cluster2   True              simple.kuadrant.local   qs008om3   simple.kuadrant.local   delegation-authoritative-record-pjpwq   <none>
```

Verify auth record contents
```
kubectl get dnsrecord -A -o json -l kuadrant.io/delegation-authoritative-record=simple.kuadrant.local | jq -r '[.items[].spec.endpoints[] | "dnsName: \(.dnsName), recordType: \(.recordType), targets: \(.targets)"]'
```
Expected output:
```
[
  "dnsName: simple.kuadrant.local, recordType: A, targets: [\"172.18.200.1\",\"172.18.200.2\"]",
  "dnsName: kuadrant-1kdspvzm-a-simple.kuadrant.local, recordType: TXT, targets: [\"\\\"heritage=external-dns,external-dns/owner=2etov4az,external-dns/version=1\\\"\"]",
  "dnsName: kuadrant-uzeol5ga-a-simple.kuadrant.local, recordType: TXT, targets: [\"\\\"heritage=external-dns,external-dns/owner=qs008om3,external-dns/version=1\\\"\"]"
]
```
 