### PR TITLE
add version and sha to build

### DIFF
--- a/coredns/plugin/Dockerfile
+++ b/coredns/plugin/Dockerfile
@@ -3,6 +3,12 @@ FROM mirror.gcr.io/library/golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+ARG GIT_SHA
+ARG VERSION
+
+ENV GIT_SHA=${GIT_SHA:-unknown}
+ENV VERSION=${VERSION:-unknown}
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -25,7 +31,7 @@ COPY zone.go zone.go
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build cmd/coredns.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags "-X main.pluginVersion=${VERSION} -X main.gitSHA=${GIT_SHA}" cmd/coredns.go
 
 # Based on https://github.com/coredns/coredns/blob/master/Dockerfile
 # Requires ths stage to avoid "Listen tcp :53: bind: permission denied" errors in nonroot containers.

--- a/coredns/plugin/Makefile
+++ b/coredns/plugin/Makefile
@@ -4,6 +4,9 @@ COREDNS_IMG ?= $(COREDNS_DEFAULT_IMG)
 
 CONTAINER_TOOL ?= docker
 
+VERSION ?= 0.0.0
+GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
+
 .PHONY: all
 all: build
 
@@ -18,7 +21,7 @@ clean: ## Clean local files.
 
 .PHONY: build
 build: ## Build coredns binary.
-	GOOS=linux CGO_ENABLED=0 go build cmd/coredns.go
+	GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.pluginVersion=${VERSION} -X main.gitSHA=${GIT_SHA}" cmd/coredns.go
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
@@ -27,11 +30,11 @@ test-unit: ## Run unit tests.
 .PHONY: run
 run: DNS_PORT=1053
 run: ## Run coredns from your host.
-	go run --race ./cmd/coredns.go -dns.port ${DNS_PORT}
+	go run --race  -ldflags "-X main.pluginVersion=${VERSION} -X main.gitSHA=${GIT_SHA}" ./cmd/coredns.go -dns.port ${DNS_PORT}
 
 .PHONY: docker-build
 docker-build: ## Build docker image.
-	$(CONTAINER_TOOL) build . -t ${COREDNS_IMG}
+	$(CONTAINER_TOOL) build . -t ${COREDNS_IMG} --build-arg VERSION=v$(VERSION) --build-arg GIT_SHA=$(GIT_SHA)
 
 .PHONY: docker-push
 docker-push: ## Push docker image.

--- a/coredns/plugin/cmd/coredns.go
+++ b/coredns/plugin/cmd/coredns.go
@@ -2,23 +2,45 @@ package main
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/coremain"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 
 	_ "github.com/kuadrant/coredns-kuadrant"
 	"github.com/kuadrant/coredns-kuadrant/cmd/plugin"
 )
 
-const pluginVersion = "0.0.0"
+var (
+	gitSHA        string // must be string as passed in by ldflag
+	pluginVersion string // must be string as passed in by ldflag
+)
 
 func init() {
 	dnsserver.Directives = plugin.Directives
 }
 
 func main() {
+	clog.Info(fmt.Sprintf("plugin version: %s, gitSha: %s", pluginVersion, gitSHA))
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok {
+		clog.Info(fmt.Sprintf("go version: %s", buildInfo.GoVersion))
+		clog.Info(fmt.Sprintf("arch: %s", getSetting("GOARCH", buildInfo.Settings)))
+	}
+
 	// extend CoreDNS version with plugin details
 	caddy.AppVersion = fmt.Sprintf("%s+kuadrant-%s", coremain.CoreVersion, pluginVersion)
 	coremain.Run()
+}
+
+// Helper function to find a specific setting.
+func getSetting(key string, settings []debug.BuildSetting) string {
+	for _, setting := range settings {
+		if setting.Key == key {
+			return setting.Value
+		}
+	}
+	return "N/A"
 }


### PR DESCRIPTION
Adding git sha and version to the image and binaries being built. 
Logging them on execution. 
manually poking the binary:
<img width="949" height="58" alt="image" src="https://github.com/user-attachments/assets/e71e1b65-b235-489f-89dd-fa36bb1ce540" />
`make run`:
<img width="1284" height="164" alt="image" src="https://github.com/user-attachments/assets/b06c7672-24f3-49e5-b4e4-e4cf95ea44ac" />
`make docker-run`:
<img width="1284" height="164" alt="image" src="https://github.com/user-attachments/assets/a5b42fb3-34f4-4627-b762-9105e259f05a" />
