### PR TITLE
feat: Add support for multiple primary controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,11 @@ build: DIRTY=$(shell hack/check-git-dirty.sh || echo "unknown")
 build: manifests generate fmt vet ## Build manager binary.
 	go build -ldflags "-X main.version=v${VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o bin/manager cmd/main.go
 
-DEFAULT_RUN_FLAGS ?= --zap-devel --provider inmemory,aws,google,azure,coredns,endpoint
+
+RUN_METRICS_ADDR=":8080"
+RUN_HEALTH_ADDR=":8081"
+RUN_DELEGATION_ROLE="primary"
+DEFAULT_RUN_FLAGS ?= --zap-devel --provider inmemory,aws,google,azure,coredns,endpoint --delegation-role=${RUN_DELEGATION_ROLE} --metrics-bind-address=${RUN_METRICS_ADDR} --health-probe-bind-address=${RUN_HEALTH_ADDR}
 RUN_FLAGS ?= $(DEFAULT_RUN_FLAGS)
 
 .PHONY: run

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/external-dns/endpoint"
@@ -318,6 +319,13 @@ func (in *DNSRecordStatus) DeepCopyInto(out *DNSRecordStatus) {
 		in, out := &in.DomainOwners, &out.DomainOwners
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.RemoteRecordStatuses != nil {
+		in, out := &in.RemoteRecordStatuses, &out.RemoteRecordStatuses
+		*out = make(map[string]apiextensionsv1.JSON, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
+		}
 	}
 }
 

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2025-08-26T13:53:31Z"
+    createdAt: "2025-09-12T15:19:30Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -94,6 +94,14 @@ spec:
           - ""
           resources:
           - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
           verbs:
           - get
           - list

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -587,6 +587,16 @@ spec:
                       type: array
                   type: object
                 type: array
+              remoteRecordStatuses:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  remoteRecordStatuses is a map of cluster IDs and their unique DNSRecordStatus as raw JSON.
+
+
+                  A CRD can't reference a type within itself so the `apiextensionsv1.JSON` type is used.
+                  Use GetRemoteRecordStatuses to get the converted type.
+                type: object
               validFor:
                 description: ValidFor indicates duration since the last reconciliation
                   we consider data in the record to be valid

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -712,6 +712,16 @@ spec:
                       type: array
                   type: object
                 type: array
+              remoteRecordStatuses:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  remoteRecordStatuses is a map of cluster IDs and their unique DNSRecordStatus as raw JSON.
+
+
+                  A CRD can't reference a type within itself so the `apiextensionsv1.JSON` type is used.
+                  Use GetRemoteRecordStatuses to get the converted type.
+                type: object
               validFor:
                 description: ValidFor indicates duration since the last reconciliation
                   we consider data in the record to be valid
@@ -819,6 +829,14 @@ rules:
   - ""
   resources:
   - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
   verbs:
   - get
   - list

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -250,7 +250,7 @@ func main() {
 			DelegationRole:  delegationRole,
 		}
 
-		if err = remoteDNSRecordController.SetupWithManager(mcmgr); err != nil {
+		if err = remoteDNSRecordController.SetupWithManager(mcmgr, false); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "RemoteDNSRecord")
 			os.Exit(1)
 		}

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -587,6 +587,16 @@ spec:
                       type: array
                   type: object
                 type: array
+              remoteRecordStatuses:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  remoteRecordStatuses is a map of cluster IDs and their unique DNSRecordStatus as raw JSON.
+
+
+                  A CRD can't reference a type within itself so the `apiextensionsv1.JSON` type is used.
+                  Use GetRemoteRecordStatuses to get the converted type.
+                type: object
               validFor:
                 description: ValidFor indicates duration since the last reconciliation
                   we consider data in the record to be valid

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,6 +13,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kuadrant.io
   resources:
   - dnshealthcheckprobes

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	google.golang.org/api v0.162.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.33.3
+	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
 	k8s.io/klog/v2 v2.130.1
@@ -107,7 +108,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/controller/dnsrecord_accessor.go
+++ b/internal/controller/dnsrecord_accessor.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	externaldns "sigs.k8s.io/external-dns/endpoint"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+)
+
+var _ DNSRecordAccessor = &RemoteDNSRecord{}
+
+type DNSRecordAccessor interface {
+	metav1.Object
+	runtime.Object
+	v1alpha1.ProviderAccessor
+	GetDNSRecord() *v1alpha1.DNSRecord
+	GetOwnerID() string
+	GetRootHost() string
+	GetZoneDomainName() string
+	GetZoneID() string
+	GetSpec() *v1alpha1.DNSRecordSpec
+	GetStatus() *v1alpha1.DNSRecordStatus
+	SetStatusCondition(conditionType string, status metav1.ConditionStatus, reason, message string)
+	SetStatusZoneID(id string)
+	SetStatusZoneDomainName(domainName string)
+	SetStatusDomainOwners(owners []string)
+	SetStatusEndpoints(endpoints []*externaldns.Endpoint)
+	SetStatusObservedGeneration(observedGeneration int64)
+	HasOwnerIDAssigned() bool
+	HasDNSZoneAssigned() bool
+}
+
+type RemoteDNSRecord struct {
+	*v1alpha1.DNSRecord
+	ClusterID string
+	status    *v1alpha1.DNSRecordStatus
+}
+
+func (s *RemoteDNSRecord) GetDNSRecord() *v1alpha1.DNSRecord {
+	return s.DNSRecord
+}
+
+func (s *RemoteDNSRecord) GetOwnerID() string {
+	return s.DNSRecord.Status.OwnerID
+}
+
+func (s *RemoteDNSRecord) GetZoneDomainName() string {
+	return s.GetStatus().ZoneDomainName
+}
+
+func (s *RemoteDNSRecord) GetZoneID() string {
+	return s.GetStatus().ZoneID
+}
+
+func (s *RemoteDNSRecord) GetSpec() *v1alpha1.DNSRecordSpec {
+	return &s.Spec
+}
+
+// GetStatus returns the status set for the current cluster ID.
+// If none is set an empty DNSRecordStatus is returned.
+func (s *RemoteDNSRecord) GetStatus() *v1alpha1.DNSRecordStatus {
+	if s.status == nil {
+		stat := s.Status.GetRemoteRecordStatus(s.ClusterID)
+		s.status = &stat
+	}
+	return s.status
+}
+
+func (s *RemoteDNSRecord) SetStatusCondition(conditionType string, status metav1.ConditionStatus, reason, message string) {
+	cond := metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: s.Generation,
+	}
+	conditions := s.GetStatus().Conditions
+	meta.SetStatusCondition(&conditions, cond)
+	s.GetStatus().Conditions = conditions
+	s.setStatus()
+}
+
+func (s *RemoteDNSRecord) SetStatusZoneID(id string) {
+	s.GetStatus().ZoneID = id
+	s.setStatus()
+}
+
+func (s *RemoteDNSRecord) SetStatusZoneDomainName(domainName string) {
+	s.GetStatus().ZoneDomainName = domainName
+}
+
+func (s *RemoteDNSRecord) SetStatusDomainOwners(owners []string) {
+	s.GetStatus().DomainOwners = owners
+	s.setStatus()
+}
+
+func (s *RemoteDNSRecord) SetStatusEndpoints(endpoints []*externaldns.Endpoint) {
+	s.GetStatus().Endpoints = endpoints
+	s.setStatus()
+}
+
+func (s *RemoteDNSRecord) SetStatusObservedGeneration(observedGeneration int64) {
+	s.GetStatus().ObservedGeneration = observedGeneration
+	s.setStatus()
+}
+
+func (s *RemoteDNSRecord) setStatus() {
+	s.DNSRecord.Status.SetRemoteRecordStatus(s.ClusterID, *s.status)
+}
+
+func (s *RemoteDNSRecord) HasDNSZoneAssigned() bool {
+	return s.GetStatus().ZoneID != "" && s.GetStatus().ZoneDomainName != ""
+}

