### PR TITLE
cli: add release workflow

### DIFF
--- a/.github/workflows/release.cli.yml
+++ b/.github/workflows/release.cli.yml
@@ -1,0 +1,26 @@
+name: Release CLI
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release-matrix:
+    name: Release dns-operator CLI Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wangyoucao577/go-release-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: 1.24.0
+          project_path: ./cmd/plugin/
+          binary_name: kubectl-dns
+          ldflags: -X "main.gitSHA=${{ github.sha }}" -X "main.version=${{ github.ref_name }}"


### PR DESCRIPTION
Add a workflow to build cli binaries

You can see a workflow run [here](https://github.com/maksymvavilov/dns-operator/actions/runs/17097389204) on [this](https://github.com/maksymvavilov/dns-operator/releases/tag/sample-release) test release of a fork 

Latest commit on the main of my fork (where the release run) is the same as on this PR. 