### PR TITLE
provider(coredns): remove NAMESERVERS from config

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -64,8 +64,6 @@ const (
 
 	// CoreDNSZonesKey list of zones available to add records into. Must be configured in the Corefile with a 'kuadrant' directive.
 	CoreDNSZonesKey = "ZONES"
-	// CoreDNSNameserversKey list of nameservers for the current CoreDNS instances.
-	CoreDNSNameserversKey = "NAMESERVERS"
 
 	DefaultProviderSecretLabel = "kuadrant.io/default-provider"
 

--- a/internal/provider/coredns/coredns_test.go
+++ b/internal/provider/coredns/coredns_test.go
@@ -2,18 +2,12 @@ package coredns_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/kuadrant/dns-operator/internal/provider"
 	"github.com/kuadrant/dns-operator/internal/provider/coredns"
-)
-
-var (
-	nameserver1 = "1.1.1.1:53"
-	nameserver2 = "2.2.2.2:53"
 )
 
 func TestCoreDNSProvider_DNSZoneForHost(t *testing.T) {
@@ -29,8 +23,7 @@ func TestCoreDNSProvider_DNSZoneForHost(t *testing.T) {
 			Host: "api.k.example.com",
 			Secret: &v1.Secret{
 				Data: map[string][]byte{
-					"ZONES":       []byte("k.example.com,example.com"),
-					"NAMESERVERS": []byte(fmt.Sprintf("%s,%s", nameserver1, nameserver2)),
+					"ZONES": []byte("k.example.com,example.com"),
 				},
 			},
 			ExpectedZoneRoot: "k.example.com",
@@ -43,8 +36,7 @@ func TestCoreDNSProvider_DNSZoneForHost(t *testing.T) {
 			Host: "api.k.example.com",
 			Secret: &v1.Secret{
 				Data: map[string][]byte{
-					"ZONES":       []byte("example.com,k.other.com"),
-					"NAMESERVERS": []byte(fmt.Sprintf("%s,%s", nameserver1, nameserver2)),
+					"ZONES": []byte("example.com,k.other.com"),
 				},
 			},
 			ExpectedZoneRoot: "example.com",
@@ -57,8 +49,7 @@ func TestCoreDNSProvider_DNSZoneForHost(t *testing.T) {
 			Host: "api.k.other.com",
 			Secret: &v1.Secret{
 				Data: map[string][]byte{
-					"ZONES":       []byte("k.example.com,example.com"),
-					"NAMESERVERS": []byte(fmt.Sprintf("%s,%s", nameserver1, nameserver2)),
+					"ZONES": []byte("k.example.com,example.com"),
 				},
 			},
 			ExpectedZoneRoot: "",


### PR DESCRIPTION
closes #581 

NAMESERVERS is no longer required by the CoreDNS provider, this removes it as a mandatory piece of data in the CoreDNS provider secret.

Note: Our e2e test suite is currently using the NAMESERVERS data in the secret so it is still being generated and added as part of local setup. It is not required for the CoreDNS provider to function though, and will look to remove it completely at a later stage.