### PR TITLE
equate not set delegate field to false in CR validation

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -90,8 +90,8 @@ type HealthCheckStatusProbe struct {
 // DNSRecordSpec defines the desired state of DNSRecord
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.ownerID) || has(self.ownerID)", message="OwnerID can't be unset if it was previously set"
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.ownerID) || !has(self.ownerID)", message="OwnerID can't be set if it was previously unset"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.delegate) || has(self.delegate)", message="Delegate can't be unset if it was previously set"
-// +kubebuilder:validation:XValidation:rule="has(oldSelf.delegate) || !has(self.delegate)", message="Delegate can't be set if it was previously unset"
+// +kubebuilder:validation:XValidation:rule="has(oldSelf.delegate) || !has(self.delegate) || self.delegate == false", message="delegate can't be set to true if unset"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)", message="delegate can't be unset if true"
 // +kubebuilder:validation:XValidation:rule="!(has(self.providerRef) && has(self.delegate) && self.delegate == true)", message="delegate=true and providerRef are mutually exclusive"
 type DNSRecordSpec struct {
 	// ownerID is a unique string used to identify the owner of this record.

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2025-09-12T15:19:30Z"
+    createdAt: "2025-09-18T11:21:02Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -216,10 +216,11 @@ spec:
               rule: '!has(oldSelf.ownerID) || has(self.ownerID)'
             - message: OwnerID can't be set if it was previously unset
               rule: has(oldSelf.ownerID) || !has(self.ownerID)
-            - message: Delegate can't be unset if it was previously set
-              rule: '!has(oldSelf.delegate) || has(self.delegate)'
-            - message: Delegate can't be set if it was previously unset
-              rule: has(oldSelf.delegate) || !has(self.delegate)
+            - message: delegate can't be set to true if unset
+              rule: has(oldSelf.delegate) || !has(self.delegate) || self.delegate
+                == false
+            - message: delegate can't be unset if true
+              rule: '!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)'
             - message: delegate=true and providerRef are mutually exclusive
               rule: '!(has(self.providerRef) && has(self.delegate) && self.delegate
                 == true)'

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -341,10 +341,11 @@ spec:
               rule: '!has(oldSelf.ownerID) || has(self.ownerID)'
             - message: OwnerID can't be set if it was previously unset
               rule: has(oldSelf.ownerID) || !has(self.ownerID)
-            - message: Delegate can't be unset if it was previously set
-              rule: '!has(oldSelf.delegate) || has(self.delegate)'
-            - message: Delegate can't be set if it was previously unset
-              rule: has(oldSelf.delegate) || !has(self.delegate)
+            - message: delegate can't be set to true if unset
+              rule: has(oldSelf.delegate) || !has(self.delegate) || self.delegate
+                == false
+            - message: delegate can't be unset if true
+              rule: '!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)'
             - message: delegate=true and providerRef are mutually exclusive
               rule: '!(has(self.providerRef) && has(self.delegate) && self.delegate
                 == true)'

--- a/config/crd/bases/kuadrant.io_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.io_dnsrecords.yaml
@@ -216,10 +216,11 @@ spec:
               rule: '!has(oldSelf.ownerID) || has(self.ownerID)'
             - message: OwnerID can't be set if it was previously unset
               rule: has(oldSelf.ownerID) || !has(self.ownerID)
-            - message: Delegate can't be unset if it was previously set
-              rule: '!has(oldSelf.delegate) || has(self.delegate)'
-            - message: Delegate can't be set if it was previously unset
-              rule: has(oldSelf.delegate) || !has(self.delegate)
+            - message: delegate can't be set to true if unset
+              rule: has(oldSelf.delegate) || !has(self.delegate) || self.delegate
+                == false
+            - message: delegate can't be unset if true
+              rule: '!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)'
             - message: delegate=true and providerRef are mutually exclusive
               rule: '!(has(self.providerRef) && has(self.delegate) && self.delegate
                 == true)'

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -30,6 +30,14 @@ func GenerateName() string {
 	return namegenerator.NewNameGenerator(nBig.Int64()).Generate()
 }
 
