### PR TITLE
Update integration test suite for primary and secondary testing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,11 +162,12 @@ test: test-unit test-integration ## Run tests.
 
 .PHONY: test-unit
 test-unit: manifests generate fmt vet ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -tags=unit -coverprofile cover-unit.out
+	go test ./... -tags=unit -coverprofile cover-unit.out
 
 .PHONY: test-integration
+test-integration: GINKGO_FLAGS=
 test-integration: manifests generate fmt vet envtest ginkgo ## Run integration tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -tags=integration ./internal/controller -coverprofile cover-integration.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) $(GINKGO_FLAGS) -tags=integration ./internal/controller -coverprofile cover-integration.out
 
 .PHONY: test-e2e
 test-e2e: ginkgo

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -172,7 +172,7 @@ func main() {
 	var err error
 	if delegationRole == controller.DelegationRoleSecondary {
 		setupLog.Info("Creating manager")
-		// Use the normal controller runtime manager when in remote mode
+		// Use the normal controller runtime manager when running with the secondary delegation role
 		mgr, err = ctrl.NewManager(ctrl.GetConfigOrDie(), defaultOptions)
 		if err != nil {
 			setupLog.Error(err, "unable to start manager")

--- a/internal/controller/kubeconfig_provider_test.go
+++ b/internal/controller/kubeconfig_provider_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+)
+
+var _ = Describe("Kubeconfig Provider", Labels{"multicluster"}, func() {
+
+	var (
+		secondaryClusterSecret *v1.Secret
+
+		// buffer containing all the log entries added during the current spec execution
+		// can be used in conjunction with `gbytes.Say` matcher to check log entries see https://onsi.github.io/gomega/#codegbytescode-testing-streaming-buffers
+		logBuffer *gbytes.Buffer
+	)
+
+	BeforeEach(func() {
+		logBuffer = gbytes.NewBuffer()
+		GinkgoWriter.TeeTo(logBuffer)
+
+		secondaryClusterSecret = &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secondary-cluster-1",
+				Namespace: testDefaultClusterSecretNamespace,
+				Labels: map[string]string{
+					testDefaultClusterSecretLabel: "true",
+				},
+			},
+			StringData: map[string]string{
+				"kubeconfig": string(secondaryKubeconfig),
+			},
+		}
+	})
+
+	AfterEach(func() {
+		if secondaryClusterSecret != nil {
+			Expect(client.IgnoreNotFound(primaryK8sClient.Delete(ctx, secondaryClusterSecret))).To(Succeed())
+		}
+		GinkgoWriter.ClearTeeWriters()
+	})
+
+	It("successfully establishes a connection to a remote cluster when valid kubeconfig secret is created", Labels{"primary"}, func(ctx SpecContext) {
+		createClusterKubeconfigSecret(primaryK8sClient, secondaryClusterSecret, logBuffer)
+	})
+
+	It("successfully closes connection to the remote cluster when kubeconfig secret is deleted", Labels{"primary"}, func(ctx SpecContext) {
+		createClusterKubeconfigSecret(primaryK8sClient, secondaryClusterSecret, logBuffer)
+		deleteClusterKubeconfigSecret(primaryK8sClient, secondaryClusterSecret, logBuffer)
+	})
+
+	It("fails to establishes a connection to a remote cluster when invalid kubeconfig secret is created", Labels{"primary"}, func(ctx SpecContext) {
+		invalidSecret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secondary-cluster-1",
+				Namespace: testDefaultClusterSecretNamespace,
+				Labels: map[string]string{
+					testDefaultClusterSecretLabel: "true",
+				},
+			},
+			StringData: map[string]string{
+				"kubeconfig": "",
+			},
+		}
+		Expect(primaryK8sClient.Create(ctx, invalidSecret)).To(Succeed())
+		Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("Secret does not contain kubeconfig data, skipping\\s*{\"cluster\": \"%s\", \"secret\": \"%s\\/%s\", \"key\": \"kubeconfig\"}", invalidSecret.Name, invalidSecret.Namespace, invalidSecret.Name)))
+	})
+
+	It("triggers reconcile of secondary cluster record on primary", Labels{"primary", "secondary"}, func(ctx SpecContext) {
+		createClusterKubeconfigSecret(primaryK8sClient, secondaryClusterSecret, logBuffer)
+
+		testNamespace := generateTestNamespaceName()
+		CreateNamespace(testNamespace, secondaryK8sClient)
+
+		testZoneDomainName := strings.Join([]string{GenerateName(), "example.com"}, ".")
+		testHostname := strings.Join([]string{"foo", testZoneDomainName}, ".")
+
+		secondaryRecord := &v1alpha1.DNSRecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testHostname,
+				Namespace: testNamespace,
+			},
+			Spec: v1alpha1.DNSRecordSpec{
+				RootHost:  testHostname,
+				Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
+			},
+		}
+		Expect(secondaryK8sClient.Create(ctx, secondaryRecord)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryRecord), secondaryRecord)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, TestTimeoutShort, time.Second).Should(Succeed())
+
+		//Verify the secondary log contains the expected statements
+		Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("secondary.dnsrecord_controller\\s*Reconciled DNSRecord %s from namespace %s", secondaryRecord.Name, secondaryRecord.Namespace)))
+		//Example: 2025-08-26T17:55:11+01:00     INFO    secondary.dnsrecord_controller  Reconciled DNSRecord foo.hidden-voice.example.com from namespace test-namespace-a874ca2a-19b1-4e38-b040-bb357df7dd8e in 7.031572ms      {"controller": "dnsrecord", "controllerGroup": "kuadrant.io", "controllerKind": "DNSRecord", "DNSRecord": {"name":"foo.hidden-voice.example.com","namespace":"test-namespace-a874ca2a-19b1-4e38-b040-bb357df7dd8e"}, "namespace": "test-namespace-a874ca2a-19b1-4e38-b040-bb357df7dd8e", "name": "foo.hidden-voice.example.com", "reconcileID": "2d512957-50bf-4c75-a701-0f7b4f409ae3"}
+
+		//Verify the primary log contains the expected statements
+		Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("primary.remote_dnsrecord_controller\\s+Remote Reconcile\\s+{\"controller\": \"remote-dnsrecord-controller\".+\"cluster\": \"%s\".+\"req\": \"cluster:\\/\\/%s\\/%s\\/%s\"", secondaryClusterSecret.Name, secondaryClusterSecret.Name, secondaryRecord.Namespace, secondaryRecord.Name)))
+		//Example: 2025-08-26T17:55:11+01:00     INFO    primary.remote_dnsrecord_controller     Remote Reconcile        {"controller": "remote-dnsrecord-controller", "controllerGroup": "kuadrant.io", "controllerKind": "DNSRecord", "reconcileID": "728d600c-12b8-4650-9fee-baf635636bad", "cluster": "secondary-cluster-1", "req": "cluster://secondary-cluster-1/test-namespace-a874ca2a-19b1-4e38-b040-bb357df7dd8e/foo.hidden-voice.example.com"}
+	})
+
+})
+
+func createClusterKubeconfigSecret(k8sClient client.Client, secret *v1.Secret, logBuffer *gbytes.Buffer) {
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+	Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("Creating new cluster from kubeconfig\\s*{\"cluster\": \"%s\", \"secret\": \"%s\\/%s\"}", secret.Name, secret.Namespace, secret.Name)))
+	Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("Successfully added cluster\\s*{\"cluster\": \"%s\", \"secret\": \"%s\\/%s\"}", secret.Name, secret.Namespace, secret.Name)))
+	Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("Successfully engaged manager\\s*{\"cluster\": \"%s\", \"secret\": \"%s\\/%s\"}", secret.Name, secret.Namespace, secret.Name)))
+}
+
+func deleteClusterKubeconfigSecret(k8sClient client.Client, secret *v1.Secret, logBuffer *gbytes.Buffer) {
+	Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+	Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("Removing cluster\\s*{\"cluster\": \"%s\"}", secret.Name)))
+	Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("Successfully removed cluster and cancelled cluster context\\s*{\"cluster\": \"%s\"}", secret.Name)))
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -34,12 +35,16 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	kubeconfigprovider "sigs.k8s.io/multicluster-runtime/providers/kubeconfig"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
 	"github.com/kuadrant/dns-operator/internal/provider"
