### PR TITLE
Remove duplicate flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -113,9 +113,6 @@ func main() {
 	flag.BoolVar(&dnsProbesEnabled, dnsProbesEnabledKey.Flag(), true, "Enable DNSHealthProbes controller.")
 	flag.BoolVar(&allowInsecureCerts, allowInsecureCertsKey.Flag(), true, "Allow DNSHealthProbes to use insecure certificates")
 
-	flag.BoolVar(&dnsProbesEnabled, dnsProbesEnabledKey.Flag(), true, "Enable DNSHealthProbes controller.")
-	flag.BoolVar(&allowInsecureCerts, allowInsecureCertsKey.Flag(), true, "Allow DNSHealthProbes to use insecure certificates")
-
 	flag.StringVar(&metricsAddr, metricsAddrKey.Flag(), ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, probeAddrKey.Flag(), ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, enableLeaderElectionKey.Flag(), false,


### PR DESCRIPTION
DNS operator crash looping after #516

Can see the failure in the E2E tests which weren't required to merge https://github.com/Kuadrant/dns-operator/actions/runs/16748147147/job/47411515503