--- a/internal/controller/dnsrecord_controller_delegation_test.go
+++ b/internal/controller/dnsrecord_controller_delegation_test.go
@@ -45,10 +45,11 @@ var _ = Describe("DNSRecordReconciler", func() {
 			// buffer containing all the log entries added during the current spec execution
 			logBuffer *gbytes.Buffer
 
-			primaryDNSRecord *v1alpha1.DNSRecord
+			primary1DNSRecord *v1alpha1.DNSRecord
 
-			dnsProviderSecret *v1.Secret
-			testNamespace     string
+			primary1DNSProviderSecret *v1.Secret
+
+			testNamespace string
 			// testZoneDomainName generated domain for this test e.g. xyz.example.com
 			testZoneDomainName string
 			// testZoneID generated zoneID for this test. Currently, the same as testZoneDomainName for inmemory provider.
@@ -63,7 +64,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 			testNamespace = generateTestNamespaceName()
 
-			By(fmt.Sprintf("creating '%s' test namespace on the primary", testNamespace))
+			By(fmt.Sprintf("creating '%s' test namespace on primary-1", testNamespace))
 			CreateNamespace(testNamespace, primaryK8sClient)
 
 			testZoneDomainName = strings.Join([]string{GenerateName(), "example.com"}, ".")
@@ -72,14 +73,14 @@ var _ = Describe("DNSRecordReconciler", func() {
 			// Issue here to change this https://github.com/Kuadrant/dns-operator/issues/208
 			testZoneID = testZoneDomainName
 
-			By(fmt.Sprintf("creating inmemory dns provider in the '%s' test namespace on the primary", testNamespace))
-			dnsProviderSecret = builder.NewProviderBuilder("inmemory-credentials", testNamespace).
+			By(fmt.Sprintf("creating inmemory dns provider in the '%s' test namespace on primary-1", testNamespace))
+			primary1DNSProviderSecret = builder.NewProviderBuilder("inmemory-credentials", testNamespace).
 				For(v1alpha1.SecretTypeKuadrantInmemory).
 				WithZonesInitialisedFor(testZoneDomainName).
 				Build()
-			Expect(primaryK8sClient.Create(ctx, dnsProviderSecret)).To(Succeed())
+			Expect(primaryK8sClient.Create(ctx, primary1DNSProviderSecret)).To(Succeed())
 
-			primaryDNSRecord = &v1alpha1.DNSRecord{
+			primary1DNSRecord = &v1alpha1.DNSRecord{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testHostname,
 					Namespace: testNamespace,
@@ -103,25 +104,25 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 		It("should default to false if not specified", func(ctx SpecContext) {
 			By("creating a dnsrecord with no delegate field")
-			primaryDNSRecord.Spec = v1alpha1.DNSRecordSpec{
+			primary1DNSRecord.Spec = v1alpha1.DNSRecordSpec{
 				RootHost: testHostname,
 				ProviderRef: &v1alpha1.ProviderRef{
-					Name: dnsProviderSecret.Name,
+					Name: primary1DNSProviderSecret.Name,
 				},
 				Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
 			}
 			By("verifying created record has delegating=false")
-			Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+			Expect(primaryK8sClient.Create(ctx, primary1DNSRecord)).To(Succeed())
 			Eventually(func(g Gomega) {
-				err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)
+				err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(primaryDNSRecord.IsDelegating()).To(BeFalse())
-				g.Expect(primaryDNSRecord.Status.Conditions).ToNot(
+				g.Expect(primary1DNSRecord.IsDelegating()).To(BeFalse())
+				g.Expect(primary1DNSRecord.Status.Conditions).ToNot(
 					ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
 					})),
 				)
-				g.Expect(primaryDNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
+				g.Expect(primary1DNSRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 		})
 
@@ -129,32 +130,32 @@ var _ = Describe("DNSRecordReconciler", func() {
 			var authRecord *v1alpha1.DNSRecord
 
 			By("creating delegating dnsrecord on the primary")
-			Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+			Expect(primaryK8sClient.Create(ctx, primary1DNSRecord)).To(Succeed())
 
 			By("verifying the status of the primary record")
 			Eventually(func(g Gomega) {
 				// Find the record
-				g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)).To(Succeed())
+				g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)).To(Succeed())
 				// Verify the expected state of the record
-				g.Expect(primaryDNSRecord.Status.Conditions).To(
+				g.Expect(primary1DNSRecord.Status.Conditions).To(
 					ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
 						"Status":             Equal(metav1.ConditionTrue),
 						"Reason":             Equal("ProviderSuccess"),
 						"Message":            Equal("Provider ensured the dns record"),
-						"ObservedGeneration": Equal(primaryDNSRecord.Generation),
+						"ObservedGeneration": Equal(primary1DNSRecord.Generation),
 					})),
 				)
-				g.Expect(primaryDNSRecord.Status.Conditions).To(
+				g.Expect(primary1DNSRecord.Status.Conditions).To(
 					ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
 						"Status": Equal(metav1.ConditionTrue),
 					})),
 				)
-				g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
-				g.Expect(primaryDNSRecord.IsDelegating()).To(BeTrue())
-				g.Expect(primaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash()))
-				g.Expect(primaryDNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+				g.Expect(primary1DNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+				g.Expect(primary1DNSRecord.IsDelegating()).To(BeTrue())
+				g.Expect(primary1DNSRecord.Status.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash()))
+				g.Expect(primary1DNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 
 			By("verifying the authoritative record exists and has the correct spec and status")
@@ -198,7 +199,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":    HaveSuffix(testHostname),
-						"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+						"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 						"RecordType": Equal("TXT"),
 						"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 					})),
@@ -207,18 +208,18 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 			By("verifying the primary record status references the authoritative record")
 			// Verify record status has authoritative record referenced
-			Expect(primaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
-			Expect(primaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+			Expect(primary1DNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+			Expect(primary1DNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
 
 			By(fmt.Sprintf("setting the inmemory dns provider as the default in the '%s' test namespace", testNamespace))
 			// Set the default-provider label on the provider secret
-			labels := dnsProviderSecret.GetLabels()
+			labels := primary1DNSProviderSecret.GetLabels()
 			if labels == nil {
 				labels = map[string]string{}
 			}
 			labels[v1alpha1.DefaultProviderSecretLabel] = "true"
-			dnsProviderSecret.SetLabels(labels)
-			Expect(primaryK8sClient.Update(ctx, dnsProviderSecret)).To(Succeed())
+			primary1DNSProviderSecret.SetLabels(labels)
+			Expect(primaryK8sClient.Update(ctx, primary1DNSProviderSecret)).To(Succeed())
 
 			By("verifying authoritative record becomes ready")
 			Eventually(func(g Gomega) {
@@ -248,7 +249,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 			testWildcardHostname := "*." + testHostname
 			testFooHostname := "foo." + testHostname
 
-			primaryDNSRecord = &v1alpha1.DNSRecord{
+			primary1DNSRecord = &v1alpha1.DNSRecord{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testHostname,
 					Namespace: testNamespace,
@@ -278,37 +279,37 @@ var _ = Describe("DNSRecordReconciler", func() {
 			}
 
 			By("creating delegating dnsrecord on the primary")
-			Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+			Expect(primaryK8sClient.Create(ctx, primary1DNSRecord)).To(Succeed())
 
 			By("verifying the status of the primary record")
 			Eventually(func(g Gomega) {
 				// Find the record
-				g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)).To(Succeed())
+				g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)).To(Succeed())
 				// Verify the expected state of the record
-				g.Expect(primaryDNSRecord.Status.Conditions).To(
+				g.Expect(primary1DNSRecord.Status.Conditions).To(
 					ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
 						"Status":             Equal(metav1.ConditionTrue),
 						"Reason":             Equal("ProviderSuccess"),
 						"Message":            Equal("Provider ensured the dns record"),
-						"ObservedGeneration": Equal(primaryDNSRecord.Generation),
+						"ObservedGeneration": Equal(primary1DNSRecord.Generation),
 					})),
 				)
-				g.Expect(primaryDNSRecord.IsDelegating()).To(BeTrue())
+				g.Expect(primary1DNSRecord.IsDelegating()).To(BeTrue())
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 
 			By("verifying the authoritative record exists with the correct root host and endpoints")
 			Eventually(func(g Gomega) {
 				// Find the authoritative record
 				authRecords := &v1alpha1.DNSRecordList{}
-				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.AuthoritativeRecordLabel: "true", v1alpha1.AuthoritativeRecordHashLabel: common.HashRootHost(primaryDNSRecord.GetRootHost())})).To(Succeed())
+				g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.AuthoritativeRecordLabel: "true", v1alpha1.AuthoritativeRecordHashLabel: common.HashRootHost(primary1DNSRecord.GetRootHost())})).To(Succeed())
 				g.Expect(authRecords.Items).To(HaveLen(1))
 				authRecord = &authRecords.Items[0]
 
 				// Verify the expected state of the authoritative record
-				g.Expect(authRecord.Name).To(Equal(fmt.Sprintf("authoritative-record-%s", common.HashRootHost(primaryDNSRecord.GetRootHost()))))
+				g.Expect(authRecord.Name).To(Equal(fmt.Sprintf("authoritative-record-%s", common.HashRootHost(primary1DNSRecord.GetRootHost()))))
 				g.Expect(authRecord.IsDelegating()).To(BeFalse())
-				g.Expect(authRecord.Spec.RootHost).To(Equal(primaryDNSRecord.GetRootHost()))
+				g.Expect(authRecord.Spec.RootHost).To(Equal(primary1DNSRecord.GetRootHost()))
 				// Auth record Spec.RootHost should not contain the wildcard prefix
 				g.Expect(authRecord.Spec.RootHost).ToNot(HavePrefix("*."))
 				// authoritative record should contain the expected endpoints
@@ -328,13 +329,13 @@ var _ = Describe("DNSRecordReconciler", func() {
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":    HaveSuffix("wildcard." + testHostname),
-						"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+						"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 						"RecordType": Equal("TXT"),
 						"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":    HaveSuffix("foo." + testHostname),
-						"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+						"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 						"RecordType": Equal("TXT"),
 						"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 					})),
@@ -343,8 +344,8 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 			By("verifying the primary record status references the authoritative record")
 			// Verify record status has authoritative record referenced
-			Expect(primaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
-			Expect(primaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+			Expect(primary1DNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+			Expect(primary1DNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
 		})
 
 		Context("with secondary", Labels{"multicluster"}, func() {
@@ -403,17 +404,17 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 			It("should add the correct status to a secondary cluster record that is not delegating", Labels{"secondary"}, func(ctx SpecContext) {
 				By(fmt.Sprintf("creating inmemory dns provider in the '%s' test namespace on the secondary", testNamespace))
-				dnsProviderSecret = builder.NewProviderBuilder("inmemory-credentials", testNamespace).
+				primary1DNSProviderSecret = builder.NewProviderBuilder("inmemory-credentials", testNamespace).
 					For(v1alpha1.SecretTypeKuadrantInmemory).
 					WithZonesInitialisedFor(testZoneDomainName).
 					Build()
-				Expect(secondaryK8sClient.Create(ctx, dnsProviderSecret)).To(Succeed())
+				Expect(secondaryK8sClient.Create(ctx, primary1DNSProviderSecret)).To(Succeed())
 
 				By("creating non delegating dnsrecord on the secondary")
 				secondaryDNSRecord.Spec = v1alpha1.DNSRecordSpec{
 					RootHost: testHostname,
 					ProviderRef: &v1alpha1.ProviderRef{
-						Name: dnsProviderSecret.Name,
+						Name: primary1DNSProviderSecret.Name,
 					},
 					Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
 					Delegate:  false,
@@ -449,7 +450,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				secondaryDNSRecord.Spec = v1alpha1.DNSRecordSpec{
 					RootHost: testHostname,
 					ProviderRef: &v1alpha1.ProviderRef{
-						Name: dnsProviderSecret.Name,
+						Name: primary1DNSProviderSecret.Name,
 					},
 					Endpoints: getTestEndpoints(testHostname, []string{"127.0.0.1"}),
 					Delegate:  false,
@@ -459,7 +460,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
 
 				By("verifying primary cluster skips the reconciliation of the secondary record")
-				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.remote_dnsrecord_controller\".+\"msg\":\"skipping reconciliation of remote record that is not delegating\".+\"controller\":\"remotednsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary-1.remote_dnsrecord_controller\".+\"msg\":\"skipping reconciliation of remote record that is not delegating\".+\"controller\":\"remotednsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
 			})
 
 			It("should create authoritative record on the primary for delegating record on the secondary", Labels{"primary", "secondary"}, func(ctx SpecContext) {
@@ -497,8 +498,8 @@ var _ = Describe("DNSRecordReconciler", func() {
 					g.Expect(secondaryDNSRecord.Status.ZoneDomainName).To(BeEmpty())
 					// Remote record status is set as expected
 					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveLen(1))
-					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primaryClusterID))
-					remoteRecordStatus := secondaryDNSRecord.Status.GetRemoteRecordStatus(primaryClusterID)
+					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+					remoteRecordStatus := secondaryDNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)
 					g.Expect(remoteRecordStatus).ToNot(BeNil())
 					g.Expect(remoteRecordStatus.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -565,8 +566,8 @@ var _ = Describe("DNSRecordReconciler", func() {
 				// Verify record status has authoritative record referenced
 				Expect(secondaryDNSRecord.Status.ZoneID).To(BeEmpty())
 				Expect(secondaryDNSRecord.Status.ZoneDomainName).To(BeEmpty())
-				Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primaryClusterID))
-				Expect(secondaryDNSRecord.Status.GetRemoteRecordStatus(primaryClusterID)).To(MatchFields(IgnoreExtras, Fields{
+				Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+				Expect(secondaryDNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)).To(MatchFields(IgnoreExtras, Fields{
 					"ZoneID":         Equal(authRecord.Name),
 					"ZoneDomainName": Equal(authRecord.Spec.RootHost),
 				}))
@@ -576,7 +577,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				var authRecord *v1alpha1.DNSRecord
 
 				By("creating delegating dnsrecord on the primary")
-				Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+				Expect(primaryK8sClient.Create(ctx, primary1DNSRecord)).To(Succeed())
 
 				By("creating delegating dnsrecord on the secondary")
 				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
@@ -584,30 +585,30 @@ var _ = Describe("DNSRecordReconciler", func() {
 				By("verifying the status of the primary and secondary records")
 				Eventually(func(g Gomega) {
 					// Find the primary record
-					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)).To(Succeed())
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)).To(Succeed())
 					// Find the secondary record
 					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
 					// Verify the expected state of the primary record
-					g.Expect(primaryDNSRecord.Status.Conditions).To(
+					g.Expect(primary1DNSRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
 							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
 							"Status":             Equal(metav1.ConditionTrue),
 							"Reason":             Equal("ProviderSuccess"),
 							"Message":            Equal("Provider ensured the dns record"),
-							"ObservedGeneration": Equal(primaryDNSRecord.Generation),
+							"ObservedGeneration": Equal(primary1DNSRecord.Generation),
 						})),
 					)
-					g.Expect(primaryDNSRecord.Status.Conditions).To(
+					g.Expect(primary1DNSRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
-					g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
-					g.Expect(primaryDNSRecord.IsDelegating()).To(BeTrue())
-					g.Expect(primaryDNSRecord.Status.OwnerID).To(Equal(primaryDNSRecord.GetUIDHash()))
-					g.Expect(primaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
-					g.Expect(primaryDNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					g.Expect(primary1DNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(primary1DNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(primary1DNSRecord.Status.OwnerID).To(Equal(primary1DNSRecord.GetUIDHash()))
+					g.Expect(primary1DNSRecord.Status.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(primary1DNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
 
 					// Verify the expected state of the secondary record
 					g.Expect(secondaryDNSRecord.Status.Conditions).To(
@@ -634,8 +635,8 @@ var _ = Describe("DNSRecordReconciler", func() {
 					g.Expect(secondaryDNSRecord.Status.ZoneDomainName).To(BeEmpty())
 					// Remote record status is set as expected
 					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveLen(1))
-					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primaryClusterID))
-					remoteRecordStatus := secondaryDNSRecord.Status.GetRemoteRecordStatus(primaryClusterID)
+					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+					remoteRecordStatus := secondaryDNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)
 					g.Expect(remoteRecordStatus).ToNot(BeNil())
 					g.Expect(remoteRecordStatus.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -646,7 +647,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					})))
 					g.Expect(remoteRecordStatus.Endpoints).ToNot(BeEmpty())
 					g.Expect(remoteRecordStatus.ObservedGeneration).To(Equal(secondaryDNSRecord.Generation))
-					g.Expect(remoteRecordStatus.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(remoteRecordStatus.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
 					//These values are checked below after we get the auth record
 					g.Expect(remoteRecordStatus.ZoneDomainName).ToNot(BeEmpty())
 					g.Expect(remoteRecordStatus.ZoneID).ToNot(BeEmpty())
@@ -691,7 +692,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"DNSName":    HaveSuffix(testHostname),
-							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 							"RecordType": Equal("TXT"),
 							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 						})),
@@ -706,15 +707,15 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 				By("verifying the primary record status references the authoritative record")
 				// Verify the primary record status has the authoritative record referenced
-				Expect(primaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
-				Expect(primaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+				Expect(primary1DNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+				Expect(primary1DNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
 
 				By("verifying the secondary record status references the authoritative record")
 				// Verify the secondary record status has the authoritative record referenced
 				Expect(secondaryDNSRecord.Status.ZoneID).To(BeEmpty())
 				Expect(secondaryDNSRecord.Status.ZoneDomainName).To(BeEmpty())
-				Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primaryClusterID))
-				Expect(secondaryDNSRecord.Status.GetRemoteRecordStatus(primaryClusterID)).To(MatchFields(IgnoreExtras, Fields{
+				Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+				Expect(secondaryDNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)).To(MatchFields(IgnoreExtras, Fields{
 					"ZoneID":         Equal(authRecord.Name),
 					"ZoneDomainName": Equal(authRecord.Spec.RootHost),
 				}))
@@ -731,7 +732,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 				var authRecord *v1alpha1.DNSRecord
 
 				By("creating delegating dnsrecord on the primary")
-				Expect(primaryK8sClient.Create(ctx, primaryDNSRecord)).To(Succeed())
+				Expect(primaryK8sClient.Create(ctx, primary1DNSRecord)).To(Succeed())
 
 				By("creating delegating dnsrecord on the secondary")
 				Expect(secondaryK8sClient.Create(ctx, secondaryDNSRecord)).To(Succeed())
@@ -739,30 +740,30 @@ var _ = Describe("DNSRecordReconciler", func() {
 				By("verifying the status of the primary and secondary records")
 				Eventually(func(g Gomega) {
 					// Find the primary record
-					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)).To(Succeed())
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)).To(Succeed())
 					// Find the secondary record
 					g.Expect(secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)).To(Succeed())
 					// Verify the expected state of the primary record
-					g.Expect(primaryDNSRecord.Status.Conditions).To(
+					g.Expect(primary1DNSRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
 							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
 							"Status":             Equal(metav1.ConditionTrue),
 							"Reason":             Equal("ProviderSuccess"),
 							"Message":            Equal("Provider ensured the dns record"),
-							"ObservedGeneration": Equal(primaryDNSRecord.Generation),
+							"ObservedGeneration": Equal(primary1DNSRecord.Generation),
 						})),
 					)
-					g.Expect(primaryDNSRecord.Status.Conditions).To(
+					g.Expect(primary1DNSRecord.Status.Conditions).To(
 						ContainElement(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
 							"Status": Equal(metav1.ConditionTrue),
 						})),
 					)
-					g.Expect(primaryDNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
-					g.Expect(primaryDNSRecord.IsDelegating()).To(BeTrue())
-					g.Expect(primaryDNSRecord.Status.OwnerID).To(Equal(primaryDNSRecord.GetUIDHash()))
-					g.Expect(primaryDNSRecord.Status.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
-					g.Expect(primaryDNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					g.Expect(primary1DNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(primary1DNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(primary1DNSRecord.Status.OwnerID).To(Equal(primary1DNSRecord.GetUIDHash()))
+					g.Expect(primary1DNSRecord.Status.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(primary1DNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
 
 					// Verify the expected state of the secondary record
 					g.Expect(secondaryDNSRecord.Status.Conditions).To(
@@ -789,8 +790,8 @@ var _ = Describe("DNSRecordReconciler", func() {
 					g.Expect(secondaryDNSRecord.Status.ZoneDomainName).To(BeEmpty())
 					// Remote record status is set as expected
 					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveLen(1))
-					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primaryClusterID))
-					remoteRecordStatus := secondaryDNSRecord.Status.GetRemoteRecordStatus(primaryClusterID)
+					g.Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+					remoteRecordStatus := secondaryDNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)
 					g.Expect(remoteRecordStatus).ToNot(BeNil())
 					g.Expect(remoteRecordStatus.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
@@ -801,7 +802,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 					})))
 					g.Expect(remoteRecordStatus.Endpoints).ToNot(BeEmpty())
 					g.Expect(remoteRecordStatus.ObservedGeneration).To(Equal(secondaryDNSRecord.Generation))
-					g.Expect(remoteRecordStatus.DomainOwners).To(ConsistOf(primaryDNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
+					g.Expect(remoteRecordStatus.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), secondaryDNSRecord.GetUIDHash()))
 					//These values are checked below after we get the auth record
 					g.Expect(remoteRecordStatus.ZoneDomainName).ToNot(BeEmpty())
 					g.Expect(remoteRecordStatus.ZoneID).ToNot(BeEmpty())
@@ -853,7 +854,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"DNSName":    HaveSuffix(testHostname),
-							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 							"RecordType": Equal("TXT"),
 							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 						})),
@@ -868,28 +869,28 @@ var _ = Describe("DNSRecordReconciler", func() {
 
 				By("verifying the primary record status references the authoritative record")
 				// Verify the primary record status has the authoritative record referenced
-				Expect(primaryDNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
-				Expect(primaryDNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
+				Expect(primary1DNSRecord.Status.ZoneID).To(Equal(authRecord.Name))
+				Expect(primary1DNSRecord.Status.ZoneDomainName).To(Equal(authRecord.Spec.RootHost))
 
 				By("verifying the secondary record status references the authoritative record")
 				// Verify the secondary record status has the authoritative record referenced
 				Expect(secondaryDNSRecord.Status.ZoneID).To(BeEmpty())
 				Expect(secondaryDNSRecord.Status.ZoneDomainName).To(BeEmpty())
-				Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primaryClusterID))
-				Expect(secondaryDNSRecord.Status.GetRemoteRecordStatus(primaryClusterID)).To(MatchFields(IgnoreExtras, Fields{
+				Expect(secondaryDNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+				Expect(secondaryDNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)).To(MatchFields(IgnoreExtras, Fields{
 					"ZoneID":         Equal(authRecord.Name),
 					"ZoneDomainName": Equal(authRecord.Spec.RootHost),
 				}))
 
 				By(fmt.Sprintf("setting the inmemory dns provider as the default in the primary clusters '%s' test namespace", testNamespace))
 				// Set the default-provider label on the provider secret
-				labels := dnsProviderSecret.GetLabels()
+				labels := primary1DNSProviderSecret.GetLabels()
 				if labels == nil {
 					labels = map[string]string{}
 				}
 				labels[v1alpha1.DefaultProviderSecretLabel] = "true"
-				dnsProviderSecret.SetLabels(labels)
-				Expect(primaryK8sClient.Update(ctx, dnsProviderSecret)).To(Succeed())
+				primary1DNSProviderSecret.SetLabels(labels)
+				Expect(primaryK8sClient.Update(ctx, primary1DNSProviderSecret)).To(Succeed())
 
 				By("verifying authoritative record becomes ready")
 				Eventually(func(g Gomega) {
@@ -956,7 +957,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"DNSName":    HaveSuffix(testHostname),
-							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 							"RecordType": Equal("TXT"),
 							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 						})),
@@ -1007,7 +1008,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"DNSName":    HaveSuffix(testHostname),
-							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 							"RecordType": Equal("TXT"),
 							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 						})),
@@ -1023,13 +1024,13 @@ var _ = Describe("DNSRecordReconciler", func() {
 				By("deleting the secondary record")
 				Expect(secondaryK8sClient.Delete(ctx, secondaryDNSRecord)).To(Succeed())
 				// both clusters should eventually see the delete event
-				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary.dnsrecord_controller\".+\"msg\":\"Deleting DNSRecord\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
-				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.remote_dnsrecord_controller\".+\"msg\":\"Deleting DNSRecord\".+\"controller\":\"remotednsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary-1.dnsrecord_controller\".+\"msg\":\"Deleting DNSRecord\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary-1.remote_dnsrecord_controller\".+\"msg\":\"Deleting DNSRecord\".+\"controller\":\"remotednsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
 				// primary should eventually say it's removed the records from the zone
-				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.remote_dnsrecord_controller\".+\"msg\":\"Deleted DNSRecord in zone\".+\"controller\":\"remotednsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary-1.remote_dnsrecord_controller\".+\"msg\":\"Deleted DNSRecord in zone\".+\"controller\":\"remotednsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
 				// secondary should eventually say it removed the finalizer, primary should not
-				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary.dnsrecord_controller\".+\"msg\":\"Removing Finalizer\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
-				Consistently(logBuffer, TestTimeoutShort).Should(Not(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.dnsrecord_controller\".+\"msg\":\"Removing Finalizer\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace))))
+				Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary-1.dnsrecord_controller\".+\"msg\":\"Removing Finalizer\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace)))
+				Consistently(logBuffer, TestTimeoutShort).Should(Not(gbytes.Say(fmt.Sprintf("\"logger\":\"primary-1.dnsrecord_controller\".+\"msg\":\"Removing Finalizer\".+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryDNSRecord.Name, secondaryDNSRecord.Namespace))))
 				// secondary record should be removed
 				Eventually(func(g Gomega) {
 					err := secondaryK8sClient.Get(ctx, client.ObjectKeyFromObject(secondaryDNSRecord), secondaryDNSRecord)
@@ -1052,7 +1053,7 @@ var _ = Describe("DNSRecordReconciler", func() {
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"DNSName":    HaveSuffix(testHostname),
-							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primaryDNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
 							"RecordType": Equal("TXT"),
 							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
 						})),
@@ -1060,10 +1061,10 @@ var _ = Describe("DNSRecordReconciler", func() {
 				}, TestTimeoutMedium, time.Second).Should(Succeed())
 
 				By("deleting the primary record")
-				Expect(primaryK8sClient.Delete(ctx, primaryDNSRecord)).To(Succeed())
+				Expect(primaryK8sClient.Delete(ctx, primary1DNSRecord)).To(Succeed())
 				// primary record should be removed
 				Eventually(func(g Gomega) {
-					err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primaryDNSRecord), primaryDNSRecord)
+					err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)
 					g.Expect(err).To(HaveOccurred())
 					g.Expect(err).To(MatchError(ContainSubstring("not found")))
 				}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
@@ -1081,6 +1082,697 @@ var _ = Describe("DNSRecordReconciler", func() {
 				// primary record should be removed
 				Eventually(func(g Gomega) {
 					err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(authRecord), authRecord)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+			})
+		})
+
+		Context("with multiple primaries", Labels{"multicluster"}, func() {
+			var (
+				primary2DNSRecord         *v1alpha1.DNSRecord
+				primary1ClusterSecret     *v1.Secret
+				primary2ClusterSecret     *v1.Secret
+				primary2DNSProviderSecret *v1.Secret
+			)
+
+			BeforeEach(func() {
+				By("creating kubeconfig secret for primary-2 on primary-1")
+				primary2ClusterSecret = &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "primary-cluster-2",
+						Namespace: testDefaultClusterSecretNamespace,
+						Labels: map[string]string{
+							testDefaultClusterSecretLabel: "true",
+						},
+					},
+					StringData: map[string]string{
+						"kubeconfig": string(primary2Kubeconfig),
+					},
+				}
+				createClusterKubeconfigSecret(primaryK8sClient, primary2ClusterSecret, logBuffer)
+
+				By("creating kubeconfig secret for primary-1 on primary-2")
+				primary1ClusterSecret = &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "primary-cluster-1",
+						Namespace: testDefaultClusterSecretNamespace,
+						Labels: map[string]string{
+							testDefaultClusterSecretLabel: "true",
+						},
+					},
+					StringData: map[string]string{
+						"kubeconfig": string(primaryKubeconfig),
+					},
+				}
+				createClusterKubeconfigSecret(primary2K8sClient, primary1ClusterSecret, logBuffer)
+
+				By(fmt.Sprintf("creating '%s' test namespace on primary-2", testNamespace))
+				CreateNamespace(testNamespace, primary2K8sClient)
+
+				By(fmt.Sprintf("creating inmemory dns provider in the '%s' test namespace on primary-2", testNamespace))
+				primary2DNSProviderSecret = builder.NewProviderBuilder("inmemory-credentials", testNamespace).
+					For(v1alpha1.SecretTypeKuadrantInmemory).
+					WithZonesInitialisedFor(testZoneDomainName).
+					Build()
+				Expect(primary2K8sClient.Create(ctx, primary2DNSProviderSecret)).To(Succeed())
+
+				primary2DNSRecord = &v1alpha1.DNSRecord{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testHostname,
+						Namespace: testNamespace,
+					},
+					Spec: v1alpha1.DNSRecordSpec{
+						RootHost: testHostname,
+						Endpoints: []*externaldnsendpoint.Endpoint{
+							{
+								DNSName:          testHostname,
+								Targets:          []string{"127.0.0.2"},
+								RecordType:       "A",
+								RecordTTL:        60,
+								Labels:           nil,
+								ProviderSpecific: nil,
+							},
+						},
+						Delegate: true,
+					},
+				}
+			})
+
+			AfterEach(func() {
+				if primary1ClusterSecret != nil {
+					Expect(client.IgnoreNotFound(primary2K8sClient.Delete(ctx, primary1ClusterSecret))).To(Succeed())
+				}
+				if primary2ClusterSecret != nil {
+					Expect(client.IgnoreNotFound(primaryK8sClient.Delete(ctx, primary2ClusterSecret))).To(Succeed())
+				}
+				GinkgoWriter.ClearTeeWriters()
+			})
+
+			// Multi Primary test that covers the following:
+			// - auth record is created correctly and updated on both primary clusters
+			// - auth records become ready when a default provider is added on both primary clusters
+			// - auth record is updated correctly on delegating record endpoint updates on both primary clusters
+			// - auth record is updated correctly on delegating record endpoint additions on both primary clusters
+			// - auth record is updated correctly on delegating record endpoint deletions on both primary clusters
+			// - auth record is updated correctly on delegating record deletion on both primary clusters
+			// - deletion of records is prevented if a primary cannot update a remote record (disconnected)
+			// - auth records update correctly when primary/primary connections are re-established
+			It("should handle create, update and deletion of delegating records on multiple primaries", Labels{"primary", "multi-primary"}, func(ctx SpecContext) {
+				var primary1AuthRecord, primary2AuthRecord *v1alpha1.DNSRecord
+
+				By("creating delegating dnsrecord on primary-1")
+				Expect(primaryK8sClient.Create(ctx, primary1DNSRecord)).To(Succeed())
+
+				By("creating delegating dnsrecord on primary-2")
+				Expect(primary2K8sClient.Create(ctx, primary2DNSRecord)).To(Succeed())
+
+				By("verifying the status of primary-1 and primary-2 records")
+				Eventually(func(g Gomega) {
+					// Find the primary-1 record
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)).To(Succeed())
+					// Find the primary-2 record
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2DNSRecord), primary2DNSRecord)).To(Succeed())
+
+					// Verify the expected state of the primary records
+					// primary-1(primary1DNSRecord) should have status and remote record status for primary-2(primary2DNSRecord)
+					g.Expect(primary1DNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(primary1DNSRecord.Generation),
+						})),
+					)
+					g.Expect(primary1DNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+					g.Expect(primary1DNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(primary1DNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(primary1DNSRecord.Status.OwnerID).To(Equal(primary1DNSRecord.GetUIDHash()))
+					// Main Status has zone status set, values are checked below after we get the auth record
+					g.Expect(primary1DNSRecord.Status.ZoneID).ToNot(BeEmpty())
+					g.Expect(primary1DNSRecord.Status.ZoneDomainName).ToNot(BeEmpty())
+					g.Expect(primary1DNSRecord.Status.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), primary2DNSRecord.GetUIDHash()))
+					g.Expect(primary1DNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					// Remote record status is set as expected for primary-2 record
+					g.Expect(primary1DNSRecord.Status.RemoteRecordStatuses).To(HaveLen(1))
+					g.Expect(primary1DNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary2ClusterID))
+					remoteRecordStatus := primary1DNSRecord.Status.GetRemoteRecordStatus(primary2ClusterID)
+					g.Expect(remoteRecordStatus).ToNot(BeNil())
+					g.Expect(remoteRecordStatus.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":             Equal(metav1.ConditionTrue),
+						"Reason":             Equal("ProviderSuccess"),
+						"Message":            Equal("Provider ensured the dns record"),
+						"ObservedGeneration": Equal(primary1DNSRecord.Generation),
+					})))
+					g.Expect(remoteRecordStatus.Endpoints).ToNot(BeEmpty())
+					g.Expect(remoteRecordStatus.ObservedGeneration).To(Equal(primary1DNSRecord.Generation))
+					g.Expect(remoteRecordStatus.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), primary2DNSRecord.GetUIDHash()))
+					//These values are checked below after we get the auth record
+					g.Expect(remoteRecordStatus.ZoneDomainName).ToNot(BeEmpty())
+					g.Expect(remoteRecordStatus.ZoneID).ToNot(BeEmpty())
+
+					// primary-2(primary2DNSRecord) should have status and remote record status for primary-1(primary1DNSRecord)
+					g.Expect(primary2DNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":             Equal(metav1.ConditionTrue),
+							"Reason":             Equal("ProviderSuccess"),
+							"Message":            Equal("Provider ensured the dns record"),
+							"ObservedGeneration": Equal(primary2DNSRecord.Generation),
+						})),
+					)
+					g.Expect(primary2DNSRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+							"Status": Equal(metav1.ConditionTrue),
+						})),
+					)
+					g.Expect(primary2DNSRecord.Finalizers).To(ContainElement(DNSRecordFinalizer))
+					g.Expect(primary2DNSRecord.IsDelegating()).To(BeTrue())
+					g.Expect(primary2DNSRecord.Status.OwnerID).To(Equal(primary2DNSRecord.GetUIDHash()))
+					// Main Status has zone status set, values are checked below after we get the auth record
+					g.Expect(primary2DNSRecord.Status.ZoneID).ToNot(BeEmpty())
+					g.Expect(primary2DNSRecord.Status.ZoneDomainName).ToNot(BeEmpty())
+					g.Expect(primary2DNSRecord.Status.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), primary2DNSRecord.GetUIDHash()))
+					g.Expect(primary2DNSRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					// Remote record status is set as expected for primary-1 record
+					g.Expect(primary2DNSRecord.Status.RemoteRecordStatuses).To(HaveLen(1))
+					g.Expect(primary2DNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+					remoteRecordStatus = primary2DNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)
+					g.Expect(remoteRecordStatus).ToNot(BeNil())
+					g.Expect(remoteRecordStatus.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":               Equal(string(v1alpha1.ConditionTypeReady)),
+						"Status":             Equal(metav1.ConditionTrue),
+						"Reason":             Equal("ProviderSuccess"),
+						"Message":            Equal("Provider ensured the dns record"),
+						"ObservedGeneration": Equal(primary2DNSRecord.Generation),
+					})))
+					g.Expect(remoteRecordStatus.Endpoints).ToNot(BeEmpty())
+					g.Expect(remoteRecordStatus.ObservedGeneration).To(Equal(primary2DNSRecord.Generation))
+					g.Expect(remoteRecordStatus.DomainOwners).To(ConsistOf(primary1DNSRecord.GetUIDHash(), primary2DNSRecord.GetUIDHash()))
+					//These values are checked below after we get the auth record
+					g.Expect(remoteRecordStatus.ZoneDomainName).ToNot(BeEmpty())
+					g.Expect(remoteRecordStatus.ZoneID).ToNot(BeEmpty())
+				}, TestTimeoutLong, time.Second).Should(Succeed())
+
+				By("verifying an authoritative record exists for the test host on both primary-1 and primary-2")
+				Eventually(func(g Gomega) {
+					// Find the authoritative record on primary-1
+					authRecords := &v1alpha1.DNSRecordList{}
+					g.Expect(primaryK8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.AuthoritativeRecordLabel: "true", v1alpha1.AuthoritativeRecordHashLabel: common.HashRootHost(testHostname)})).To(Succeed())
+					g.Expect(authRecords.Items).To(HaveLen(1))
+					primary1AuthRecord = &authRecords.Items[0]
+
+					// Find the authoritative record on primary-2
+					g.Expect(primary2K8sClient.List(ctx, authRecords, client.InNamespace(testNamespace), client.MatchingLabels{v1alpha1.AuthoritativeRecordLabel: "true", v1alpha1.AuthoritativeRecordHashLabel: common.HashRootHost(testHostname)})).To(Succeed())
+					g.Expect(authRecords.Items).To(HaveLen(1))
+					primary2AuthRecord = &authRecords.Items[0]
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the authoritative records have the correct spec and status")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on primary-1
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1AuthRecord), primary1AuthRecord)).To(Succeed())
+					// Verify the expected state of the authoritative record
+					g.Expect(primary1AuthRecord.Name).To(Equal(fmt.Sprintf("authoritative-record-%s", common.HashRootHost(testHostname))))
+					g.Expect(primary1AuthRecord.IsDelegating()).To(BeFalse())
+					g.Expect(primary1AuthRecord.Spec.RootHost).To(Equal(testHostname))
+					// no default secret yet
+					g.Expect(primary1AuthRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					g.Expect(primary1AuthRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionFalse),
+							"Reason":  Equal("DNSProviderError"),
+							"Message": Equal("No default provider secret labeled kuadrant.io/default-provider was found"),
+						})),
+					)
+					g.Expect(primary1AuthRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					g.Expect(primary1AuthRecord.Status.OwnerID).To(Equal(primary1AuthRecord.GetUIDHash()))
+					//domain owners won't be set until the dns provider is set
+					g.Expect(primary1AuthRecord.Status.DomainOwners).To(BeEmpty())
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(HaveLen(3))
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.0.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+
+					// Get the authoritative record on primary-2
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2AuthRecord), primary2AuthRecord)).To(Succeed())
+					// Verify the expected state of the authoritative record
+					g.Expect(primary2AuthRecord.Name).To(Equal(fmt.Sprintf("authoritative-record-%s", common.HashRootHost(testHostname))))
+					g.Expect(primary2AuthRecord.IsDelegating()).To(BeFalse())
+					g.Expect(primary2AuthRecord.Spec.RootHost).To(Equal(testHostname))
+					// no default secret yet
+					g.Expect(primary2AuthRecord.Labels).Should(Not(HaveKey("kuadrant.io/dns-provider-name")))
+					g.Expect(primary2AuthRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionFalse),
+							"Reason":  Equal("DNSProviderError"),
+							"Message": Equal("No default provider secret labeled kuadrant.io/default-provider was found"),
+						})),
+					)
+					g.Expect(primary2AuthRecord.Status.Conditions).ToNot(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type": Equal(string(v1alpha1.ConditionTypeReadyForDelegation)),
+						})),
+					)
+					g.Expect(primary2AuthRecord.Status.OwnerID).To(Equal(primary2AuthRecord.GetUIDHash()))
+					//domain owners won't be set until the dns provider is set
+					g.Expect(primary2AuthRecord.Status.DomainOwners).To(BeEmpty())
+					//authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(HaveLen(3))
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.0.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the primary-1 record status references the primary-1 authoritative record")
+				// Verify the primary records have the authoritative record referenced
+				Expect(primary1DNSRecord.Status.ZoneID).To(Equal(primary1AuthRecord.Name))
+				Expect(primary1DNSRecord.Status.ZoneDomainName).To(Equal(primary1AuthRecord.Spec.RootHost))
+				Expect(primary1DNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary2ClusterID))
+				Expect(primary1DNSRecord.Status.GetRemoteRecordStatus(primary2ClusterID)).To(MatchFields(IgnoreExtras, Fields{
+					"ZoneID":         Equal(primary2AuthRecord.Name),
+					"ZoneDomainName": Equal(primary2AuthRecord.Spec.RootHost),
+				}))
+
+				By("verifying the primary-2 record status references the primary-2 authoritative record")
+				// Verify the primary records have the authoritative record referenced
+				Expect(primary2DNSRecord.Status.ZoneID).To(Equal(primary2AuthRecord.Name))
+				Expect(primary2DNSRecord.Status.ZoneDomainName).To(Equal(primary2AuthRecord.Spec.RootHost))
+				Expect(primary2DNSRecord.Status.RemoteRecordStatuses).To(HaveKey(primary1ClusterID))
+				Expect(primary2DNSRecord.Status.GetRemoteRecordStatus(primary1ClusterID)).To(MatchFields(IgnoreExtras, Fields{
+					"ZoneID":         Equal(primary1AuthRecord.Name),
+					"ZoneDomainName": Equal(primary1AuthRecord.Spec.RootHost),
+				}))
+
+				By(fmt.Sprintf("setting the inmemory dns provider as the default in the primary-1 clusters '%s' test namespace", testNamespace))
+				// Set the default-provider label on the provider secret
+				labels := primary1DNSProviderSecret.GetLabels()
+				if labels == nil {
+					labels = map[string]string{}
+				}
+				labels[v1alpha1.DefaultProviderSecretLabel] = "true"
+				primary1DNSProviderSecret.SetLabels(labels)
+				Expect(primaryK8sClient.Update(ctx, primary1DNSProviderSecret)).To(Succeed())
+
+				By(fmt.Sprintf("setting the inmemory dns provider as the default in the primary-2 clusters '%s' test namespace", testNamespace))
+				// Set the default-provider label on the provider secret
+				labels = primary2DNSProviderSecret.GetLabels()
+				if labels == nil {
+					labels = map[string]string{}
+				}
+				labels[v1alpha1.DefaultProviderSecretLabel] = "true"
+				primary2DNSProviderSecret.SetLabels(labels)
+				Expect(primary2K8sClient.Update(ctx, primary2DNSProviderSecret)).To(Succeed())
+
+				By("verifying authoritative records becomes ready")
+				Eventually(func(g Gomega) {
+					// Get the primary-1 authoritative record
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1AuthRecord), primary1AuthRecord)).To(Succeed())
+					// Verify the primary-1 authoritative record becomes ready
+					g.Expect(primary1AuthRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionTrue),
+							"Reason":  Equal("ProviderSuccess"),
+							"Message": Equal("Provider ensured the dns record"),
+						})),
+					)
+					// Verify the primary-1 authoritative record has the expected provider label
+					g.Expect(primary1AuthRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
+					// Verify the authoritative record has the expected domain owners
+					g.Expect(primary1AuthRecord.Status.DomainOwners).To(ConsistOf(primary1AuthRecord.GetUIDHash(), primary2AuthRecord.GetUIDHash()))
+
+					// Get the primary-2 authoritative record
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2AuthRecord), primary2AuthRecord)).To(Succeed())
+					// Verify the primary-1 authoritative record becomes ready
+					g.Expect(primary2AuthRecord.Status.Conditions).To(
+						ContainElement(MatchFields(IgnoreExtras, Fields{
+							"Type":    Equal(string(v1alpha1.ConditionTypeReady)),
+							"Status":  Equal(metav1.ConditionTrue),
+							"Reason":  Equal("ProviderSuccess"),
+							"Message": Equal("Provider ensured the dns record"),
+						})),
+					)
+					// Verify the primary-1 authoritative record has the expected provider label
+					g.Expect(primary2AuthRecord.Labels).Should(HaveKeyWithValue("kuadrant.io/dns-provider-name", "inmemory"))
+					// Verify the authoritative record has the expected domain owners
+					g.Expect(primary2AuthRecord.Status.DomainOwners).To(ConsistOf(primary1AuthRecord.GetUIDHash(), primary2AuthRecord.GetUIDHash()))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("updating existing endpoint and adding additional endpoint to primary-2 record")
+				Eventually(func(g Gomega) {
+					// refresh the primary-2 record
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2DNSRecord), primary2DNSRecord)).To(Succeed())
+					primary2DNSRecord.Spec.Endpoints = []*externaldnsendpoint.Endpoint{
+						{
+							DNSName:          testHostname,
+							Targets:          []string{"127.0.1.2"},
+							RecordType:       "A",
+							RecordTTL:        60,
+							Labels:           nil,
+							ProviderSpecific: nil,
+						},
+						{
+							DNSName:          "cname." + testHostname,
+							Targets:          []string{testHostname},
+							RecordType:       "CNAME",
+							RecordTTL:        120,
+							Labels:           nil,
+							ProviderSpecific: nil,
+						},
+					}
+					g.Expect(primary2K8sClient.Update(ctx, primary2DNSRecord)).To(Succeed())
+				}, TestTimeoutShort, time.Second).Should(Succeed())
+
+				By("verifying the primary-1 and primary-2 authoritative record endpoints are updated correctly")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on primary-1
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1AuthRecord), primary1AuthRecord)).To(Succeed())
+					// authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(HaveLen(5))
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.1.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal("cname." + testHostname),
+							"Targets":    ConsistOf(testHostname),
+							"RecordType": Equal("CNAME"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(120)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix("cname." + testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+
+					// Get the authoritative record on primary-2
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2AuthRecord), primary2AuthRecord)).To(Succeed())
+					// authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(HaveLen(5))
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.1.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal("cname." + testHostname),
+							"Targets":    ConsistOf(testHostname),
+							"RecordType": Equal("CNAME"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(120)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix("cname." + testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				// The following is to check that primaries recover correctly if they miss events during disconnection/reconnection
+				By("removing the primary-2 cluster secret from the primary-1 cluster")
+				deleteClusterKubeconfigSecret(primaryK8sClient, primary2ClusterSecret, logBuffer)
+
+				By("updating existing endpoint and removing endpoint from primary-2 record")
+				Eventually(func(g Gomega) {
+					// refresh the primary-2 record
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2DNSRecord), primary2DNSRecord)).To(Succeed())
+					primary2DNSRecord.Spec.Endpoints = []*externaldnsendpoint.Endpoint{
+						{
+							DNSName:          testHostname,
+							Targets:          []string{"127.1.1.2"},
+							RecordType:       "A",
+							RecordTTL:        60,
+							Labels:           nil,
+							ProviderSpecific: nil,
+						},
+					}
+					g.Expect(primary2K8sClient.Update(ctx, primary2DNSRecord)).To(Succeed())
+				}, TestTimeoutShort, time.Second).Should(Succeed())
+
+				By("verifying the primary-2 authoritative record endpoints are updated correctly")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on primary-2
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2AuthRecord), primary2AuthRecord)).To(Succeed())
+					// authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(HaveLen(3))
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.1.1.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the primary-1 authoritative record endpoints are not being updated")
+				Consistently(func(g Gomega) {
+					// Get the authoritative record on primary-1
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1AuthRecord), primary1AuthRecord)).To(Succeed())
+					// authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(HaveLen(5))
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1", "127.0.1.2"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal("cname." + testHostname),
+							"Targets":    ConsistOf(testHostname),
+							"RecordType": Equal("CNAME"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(120)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix("cname." + testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary2DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutShort).Should(Succeed())
+
+				//Check deleting record on primary-2 does not get removed while primary-1 has no access to update it
+				By("deleting the primary-2 record")
+				Expect(primary2K8sClient.Delete(ctx, primary2DNSRecord)).To(Succeed())
+				//  primary-2 record should not get removed, but be marked as deleting
+				By("checking primary-2 record is not being removed")
+				Eventually(func(g Gomega) {
+					err := primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2DNSRecord), primary2DNSRecord)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(primary2DNSRecord.IsDeleting()).To(BeTrue())
+				}, TestTimeoutShort, time.Second).Should(Succeed())
+				Consistently(func(g Gomega) {
+					err := primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2DNSRecord), primary2DNSRecord)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(primary2DNSRecord.IsDeleting()).To(BeTrue())
+				}, TestTimeoutShort).Should(Succeed())
+
+				By("creating kubeconfig secret for primary-2 on primary-1")
+				primary2ClusterSecret = &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "primary-cluster-2",
+						Namespace: testDefaultClusterSecretNamespace,
+						Labels: map[string]string{
+							testDefaultClusterSecretLabel: "true",
+						},
+					},
+					StringData: map[string]string{
+						"kubeconfig": string(primary2Kubeconfig),
+					},
+				}
+				createClusterKubeconfigSecret(primaryK8sClient, primary2ClusterSecret, logBuffer)
+
+				//  primary-2 record should now get removed
+				By("checking primary-2 record gets removed")
+				Eventually(func(g Gomega) {
+					err := primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2DNSRecord), primary2DNSRecord)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, TestTimeoutShort, time.Second).Should(Succeed())
+
+				By("verifying the primary-2 authoritative record endpoints are updated correctly")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on primary-2
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2AuthRecord), primary2AuthRecord)).To(Succeed())
+					// authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(HaveLen(2))
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("verifying the primary-1 authoritative record endpoints are updated correctly")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on primary-1
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1AuthRecord), primary1AuthRecord)).To(Succeed())
+					// authoritative record should contain the expected endpoint and registry record
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(HaveLen(2))
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(ContainElements(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    Equal(testHostname),
+							"Targets":    ConsistOf("127.0.0.1"),
+							"RecordType": Equal("A"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"DNSName":    HaveSuffix(testHostname),
+							"Targets":    ConsistOf("\"heritage=external-dns,external-dns/owner=" + primary1DNSRecord.Status.OwnerID + ",external-dns/version=1\""),
+							"RecordType": Equal("TXT"),
+							"RecordTTL":  Equal(externaldnsendpoint.TTL(0)),
+						})),
+					))
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("deleting the primary-1 record")
+				Expect(primaryK8sClient.Delete(ctx, primary1DNSRecord)).To(Succeed())
+				// primary-1 record should be removed
+				Eventually(func(g Gomega) {
+					err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1DNSRecord), primary1DNSRecord)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+				}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())
+
+				By("verifying the primary-1 and primary-2 authoritative record endpoints are empty")
+				Eventually(func(g Gomega) {
+					// Get the authoritative record on primary-1
+					g.Expect(primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1AuthRecord), primary1AuthRecord)).To(Succeed())
+					//authoritative record should contain no endpoints
+					g.Expect(primary1AuthRecord.Spec.Endpoints).To(BeEmpty())
+					// Get the authoritative record on primary-2
+					g.Expect(primary2K8sClient.Get(ctx, client.ObjectKeyFromObject(primary2AuthRecord), primary2AuthRecord)).To(Succeed())
+					//authoritative record should contain no endpoints
+					g.Expect(primary2AuthRecord.Spec.Endpoints).To(BeEmpty())
+				}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+				By("deleting the primary-1 and primary-2 authoritative records")
+				Expect(primaryK8sClient.Delete(ctx, primary1AuthRecord)).To(Succeed())
+				Expect(primary2K8sClient.Delete(ctx, primary2AuthRecord)).To(Succeed())
+				// primary-1 and primary-2 auth record should be removed
+				Eventually(func(g Gomega) {
+					err := primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary1AuthRecord), primary1AuthRecord)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(err).To(MatchError(ContainSubstring("not found")))
+
+					err = primaryK8sClient.Get(ctx, client.ObjectKeyFromObject(primary2AuthRecord), primary2AuthRecord)
 					g.Expect(err).To(HaveOccurred())
 					g.Expect(err).To(MatchError(ContainSubstring("not found")))
 				}, TestTimeoutMedium, time.Second, ctx).Should(Succeed())

