### PR TITLE
run e2e workflow when triggering_actor has write permissions

### DIFF
--- a/.github/workflows/ci-e2e-0.yaml
+++ b/.github/workflows/ci-e2e-0.yaml
@@ -48,6 +48,10 @@ on:
         type: boolean
   merge_group:
     types: [ checks_requested ]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
 
 env:
   TEST_NAMESPACE: e2e-test
@@ -61,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Pre job checks
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip_e2e: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - uses: actions/checkout@v4
       - id: skip_check
@@ -69,13 +73,28 @@ jobs:
         with:
           cancel_others: false
           paths_ignore: '["**/*.md", "**/*.adoc", "LICENSE"]'
-          do_not_skip: '["push", "merge_group", "workflow_dispatch", "schedule"]'
+          do_not_skip: '["pull_request", "push", "merge_group", "workflow_dispatch", "schedule"]'
   e2e-test-suite:
     name: E2E Test Suite
-    if: needs.pre-job.outputs.should_skip != 'true'
+    if: needs.pre-job.outputs.should_skip_e2e != 'true'
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
When a new PR is opened against main on the Kuadrant dns-operator repo, the e2e tests will not run.

By adding a `run-e2e` label to that PR (action that is only available with write access to the repo), the e2e tests will run on any update to the PR.

If the label is present and the e2e tests are failing, the PR will not be able to merge.

If the workflow is edited in the incoming branch to change this flow, it will not be honoured (unless merged).