### PR TITLE
apply ready for delegation status to all delegating records

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -243,7 +243,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 
-		if r.IsSecondary() && dnsRecord.IsDelegating() {
+		if dnsRecord.IsDelegating() {
 			// finalizers are present, set delegation status ready
 			if c := meta.FindStatusCondition(dnsRecord.Status.Conditions, string(v1alpha1.ConditionTypeReadyForDelegation)); c == nil || c.Status == metav1.ConditionFalse {
 				logger.Info("Finalizers present, setting delegation condition", "condition_type", v1alpha1.ConditionTypeReadyForDelegation)
@@ -255,8 +255,10 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrl.Result{RequeueAfter: randomizedValidationRequeue}, nil
 			}
 
-			// Local records that are delegating on secondary clusters should just return here
-			return ctrl.Result{}, nil
+			if r.IsSecondary() {
+				// Local records that are delegating on secondary clusters should just return here
+				return ctrl.Result{}, nil
+			}
 		}
 	} else {
 		if !dnsRecord.Status.ReadyForDelegation() {

--- a/internal/controller/dnsrecord_controller_delegation_test.go
+++ b/internal/controller/dnsrecord_controller_delegation_test.go
@@ -102,7 +102,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 		})
 
 		It("should default to false if not specified", func(ctx SpecContext) {
-			By("creating a dnsrecord with not delegate field")
+			By("creating a dnsrecord with no delegate field")
 			primaryDNSRecord.Spec = v1alpha1.DNSRecordSpec{
 				RootHost: testHostname,
 				ProviderRef: &v1alpha1.ProviderRef{
@@ -116,6 +116,11 @@ var _ = Describe("DNSRecordReconciler", func() {
 				err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(primaryDNSRecord.IsDelegating()).To(BeFalse())
+				g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+					})),
+				)
 				g.Expect(primaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 		})
@@ -140,10 +145,10 @@ var _ = Describe("DNSRecordReconciler", func() {
 						"ObservedGeneration": Equal(primaryDNSRecord.Generation),
 					})),
 				)
-				//ToDo is this right?
-				g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+				g.Expect(primaryDNSRecord.Status.Conditions).To(
 					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						"Status": Equal(metav1.ConditionTrue),
 					})),
 				)
 				g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
@@ -450,10 +455,10 @@ var _ = Describe("DNSRecordReconciler", func() {
 							"ObservedGeneration": Equal(primaryDNSRecord.Generation),
 						})),
 					)
-					//ToDo is this right?
-					g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+					g.Expect(primaryDNSRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
-							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
 					g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
@@ -577,10 +582,10 @@ var _ = Describe("DNSRecordReconciler", func() {
 							"ObservedGeneration": Equal(primaryDNSRecord.Generation),
 						})),
 					)
-					//ToDo is this right?
-					g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+					g.Expect(primaryDNSRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
-							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
 					g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))


### PR DESCRIPTION
Updates the reconciliation logic to apply the "ReadyForDelegation" status to all delegating DNSRecords regardless of it being processed as a primary or secondary.

In the case of "primry-primary" setups the "ReadyForDelegation" status will need to exist on all delegating records in order for another primary to process it as a remote record that should be included in its own authoritative record.

follow up to https://github.com/Kuadrant/dns-operator/pull/520