### PR TITLE
update delegation authoritative record naming

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -31,7 +31,8 @@ type Protocol string
 
 const HttpProtocol Protocol = "HTTP"
 const HttpsProtocol Protocol = "HTTPS"
-const DelegationAuthoritativeRecordLabel = "kuadrant.io/delegation-authoritative-record"
+const AuthoritativeRecordLabel = "kuadrant.io/authoritative-record"
+const AuthoritativeRecordHashLabel = "kuadrant.io/authoritative-record-hash"
 
 // HealthCheckSpec configures health checks in the DNS provider.
 // By default this health check will be applied to each unique DNS A Record for

--- a/internal/controller/dnsrecord_controller_delegation_test.go
+++ b/internal/controller/dnsrecord_controller_delegation_test.go
@@ -166,6 +166,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				authRecord = &authRecords.Items[0]
 
 				// Verify the expected state of the authoritative record
+				g.Expect(authRecord.Name).To(Equal(fmt.Sprintf("delegation-authoritative-record-%s", common.HashRootHost(testHostname))))
 				g.Expect(authRecord.IsDelegating()).To(BeFalse())
 				g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
 				// no default secret yet
@@ -389,6 +390,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					g.Expect(authRecords.Items).To(HaveLen(1))
 					authRecord = &authRecords.Items[0]
 					// Verify the expected state of the authoritative record
+					g.Expect(authRecord.Name).To(Equal(fmt.Sprintf("delegation-authoritative-record-%s", common.HashRootHost(testHostname))))
 					g.Expect(authRecord.IsDelegating()).To(BeFalse())
 					g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
 					// no default secret yet
@@ -498,6 +500,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					g.Expect(authRecords.Items).To(HaveLen(1))
 					authRecord = &authRecords.Items[0]
 					// Verify the expected state of the authoritative record
+					g.Expect(authRecord.Name).To(Equal(fmt.Sprintf("delegation-authoritative-record-%s", common.HashRootHost(testHostname))))
 					g.Expect(authRecord.IsDelegating()).To(BeFalse())
 					g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
 					// no default secret yet
@@ -631,6 +634,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					// Get the authoritative record on the primary
 					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)).To(Succeed())
 					// Verify the expected state of the authoritative record
+					g.Expect(authRecord.Name).To(Equal(fmt.Sprintf("delegation-authoritative-record-%s", common.HashRootHost(testHostname))))
 					g.Expect(authRecord.IsDelegating()).To(BeFalse())
 					g.Expect(authRecord.Spec.RootHost).To(Equal(testHostname))
 					// no default secret yet

--- a/internal/controller/dnsrecord_delegation_helper.go
+++ b/internal/controller/dnsrecord_delegation_helper.go
@@ -33,7 +33,7 @@ func (r *DNSRecordDelegationHelper) EnsureAuthoritativeRecord(ctx context.Contex
 func (r *DNSRecordDelegationHelper) getAuthoritativeRecordFor(ctx context.Context, record v1alpha1.DNSRecord) (*v1alpha1.DNSRecord, error) {
 	aRecords := v1alpha1.DNSRecordList{}
 
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.HashRootHost(record.Spec.RootHost)))
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=true, %s=%s", v1alpha1.AuthoritativeRecordLabel, v1alpha1.AuthoritativeRecordHashLabel, common.HashRootHost(record.Spec.RootHost)))
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,8 @@ func authoritativeRecordFor(rec v1alpha1.DNSRecord) *v1alpha1.DNSRecord {
 			Name:      toAuthoritativeRecordName(rootHostHash),
 			Namespace: rec.Namespace,
 			Labels: map[string]string{
-				v1alpha1.DelegationAuthoritativeRecordLabel: rootHostHash,
+				v1alpha1.AuthoritativeRecordLabel:     "true",
+				v1alpha1.AuthoritativeRecordHashLabel: rootHostHash,
 			},
 		},
 		Spec: v1alpha1.DNSRecordSpec{
@@ -76,5 +77,5 @@ func authoritativeRecordFor(rec v1alpha1.DNSRecord) *v1alpha1.DNSRecord {
 }
 
 func toAuthoritativeRecordName(rootHostHash string) string {
-	return fmt.Sprintf("delegation-authoritative-record-%s", rootHostHash)
+	return fmt.Sprintf("authoritative-record-%s", rootHostHash)
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -100,7 +100,7 @@ func (f *factory) ProviderFor(ctx context.Context, pa v1alpha1.ProviderAccessor,
 			},
 			Type: v1alpha1.SecretTypeKuadrantEndpoint,
 			Data: map[string][]byte{
-				v1alpha1.EndpointLabelSelectorKey: []byte(fmt.Sprintf("%s=%s", v1alpha1.DelegationAuthoritativeRecordLabel, common.HashRootHost(pa.GetRootHost()))),
+				v1alpha1.EndpointLabelSelectorKey: []byte(fmt.Sprintf("%s=true, %s=%s", v1alpha1.AuthoritativeRecordLabel, v1alpha1.AuthoritativeRecordHashLabel, common.HashRootHost(pa.GetRootHost()))),
 			},
 		}
 	} else {


### PR DESCRIPTION
Updates the naming of the authoritative dnsrecord created by the delegation feature to base the name on a hash of the root host rather than generating a random name. Naming the auth records in this way allows them to be deterministic, and in environments with more than one primary allows the names to match across clusters conforming to the sameness principals of k8s multi cluster that we want to achieve.

Updates the labels added to "authoritative" records during creation: 
```
kuadrant.io/authoritative-record=true
kuadrant.io/authoritative-record-hash=<hash of record.spec.rootHost>
```

Allows authoritative records to be more easily listed via the cli:
```
kubectl get dnsrecord -A -l kuadrant.io/authoritative-record=true
```

follow up to https://github.com/Kuadrant/dns-operator/pull/520