### PR TITLE
emit dns record metadata as metric

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -451,6 +451,13 @@ func (r *DNSRecordReconciler) updateStatusAndRequeue(ctx context.Context, previo
 		}
 	}
 	logger.V(1).Info(fmt.Sprintf("Requeue in %s", requeueTime.String()))
+
+	var gauge float64
+	if meta.IsStatusConditionTrue(current.Status.Conditions, string(v1alpha1.ConditionTypeReady)) {
+		gauge = 1
+	}
+	metrics.RecordReady.WithLabelValues(current.Name, current.Namespace, current.Spec.RootHost, strconv.FormatBool(current.IsDelegating())).Set(gauge)
+
 	return ctrl.Result{RequeueAfter: requeueTime}, nil
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,6 +9,8 @@ import (
 const (
 	dnsRecordNameLabel           = "dns_record_name"
 	dnsRecordNamespaceLabel      = "dns_record_namespace"
+	dnsRecordRootHost            = "dns_record_root_host"
+	dnsRecordDelegating          = "dns_record_is_delegating"
 	dnsHealthCheckNameLabel      = "dns_health_check_name"
 	dnsHealthCheckNamespaceLabel = "dns_health_check_namespace"
 	dnsHealthCheckHostLabel      = "dns_health_check_host"
@@ -36,10 +38,17 @@ var (
 			Help: "Emits one when provider secret is found to be absent, or zero when expected secrets exist",
 		},
 		[]string{mzRecordNameLabel, mzRecordNamespaceLabel, mzSecretNameLabel})
+	RecordReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "dns_provider_record_ready",
+			Help: "Reports the ready state of the dns record. 0 - not ready or deleted, 1 - ready. It also provides some metadata of the record in question",
+		},
+		[]string{dnsRecordNameLabel, dnsRecordNamespaceLabel, dnsRecordRootHost, dnsRecordDelegating})
 )
 
 func init() {
 	metrics.Registry.MustRegister(WriteCounter)
 	metrics.Registry.MustRegister(SecretMissing)
 	metrics.Registry.MustRegister(ProbeCounter)
+	metrics.Registry.MustRegister(RecordReady)
 }


### PR DESCRIPTION
Adding a new metric to report usefull metadata from DNSRecord CR. 
There will be a new metric per DNS Record and the metrics will stay there. Meaning if you create and delete 100 records - you will have 100 "dead" metrics (until they are [removed](https://prometheus.io/docs/prometheus/latest/storage/#right-sizing-retention-size)) 

Here is how it looks:
<img width="1404" height="299" alt="image" src="https://github.com/user-attachments/assets/6598fd75-05e1-4992-90f3-7610ae1c51d2" />

There are two ways to skin this cat: 
1. have the ready metric carry all the metadata <- current approach 
2. have a dedicated `_info` metric purely for the metadata and later on create a separate ready metric for #342  