--- a/internal/controller/kubeconfig_provider_test.go
+++ b/internal/controller/kubeconfig_provider_test.go
@@ -105,10 +105,10 @@ var _ = Describe("Kubeconfig Provider", Labels{"multicluster"}, func() {
 		}, TestTimeoutShort, time.Second).Should(Succeed())
 
 		//Verify the secondary log contains the expected statements
-		Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary.dnsrecord_controller\".+\"msg\":\"Reconciled DNSRecord.+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryRecord.Name, secondaryRecord.Namespace)))
+		Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"secondary-1.dnsrecord_controller\".+\"msg\":\"Reconciled DNSRecord.+\"controller\":\"dnsrecord\".+\"name\":\"%s\".+\"namespace\":\"%s\"", secondaryRecord.Name, secondaryRecord.Namespace)))
 
 		//Verify the primary log contains the expected statements
-		Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary.remote_dnsrecord_controller\".+\"msg\":\"Remote Reconcile\".+\"controller\":\"remotednsrecord\".+\"req\":\"cluster:\\/\\/%s\\/%s\\/%s\"", secondaryClusterSecret.Name, secondaryRecord.Namespace, secondaryRecord.Name)))
+		Eventually(logBuffer).Should(gbytes.Say(fmt.Sprintf("\"logger\":\"primary-1.remote_dnsrecord_controller\".+\"msg\":\"Remote Reconcile\".+\"controller\":\"remotednsrecord\".+\"req\":\"cluster:\\/\\/%s\\/%s\\/%s\"", secondaryClusterSecret.Name, secondaryRecord.Namespace, secondaryRecord.Name)))
 	})
 
 })