+func getTypeMeta() metav1.TypeMeta {
+	gvk := v1alpha1.GroupVersion.WithKind("DNSRecord")
+	return metav1.TypeMeta{
+		Kind:       gvk.Kind,
+		APIVersion: gvk.GroupVersion().String(),
+	}
+}
+
 func getTestEndpoints(dnsName string, ip []string) []*externaldnsendpoint.Endpoint {
 	return []*externaldnsendpoint.Endpoint{
 		{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -82,6 +82,9 @@ var (
 	primary2K8sClient  client.Client
 	secondaryK8sClient client.Client
 
+	// Dynamic Kubernetes client to use unstructured
+	primaryDynamicClient *dynamic.DynamicClient
+
 	// Kubeconfig data for 'kuadrant' user added to each environment
 	primaryKubeconfig   []byte
 	primary2Kubeconfig  []byte
@@ -115,6 +118,10 @@ var _ = BeforeSuite(func() {
 	primaryK8sClient = primaryManager.GetClient()
 	primary2K8sClient = primary2Manager.GetClient()
 	secondaryK8sClient = secondaryManager.GetClient()
+
+	var err error
+	primaryDynamicClient, err = dynamic.NewForConfig(primaryTestEnv.Config)
+	Expect(err).ShouldNot(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()
@@ -157,7 +164,6 @@ var _ = BeforeSuite(func() {
 	Expect(secondaryKubeconfig).ToNot(Or(Equal(primaryKubeconfig), Equal(primary2Kubeconfig)))
 
 	//Get the kube system namespace UID for each environment
-	var err error
 	primary1ClusterID, err = getKubeSystemUID(ctx, primaryK8sClient)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(primary1ClusterID).ToNot(BeEmpty())


### PR DESCRIPTION
The issue we have now is that `false` for a boolean is treated like a `default` value and is omitted. Se [here](https://github.com/golang/go/issues/13284#issuecomment-157288692).  
The typical resolution is to make a primitive into a pointer that gives you 3 values to work with. In our case, it is not optimal as the default value and the absence of a value are functionally the same. Right now, to solve this, we are forbidding setting `delegate` if it was unset and unsetting if it was set. 

I'm changing the CEL validation rules to only forbid an update from `nil` to `true` and from `true` to `nil`. The rest of the cases are covered by the immutability rule. 

Here is a breakdown.

Rule: `oldSelf == self` 
| old   | new   | got   | want  |
|-------|-------|-------|-------|
| false | nil   | true  | true  |
| true  | nil   | true  | false |
| nil   | true  | true  | false |
| false | true  | false | false |
| nil   | false | true  | true  |
| true  | false | false | false |

Rule: `has(oldSelf.delegate) || !has(self.delegate) || self.delegate == false`
| old   | new   | got   | want  | covered above |
|-------|-------|-------|-------|:-------------:|
| false | nil   | true  | true  |               |
| true  | nil   | true  | false |               |
| nil   | true  | false | false |               |
| false | true  | true  | false |       *       |
| nil   | false | true  | true  |               |
| true  | false | true  | false |       *       |

Rule: `!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)`
| old   | new   | got   | want  | covered above |
|-------|-------|-------|-------|:-------------:|
| false | nil   | true  | true  |               |
| true  | nil   | false | false |               |
| nil   | true  | true  | false |       *       |
| false | true  | true  | false |       *       |
| nil   | false | true  | true  |               |
| true  | false | true  | false |       *       |

All combinations:
| old   | new   | all rules | want  |
|-------|-------|-----------|-------|
| nil   | nil   | n/a       | n/a   |
| false | nil   | true      | true  |
| true  | nil   | false     | false |
| nil   | true  | false     | false |
| false | true  | false     | false |
| true  | true  | n/a       | n/a   |
| nil   | false | true      | true  |
| false | false | n/a       | n/a   |
| true  | false | false     | false |