### PR TITLE
fix: Delegating records with wildcard root hosts

### DIFF
--- a/api/v1alpha1/dnsrecord_types_test.go
+++ b/api/v1alpha1/dnsrecord_types_test.go
@@ -73,3 +73,34 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestDNSRecord_GetRootHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		rootHost string
+		want     string
+	}{
+		{
+			name:     "returns spec.RootHost",
+			rootHost: "example.com",
+			want:     "example.com",
+		},
+		{
+			name:     "returns spec.RootHost without wildcard prefix",
+			rootHost: "*.example.com",
+			want:     "example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DNSRecord{
+				Spec: DNSRecordSpec{
+					RootHost: tt.rootHost,
+				},
+			}
+			if got := s.GetRootHost(); got != tt.want {
+				t.Errorf("GetRootHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/dnsrecord_delegation_helper.go
+++ b/internal/controller/dnsrecord_delegation_helper.go
@@ -33,12 +33,12 @@ func (r *DNSRecordDelegationHelper) EnsureAuthoritativeRecord(ctx context.Contex
 func (r *DNSRecordDelegationHelper) getAuthoritativeRecordFor(ctx context.Context, record v1alpha1.DNSRecord) (*v1alpha1.DNSRecord, error) {
 	aRecords := v1alpha1.DNSRecordList{}
 
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s=true, %s=%s", v1alpha1.AuthoritativeRecordLabel, v1alpha1.AuthoritativeRecordHashLabel, common.HashRootHost(record.Spec.RootHost)))
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=true, %s=%s", v1alpha1.AuthoritativeRecordLabel, v1alpha1.AuthoritativeRecordHashLabel, common.HashRootHost(record.GetRootHost())))
 	if err != nil {
 		return nil, err
 	}
 
-	if err := r.Client.List(ctx, &aRecords, &client.ListOptions{LabelSelector: labelSelector}); err != nil {
+	if err = r.Client.List(ctx, &aRecords, &client.ListOptions{LabelSelector: labelSelector}); err != nil {
 		return nil, fmt.Errorf("failed to get authoritative record: %w", err)
 	}
 
@@ -60,7 +60,7 @@ func (r *DNSRecordDelegationHelper) createAuthoritativeRecordFor(ctx context.Con
 }
 
 func authoritativeRecordFor(rec v1alpha1.DNSRecord) *v1alpha1.DNSRecord {
-	rootHostHash := common.HashRootHost(rec.Spec.RootHost)
+	rootHostHash := common.HashRootHost(rec.GetRootHost())
 	return &v1alpha1.DNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      toAuthoritativeRecordName(rootHostHash),
@@ -71,7 +71,7 @@ func authoritativeRecordFor(rec v1alpha1.DNSRecord) *v1alpha1.DNSRecord {
 			},
 		},
 		Spec: v1alpha1.DNSRecordSpec{
-			RootHost: rec.Spec.RootHost,
+			RootHost: rec.GetRootHost(),
 		},
 	}
 }


### PR DESCRIPTION
Fixes an issue where delegating records using a wildcard root host (i.e. *.foo.example.com) would not correctly add all endpoints into the authoritative record.

This change updates the generation of the authoritative record to always use a root host value without any wildcard prefix for the name, rootHost and hash allowing all endpoints to match the plan filtering as expected.