--- a/internal/controller/remote_dnsrecord_controller.go
+++ b/internal/controller/remote_dnsrecord_controller.go
@@ -42,6 +42,7 @@ import (
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 	externaldnsprovider "sigs.k8s.io/external-dns/provider"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	"sigs.k8s.io/multicluster-runtime/pkg/controller"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
@@ -411,7 +412,7 @@ func (r *RemoteDNSRecordReconciler) getClusterUID(ctx context.Context) (string, 
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *RemoteDNSRecordReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+func (r *RemoteDNSRecordReconciler) SetupWithManager(mgr mcmanager.Manager, skipNameValidation bool) error {
 	var gvk schema.GroupVersionKind
 	var err error
 	gvk, err = apiutil.GVKForObject(&v1alpha1.DNSRecord{}, mgr.GetLocalManager().GetScheme())
@@ -424,6 +425,9 @@ func (r *RemoteDNSRecordReconciler) SetupWithManager(mgr mcmanager.Manager) erro
 	return mcbuilder.ControllerManagedBy(mgr).
 		Named("remotednsrecord").
 		For(&v1alpha1.DNSRecord{}).
+		WithOptions(controller.Options{
+			SkipNameValidation: &skipNameValidation,
+		}).
 		Complete(r)
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -69,23 +69,28 @@ const (
 var (
 	// Controller runtime env test environments for each delegation role
 	primaryTestEnv   *envtest.Environment
+	primary2TestEnv  *envtest.Environment
 	secondaryTestEnv *envtest.Environment
 
 	// Managers created for each environment
 	primaryManager   ctrl.Manager
+	primary2Manager  ctrl.Manager
 	secondaryManager ctrl.Manager
 
 	// Kubernetes clients created for each environment
 	primaryK8sClient   client.Client
+	primary2K8sClient  client.Client
 	secondaryK8sClient client.Client
 
 	// Kubeconfig data for 'kuadrant' user added to each environment
-	secondaryKubeconfig []byte
 	primaryKubeconfig   []byte
+	primary2Kubeconfig  []byte
+	secondaryKubeconfig []byte
 
 	// Cluster ID for each environment
+	primary1ClusterID  string
+	primary2ClusterID  string
 	secondaryClusterID string
-	primaryClusterID   string
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -103,10 +108,12 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 	By("bootstrapping test environment")
 
-	primaryTestEnv, primaryManager = setupEnv(DelegationRolePrimary)
-	secondaryTestEnv, secondaryManager = setupEnv(DelegationRoleSecondary)
+	primaryTestEnv, primaryManager = setupEnv(DelegationRolePrimary, 1)
+	primary2TestEnv, primary2Manager = setupEnv(DelegationRolePrimary, 2)
+	secondaryTestEnv, secondaryManager = setupEnv(DelegationRoleSecondary, 1)
 
 	primaryK8sClient = primaryManager.GetClient()
+	primary2K8sClient = primary2Manager.GetClient()
 	secondaryK8sClient = secondaryManager.GetClient()
 
 	go func() {
@@ -117,36 +124,56 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		err := primary2Manager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	go func() {
+		defer GinkgoRecover()
 		err := secondaryManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
-	//Create the namespace to hold multicluster secrets on the primary
-	By(fmt.Sprintf("creating namespace '%s' on primary", testDefaultClusterSecretNamespace))
+	//Create the namespace to hold multicluster secrets on the primaries
+	By(fmt.Sprintf("creating namespace '%s' on primaries", testDefaultClusterSecretNamespace))
 	CreateNamespace(testDefaultClusterSecretNamespace, primaryK8sClient)
+	CreateNamespace(testDefaultClusterSecretNamespace, primary2K8sClient)
 
-	//Create a 'kuadrant' user in the primary environment and store the kubeconfig
-	By("creating user 'kuadrant' in primary environment")
+	//Create a 'kuadrant' user in the primary environments and store the kubeconfig
+	By("creating user 'kuadrant' in primary environments")
 	primaryKubeconfig = createKuadrantUser(primaryTestEnv)
 	Expect(primaryKubeconfig).ToNot(BeEmpty())
+	primary2Kubeconfig = createKuadrantUser(primary2TestEnv)
+	Expect(primary2Kubeconfig).ToNot(BeEmpty())
 
-	//Create a 'kuadrant' user in the secondary environment and store the kubeconfig
-	By("creating user 'kuadrant' in secondary environment")
+	//Create a 'kuadrant' user in the secondary environments and store the kubeconfig
+	By("creating user 'kuadrant' in secondary environments")
 	secondaryKubeconfig = createKuadrantUser(secondaryTestEnv)
 	Expect(secondaryKubeconfig).ToNot(BeEmpty())
 
-	Expect(primaryKubeconfig).ToNot(Equal(secondaryKubeconfig))
+	//Verify kubeconfigs are different
+	Expect(primaryKubeconfig).ToNot(Or(Equal(secondaryKubeconfig), Equal(primary2Kubeconfig)))
+	Expect(primary2Kubeconfig).ToNot(Or(Equal(secondaryKubeconfig), Equal(primaryKubeconfig)))
+	Expect(secondaryKubeconfig).ToNot(Or(Equal(primaryKubeconfig), Equal(primary2Kubeconfig)))
 
+	//Get the kube system namespace UID for each environment
 	var err error
-	primaryClusterID, err = getKubeSystemUID(ctx, primaryK8sClient)
+	primary1ClusterID, err = getKubeSystemUID(ctx, primaryK8sClient)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(primaryClusterID).ToNot(BeEmpty())
+	Expect(primary1ClusterID).ToNot(BeEmpty())
+
+	primary2ClusterID, err = getKubeSystemUID(ctx, primary2K8sClient)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(primary2ClusterID).ToNot(BeEmpty())
 
 	secondaryClusterID, err = getKubeSystemUID(ctx, secondaryK8sClient)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(secondaryClusterID).ToNot(BeEmpty())
 
-	Expect(secondaryClusterID).ToNot(Equal(primaryClusterID))
+	//Verify IDs are different
+	Expect(primary1ClusterID).ToNot(Or(Equal(primary2ClusterID), Equal(secondaryClusterID)))
+	Expect(primary2ClusterID).ToNot(Or(Equal(primary1ClusterID), Equal(secondaryClusterID)))
+	Expect(secondaryClusterID).ToNot(Or(Equal(primary1ClusterID), Equal(primary2ClusterID)))
 })
 
 var _ = AfterSuite(func() {
@@ -154,6 +181,11 @@ var _ = AfterSuite(func() {
 	cancel()
 	if primaryTestEnv != nil {
 		err := primaryTestEnv.Stop()
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	if primary2TestEnv != nil {
+		err := primary2TestEnv.Stop()
 		Expect(err).NotTo(HaveOccurred())
 	}
 
@@ -191,7 +223,7 @@ func CreateNamespace(name string, client client.Client) {
 // Secondary:
 //   - create controller-runtime manager
 //   - setup DNSRecordReconciler
-func setupEnv(delegationRole string) (*envtest.Environment, ctrl.Manager) {
+func setupEnv(delegationRole string, count int) (*envtest.Environment, ctrl.Manager) {
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
@@ -221,7 +253,7 @@ func setupEnv(delegationRole string) (*envtest.Environment, ctrl.Manager) {
 		Controller: config.Controller{
 			SkipNameValidation: ptr.To(true),
 		},
-		Logger: ctrl.LoggerFrom(ctx).WithName(delegationRole),
+		Logger: ctrl.LoggerFrom(ctx).WithName(fmt.Sprintf("%s-%v", delegationRole, count)),
 	}
 
 	if delegationRole == DelegationRoleSecondary {
@@ -275,7 +307,7 @@ func setupEnv(delegationRole string) (*envtest.Environment, ctrl.Manager) {
 			DelegationRole:  delegationRole,
 		}
 
-		err = remoteDNSRecordController.SetupWithManager(mcmgr)
+		err = remoteDNSRecordController.SetupWithManager(mcmgr, true)
 		Expect(err).ToNot(HaveOccurred())
 	}
 


### PR DESCRIPTION
closes #562 

Adds a new field to the status of the DNSRecord resource `remoteRecordStatuses` which is intended to hold primary cluster specific statuses, one for each primary, that is reconciling it as a "remote" and adding it's endpoints to a local authoritative record. A cluster UID value is generated from the kube-system namespace for a repeatable cluster specific ID, and used as the key in the `remoteRecordStatuses` map, with each entry being a `DNSRecordStatus` for that cluster.

Note: It was mentioned we would use a "Zone ID" or something here instead of a "Cluster ID" but that wasn't really possible since this id needed to be different for every cluster, and is really a status for a cluster rather than a record on it. 

The RemoteDNSRecordReconciler is updated to reconcile the remote record by loading and updating the correct cluster specific status in `record.Status.remoteRecordStatuses` instead of the normal `record.Status`. A `RemoteDNSRecord` wrapper and `DNSRecordAccessor` interface were added to help achieve the required loading and setting of the status, with the intention of making this a pattern used in other reconcilers at a later date to reduce the amount of duplicated code.

Most changes are confined to the remote record reconciliation logic, but some changes were made to the checks in `ProviderEndpointsRemoved` to ensure during deletion events that all remote clusters have the chance to
clean up before the dnsrecord finalizer is removed.

### Verification

Create clusters (2 primary)
```
make multicluster-local-setup CLUSTER_COUNT=2 PRIMARY_CLUSTER_COUNT=2 DEPLOY=false
```

**Terminal 1**
```
kubectl config use-context kind-kuadrant-dns-local-1 && make run RUN_METRICS_ADDR=:8080 RUN_HEALTH_ADDR=:8081 RUN_DELEGATION_ROLE=primary
```

**Terminal 2**
```
kubectl config use-context kind-kuadrant-dns-local-2 && make run RUN_METRICS_ADDR=:8082 RUN_HEALTH_ADDR=:8083 RUN_DELEGATION_ROLE=primary
```

**Terminal 3**

Label coredns as the default provider on both clusters:
```
kubectl label secret/dns-provider-credentials-coredns -n dnstest kuadrant.io/default-provider=true --context kind-kuadrant-dns-local-1
kubectl label secret/dns-provider-credentials-coredns -n dnstest kuadrant.io/default-provider=true --context kind-kuadrant-dns-local-2
```

Create delegating records on both clusters:
```
kubectl apply -f config/local-setup/dnsrecords/delegating/coredns/simple/dnsrecord-simple-coredns-cluster1.yaml --context kind-kuadrant-dns-local-1 -n dnstest
kubectl apply -f config/local-setup/dnsrecords/delegating/coredns/simple/dnsrecord-simple-coredns-cluster2.yaml --context kind-kuadrant-dns-local-2 -n dnstest
```

Verify the dnsrecord are created as expected
```
kubectl get dnsrecord -n dnstest -o wide --show-labels --context kind-kuadrant-dns-local-1
```
Expected output
```
NAME                                READY   HEALTHY   ROOT HOST              OWNER ID   ZONE DOMAIN            ZONE ID                         LABELS
authoritative-record-1c8db9d0       True              simple.k.example.com   2qaqohjj   k.example.com          k.example.com                   kuadrant.io/authoritative-record-hash=1c8db9d0,kuadrant.io/authoritative-record=true,kuadrant.io/coredns-zone-name=k.example.com,kuadrant.io/dns-provider-name=coredns
dnsrecord-simple-coredns-cluster1   True              simple.k.example.com   217kxadk   simple.k.example.com   authoritative-record-1c8db9d0   <none>
```

```
kubectl get dnsrecord -n dnstest -o wide --show-labels --context kind-kuadrant-dns-local-2
```
Expected output
```
NAME                                READY   HEALTHY   ROOT HOST              OWNER ID   ZONE DOMAIN            ZONE ID                         LABELS
authoritative-record-1c8db9d0       True              simple.k.example.com   283zngr1   k.example.com          k.example.com                   kuadrant.io/authoritative-record-hash=1c8db9d0,kuadrant.io/authoritative-record=true,kuadrant.io/coredns-zone-name=k.example.com,kuadrant.io/dns-provider-name=coredns
dnsrecord-simple-coredns-cluster2   True              simple.k.example.com   yfy2hheg   simple.k.example.com   authoritative-record-1c8db9d0   <none>
```