@@ -54,12 +59,31 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var dnsProvider provider.Provider
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+const (
+	testDefaultClusterSecretNamespace = "dns-operator-system"
+	testDefaultClusterSecretLabel     = "kuadrant.io/multicluster-kubeconfig"
+)
+
+var (
+	// Controller runtime env test environments for each delegation role
+	primaryTestEnv   *envtest.Environment
+	secondaryTestEnv *envtest.Environment
+
+	// Managers created for each environment
+	primaryManager   ctrl.Manager
+	secondaryManager ctrl.Manager
+
+	// Kubernetes clients created for each environment
+	primaryK8sClient   client.Client
+	secondaryK8sClient client.Client
+
+	// Kubeconfig data for 'kuadrant' user added to each environment
+	secondaryKubeconfig []byte
+	primaryKubeconfig   []byte
+
+	ctx    context.Context
+	cancel context.CancelFunc
+)
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -72,13 +96,93 @@ var _ = BeforeSuite(func() {
 
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
+
+	primaryTestEnv, primaryManager = setupEnv(DelegationRolePrimary)
+	secondaryTestEnv, secondaryManager = setupEnv(DelegationRoleSecondary)
+
+	primaryK8sClient = primaryManager.GetClient()
+	secondaryK8sClient = secondaryManager.GetClient()
+
+	go func() {
+		defer GinkgoRecover()
+		err := primaryManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	go func() {
+		defer GinkgoRecover()
+		err := secondaryManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	//Create the namespace to hold multicluster secrets on the primary
+	By(fmt.Sprintf("creating namespace '%s' on primary", testDefaultClusterSecretNamespace))
+	CreateNamespace(testDefaultClusterSecretNamespace, primaryK8sClient)
+
+	//Create a 'kuadrant' user in the primary environment and store the kubeconfig
+	By("creating user 'kuadrant' in primary environment")
+	primaryKubeconfig = createKuadrantUser(primaryTestEnv)
+	Expect(primaryKubeconfig).ToNot(BeEmpty())
+
+	//Create a 'kuadrant' user in the secondary environment and store the kubeconfig
+	By("creating user 'kuadrant' in secondary environment")
+	secondaryKubeconfig = createKuadrantUser(secondaryTestEnv)
+	Expect(secondaryKubeconfig).ToNot(BeEmpty())
+
+	Expect(primaryKubeconfig).ToNot(Equal(secondaryKubeconfig))
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	if primaryTestEnv != nil {
+		err := primaryTestEnv.Stop()
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	if secondaryTestEnv != nil {
+		err := secondaryTestEnv.Stop()
+		Expect(err).NotTo(HaveOccurred())
+	}
+})
+
+func CreateNamespace(name string, client client.Client) {
+	nsObject := &v1.Namespace{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+
+	err := client.Create(context.Background(), nsObject)
+	Expect(err).ToNot(HaveOccurred())
+
+	existingNamespace := &v1.Namespace{}
+	Eventually(func() error {
+		return client.Get(context.Background(), types.NamespacedName{Name: name}, existingNamespace)
+	}, time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+}
+
+// setupEnv creates a new controller runtime envTest environment with the required controllers running for the given delegation role.
+//
+// The setup of controllers here should be the same how they are configured in the main application.
+//
+// Primary:
+//   - create multicluster-controller-runtime manager
+//   - setup kubeconfig provider
+//   - setup DNSRecordReconciler
+//   - setup RemoteDNSRecordReconciler
+//
+// Secondary:
+//   - create controller-runtime manager
+//   - setup DNSRecordReconciler
+func setupEnv(delegationRole string) (*envtest.Environment, ctrl.Manager) {
+	testEnv := &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 
 	var err error
-	// cfg is defined in this file globally.
+	var cfg *rest.Config
+
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -86,64 +190,91 @@ var _ = BeforeSuite(func() {
 	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	dynClient, err := dynamic.NewForConfig(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(dynClient).NotTo(BeNil())
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	var mgr ctrl.Manager
+	var mcmgr mcmanager.Manager
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+	defaultOptions := ctrl.Options{
 		Scheme:                 scheme.Scheme,
 		HealthProbeBindAddress: "0",
 		Metrics:                metricsserver.Options{BindAddress: "0"},
-	})
-	Expect(err).ToNot(HaveOccurred())
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+		Logger: ctrl.LoggerFrom(ctx).WithName(delegationRole),
+	}
 
-	dynClient, err := dynamic.NewForConfig(cfg)
-	Expect(err).ToNot(HaveOccurred())
+	if delegationRole == DelegationRoleSecondary {
+		// Use the normal controller runtime manager when running with the secondary delegation role
+		mgr, err = ctrl.NewManager(cfg, defaultOptions)
+		Expect(err).ToNot(HaveOccurred())
+	} else {
+		// Create the kubeconfig provider with options
+		clusterProviderOpts := kubeconfigprovider.Options{
+			Namespace:             testDefaultClusterSecretNamespace,
+			KubeconfigSecretLabel: testDefaultClusterSecretLabel,
+			KubeconfigSecretKey:   "kubeconfig",
+			Scheme:                scheme.Scheme,
+		}
+
+		// Create the provider first, then the manager with the provider
+		clusterProvider := kubeconfigprovider.New(clusterProviderOpts)
+
+		// Set up a cluster-aware Manager, with the provider to lookup clusters.
+		mcmgr, err = mcmanager.New(cfg, clusterProvider, defaultOptions)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Set up provider controller with the manager.
+		err = clusterProvider.SetupWithManager(ctx, mcmgr)
+		Expect(err).ToNot(HaveOccurred())
+
+		mgr = mcmgr.GetLocalManager()
+	}
+	Expect(mgr).ToNot(BeNil())
 
 	providerFactory, err := provider.NewFactory(mgr.GetClient(), dynClient, []string{provider.DNSProviderInMem.String(), provider.DNSProviderEndpoint.String()})
 	Expect(err).ToNot(HaveOccurred())
+	Expect(providerFactory).ToNot(BeNil())
 
-	err = (&DNSRecordReconciler{
+	dnsRecordController := &DNSRecordReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		ProviderFactory: providerFactory,
-		DelegationRole:  DelegationRolePrimary,
+		DelegationRole:  delegationRole,
 		remoteClient:    false,
-	}).SetupWithManager(mgr, RequeueDuration, ValidityDuration, DefaultValidationDuration, true, true)
-	Expect(err).ToNot(HaveOccurred())
-
-	go func() {
-		defer GinkgoRecover()
-		err = mgr.Start(ctx)
-		Expect(err).ToNot(HaveOccurred())
-	}()
-
-})
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})
-
-func CreateNamespace(namespace *string) {
-	var generatedTestNamespace = "test-namespace-" + uuid.New().String()
-
-	nsObject := &v1.Namespace{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
-		ObjectMeta: metav1.ObjectMeta{Name: generatedTestNamespace},
 	}
 
-	err := k8sClient.Create(context.Background(), nsObject)
+	err = dnsRecordController.SetupWithManager(mgr, RequeueDuration, ValidityDuration, DefaultValidationDuration, true, true)
 	Expect(err).ToNot(HaveOccurred())
 
-	existingNamespace := &v1.Namespace{}
-	Eventually(func() error {
-		return k8sClient.Get(context.Background(), types.NamespacedName{Name: generatedTestNamespace}, existingNamespace)
-	}, time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+	if delegationRole == DelegationRolePrimary {
+		Expect(mcmgr).ToNot(BeNil())
 
-	*namespace = existingNamespace.Name
+		remoteDNSRecordController := &RemoteDNSRecordReconciler{
+			DNSRecordReconciler: *dnsRecordController,
+		}
+		err = remoteDNSRecordController.SetupWithManager(mcmgr)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	return testEnv, mgr
+}
+
+// createKuadrantUser creates a new user 'kuadrant' in the given envTest Environment and returns the kubeconfig data for that user.
+func createKuadrantUser(testEnv *envtest.Environment) (kubeconfig []byte) {
+	user, err := testEnv.AddUser(envtest.User{Name: "kuadrant", Groups: []string{"system:masters"}}, &rest.Config{})
+	Expect(err).ToNot(HaveOccurred())
+
+	kubeconfig, err = user.KubeConfig()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(kubeconfig).ToNot(BeEmpty())
+
+	return kubeconfig
+}
+
+func generateTestNamespaceName() string {
+	return "test-namespace-" + uuid.New().String()
 }

--- a/test/e2e/helpers/common.go
+++ b/test/e2e/helpers/common.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package helpers
 
 import (

--- a/test/e2e/helpers/fixtures.go
+++ b/test/e2e/helpers/fixtures.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package helpers
 
 import (


### PR DESCRIPTION
Updates the integration test suite to make it possible to test both primary and secondary functionality in isolation or together in more comprehensive test cases.

The test suite creates two controller-runtime test environments (k8s api server, etcd etc..) on initialisation, one to act as a primary and one as a secondary. Each test environment runs the appropriate components for the given delegation role(based on the main application):

**Primary:**
   - create multicluster-controller-runtime manager
   - setup kubeconfig provider
   - setup DNSRecordReconciler (DelegationRole: primary)
   - setup RemoteDNSRecordReconciler

**Secondary:**
   - create controller-runtime manager
   - setup DNSRecordReconciler  (DelegationRole: secondary)

The test suite contains a global reference to the primary and secondary environments, managers, k8s clients and kubeconfigs for a dedicated user "kuadrant" allowing them to be used in specs as required.

**Add kubeconfig provider tests**

Adds basic tests to the integration test suite to validate the behaviour of the kubeconfig provider for multicluster secrets.

Makes use of `gbytes.Buffer` to capture log statements during the current test and the gomega `gbytes.Say` matcher see
https://onsi.github.io/gomega/#codegbytescode-testing-streaming-buffers since there is no way of really checking the status success/failure of these secrets from any particular resource. Logs in the test suite are prepended with the delegation role (primary or secondary) so it can be determined which environment is logging the statements.