### PR TITLE
add clenup cmd for old TXTs

### DIFF
--- a/cmd/plugin/delete_old_txt.go
+++ b/cmd/plugin/delete_old_txt.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	externaldns "sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common/slice"
+	"github.com/kuadrant/dns-operator/internal/external-dns/registry"
+	"github.com/kuadrant/dns-operator/internal/provider"
+	_ "github.com/kuadrant/dns-operator/internal/provider/aws"
+	_ "github.com/kuadrant/dns-operator/internal/provider/azure"
+	_ "github.com/kuadrant/dns-operator/internal/provider/coredns"
+	"github.com/kuadrant/dns-operator/internal/provider/endpoint"
+	_ "github.com/kuadrant/dns-operator/internal/provider/google"
+)
+
+var deleteOldTXTCMD = &cobra.Command{
+	Use:  "delete-old-txt [provider-secret-name]",
+	RunE: deleteOldTXT,
+}
+
+type DeleteOldTXTCMDFlags struct {
+	ns     string
+	domain string
+}
+
+var deleteOldTXTCMDFlags DeleteOldTXTCMDFlags
+
+func init() {
+	deleteOldTXTCMD.Flags().StringVarP(&deleteOldTXTCMDFlags.ns, "namespace", "n", "default", "namespace of a provider secret")
+	deleteOldTXTCMD.Flags().StringVarP(&deleteOldTXTCMDFlags.domain, "domain", "d", "", "domain filter to appy to endpoints")
+
+}
+
+func deleteOldTXT(_ *cobra.Command, args []string) error {
+	log = logf.Log.WithName("delete-old-txt")
+
+	d := time.Now().Add(time.Minute * 5)
+	ctx, cancel := context.WithDeadline(context.Background(), d)
+	defer cancel()
+
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments (expected one secret name)")
+	}
+
+	// setup client
+	runtime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+
+	config := controllerruntime.GetConfigOrDie()
+	k8sClient, err := client.New(config, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		fmt.Printf("failed to create client: %v\n", err)
+		return nil
+	}
+
+	secretList := &v1.SecretList{}
+	secret := &v1.Secret{}
+
+	// looking for a default secret
+	if len(args) == 0 {
+		err = k8sClient.List(ctx, secretList, &client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				v1alpha1.DefaultProviderSecretLabel: "true",
+			}),
+			Namespace: deleteOldTXTCMDFlags.ns,
+		})
+		if err != nil {
+			fmt.Printf("failed to list secrets: %v\n", err)
+			return nil
+		}
+
+		if len(secretList.Items) != 1 {
+			fmt.Printf("unexpected nmber of secrets: %d; expected 1 default secret\n", len(secretList.Items))
+			return nil
+		}
+		secret = &secretList.Items[0]
+
+	} else {
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: args[0], Namespace: deleteOldTXTCMDFlags.ns}, secret)
+		if err != nil {
+			fmt.Printf("failed to get secret: %v\n", err)
+			return nil
+		}
+	}
+	// factory to get a list of all endpoints
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		fmt.Printf("failed to create dynamic client: %v\n", err)
+		return nil
+	}
+
+	providerFactory, err := provider.NewFactory(k8sClient, dynClient, provider.RegisteredDefaultProviders(), endpoint.NewAuthoritativeDNSRecordProvider)
+	if err != nil {
+		fmt.Printf("failed to create provider factory: %v\n", err)
+		return nil
+	}
+
+	// empty config to list all records
+	endpointProvider, err := providerFactory.ProviderForSecret(ctx, secret, provider.Config{})
+	if err != nil {
+		fmt.Printf("failed to get provider: %v\n", err)
+		return nil
+	}
+
+	endpoints, err := endpointProvider.Records(ctx)
+	if err != nil {
+		fmt.Printf("failed to get endpoints: %v\n", err)
+		return nil
+	}
+
+	// only old TXTs created by us should be left
+	endpoints = slice.Filter(endpoints, func(e *externaldns.Endpoint) bool {
+		if e != nil &&
+			e.RecordType == externaldns.RecordTypeTXT &&
+			strings.HasSuffix(e.DNSName, deleteOldTXTCMDFlags.domain) {
+
+			// we will always have at least one target
+			if len(e.Targets) == 0 {
+				return false
+			}
+
+			// two layers of checks to make sure we don't delete anything needed
+
+			// owner and version in targets
+			owner, epVersion, epLabels, err := registry.NewLabelsFromString(e.Targets[0], []byte{})
+			if err != nil {
+				fmt.Printf("failed to extract owner labels: %v\n", err)
+				return false
+			}
+
+			// happens when there was only one owner
+			if owner == "" {
+				owner = epLabels[externaldns.OwnerLabelKey]
+			}
+
+			// it is old only if it has owner and doesn't have version
+			if owner != "" && epVersion == "" {
+				// this should be redundant,
+				// but it might happen that they have TXTs from external dns that are not from our operator
+				// make sure the name of endpoint matches our old pattern
+				mapper := registry.NewExternalDNSAffixNameMapper("kuadrant-", "", "wildcard")
+				epName, recordType := mapper.ToEndpointName(e.DNSName, epVersion)
+
+				// if they aren't empty - it was our record
+				return epName != "" && recordType != ""
+			}
+			return false
+		}
+		return false
+	})
+
+	fmt.Printf("filtered endpoints len %d\n", len(endpoints))
+	for _, ep := range endpoints {
+		fmt.Printf("ep: %s\n", ep.DNSName)
+	}
+
+	// display what is about to be deleted
+	fmt.Printf("TXT records (%d) to be deleted:\n", len(endpoints))
+	for _, txtRecord := range endpoints {
+		fmt.Printf("%s\t IN\t %s\t %s\n", txtRecord.DNSName, txtRecord.RecordType, txtRecord.Targets)
+	}
+	fmt.Printf("Do you want to proceed? [Y/N]\n")
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	switch answer {
+	case "y":
+		//delete
+		fmt.Printf("deleting old TXT records...\n")
+		err = endpointProvider.ApplyChanges(ctx, &plan.Changes{
+			Delete: endpoints,
+		})
+		if err != nil {
+			fmt.Printf("failed to delete old TXT records: %v\n", err)
+		}
+		return nil
+	case "n":
+		// do nothing
+		return nil
+	default:
+		fmt.Printf("unknown answer %s\n", answer)
+		return nil
+	}
+}

--- a/cmd/plugin/delete_owner.go
+++ b/cmd/plugin/delete_owner.go
@@ -6,12 +6,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// Defines logic for the delete-owner subcommand
-func deleteOwnerCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:  "delete-owner",
-		RunE: deleteOwner,
-	}
+var deleteOwnerCMD = &cobra.Command{
+	Use:  "delete-owner",
+	RunE: deleteOwner,
 }
 
 func deleteOwner(_ *cobra.Command, _ []string) error {

--- a/cmd/plugin/get-zone-records.go
+++ b/cmd/plugin/get-zone-records.go
@@ -6,11 +6,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func getZoneRecordsCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:  "zone-records",
-		RunE: getZoneRecords,
-	}
+var getZoneRecordsCMD = &cobra.Command{
+	Use:  "zone-records",
+	RunE: getZoneRecords,
 }
 
 func getZoneRecords(_ *cobra.Command, _ []string) error {

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -18,39 +18,36 @@ var (
 	log     = logf.Log
 )
 
-func main() {
-	root := &cobra.Command{
-		Use:   "dns",
-		Short: "DNS Operator command line utility",
-		Long:  "DNS Operator command line utility",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			logf.SetLogger(zap.New(zap.UseDevMode(verbose), zap.WriteTo(os.Stdout)))
-			cmd.SetContext(context.Background())
-		},
-	}
-
-	root.SetArgs(os.Args[1:])
-
-	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", true, "verbose output")
-
-	root.AddCommand(versionCommand())
-	root.AddCommand(deleteOwnerCommand())
-	root.AddCommand(getZoneRecordsCommand())
-	root.AddCommand(secretGenerationCommand())
-
-	if err := root.Execute(); err != nil {
-		os.Exit(1)
-	}
+var rootCMD = &cobra.Command{
+	Use:   "dns",
+	Short: "DNS Operator command line utility",
+	Long:  "DNS Operator command line utility",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		logf.SetLogger(zap.New(zap.UseDevMode(verbose), zap.WriteTo(os.Stdout)))
+		cmd.SetContext(context.Background())
+	},
 }
 
-func versionCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Print the version number of cli",
-		Long:  "Print the version number of cli",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("dns cli version: %s (%s)\n", version, gitSHA)
-			return nil
-		},
+var versionCMD = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of cli",
+	Long:  "Print the version number of cli",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Printf("dns cli version: %s (%s)\n", version, gitSHA)
+		return nil
+	},
+}
+
+func init() {
+	rootCMD.SetArgs(os.Args[1:])
+	rootCMD.PersistentFlags().BoolVarP(&verbose, "verbose", "v", true, "verbose output")
+
+	rootCMD.AddCommand(versionCMD, deleteOldTXTCMD, getZoneRecordsCMD)
+	rootCMD.AddCommand(generateSecretCMD, deleteOwnerCMD)
+}
+
+func main() {
+	if err := rootCMD.Execute(); err != nil {
+		os.Exit(1)
 	}
 }

--- a/internal/external-dns/registry/name_mapper_externaldns.go
+++ b/internal/external-dns/registry/name_mapper_externaldns.go
@@ -10,9 +10,9 @@ type externalDNSAffixNameMapper struct {
 	wildcardReplacement string
 }
 
-var _ nameMapper = externalDNSAffixNameMapper{}
+var _ NameMapper = externalDNSAffixNameMapper{}
 
-func newExternalDNSAffixNameMapper(prefix, suffix, wildcardReplacement string) nameMapper {
+func NewExternalDNSAffixNameMapper(prefix, suffix, wildcardReplacement string) NameMapper {
 	return externalDNSAffixNameMapper{prefix: strings.ToLower(prefix), suffix: strings.ToLower(suffix), wildcardReplacement: strings.ToLower(wildcardReplacement)}
 }
 
@@ -77,7 +77,7 @@ func (pr externalDNSAffixNameMapper) isSuffix() bool {
 	return len(pr.prefix) == 0 && len(pr.suffix) > 0
 }
 
-func (pr externalDNSAffixNameMapper) toEndpointName(txtDNSName, _ string) (endpointName, recordType string) {
+func (pr externalDNSAffixNameMapper) ToEndpointName(txtDNSName, _ string) (endpointName, recordType string) {
 	lowerDNSName := strings.ToLower(txtDNSName)
 
 	// drop prefix
@@ -115,7 +115,7 @@ func (pr externalDNSAffixNameMapper) normalizeAffixTemplate(afix, recordType str
 	return afix
 }
 
-func (pr externalDNSAffixNameMapper) toTXTName(endpointDNSName, _, recordType string) string {
+func (pr externalDNSAffixNameMapper) ToTXTName(endpointDNSName, _, recordType string) string {
 	DNSName := strings.SplitN(endpointDNSName, ".", 2)
 	recordType = strings.ToLower(recordType)
 	recordT := recordType + "-"

--- a/internal/external-dns/registry/name_mapper_kuadrant.go
+++ b/internal/external-dns/registry/name_mapper_kuadrant.go
@@ -11,13 +11,13 @@ import (
   and the endpoint for the TXT record.
 */
 
-type nameMapper interface {
-	toEndpointName(txtDNSName, version string) (endpointName, recordType string)
-	toTXTName(string, string, string) string
+type NameMapper interface {
+	ToEndpointName(txtDNSName, version string) (endpointName, recordType string)
+	ToTXTName(string, string, string) string
 }
 
 type kuadrantAffixNameMapper struct {
-	legacyMappers       map[string]nameMapper
+	legacyMappers       map[string]NameMapper
 	prefix              string
 	wildcardReplacement string
 }
@@ -28,10 +28,10 @@ type legacyMapperTemplate map[string]struct {
 	wildcardReplacement string
 }
 
-var _ nameMapper = kuadrantAffixNameMapper{}
+var _ NameMapper = kuadrantAffixNameMapper{}
 
-func newKuadrantAffixMapper(legacyMappersFor legacyMapperTemplate, prefix, wildcardReplacement string) nameMapper {
-	affixMappers := make(map[string]nameMapper)
+func newKuadrantAffixMapper(legacyMappersFor legacyMapperTemplate, prefix, wildcardReplacement string) NameMapper {
+	affixMappers := make(map[string]NameMapper)
 
 	for version, params := range legacyMappersFor {
 		affixMappers[version] = legacyAffixMappers[version](params.prefix, params.suffix, params.wildcardReplacement)
@@ -43,10 +43,10 @@ func newKuadrantAffixMapper(legacyMappersFor legacyMapperTemplate, prefix, wildc
 	}
 }
 
-func (pr kuadrantAffixNameMapper) toEndpointName(txtDNSName, version string) (endpointName, recordType string) {
+func (pr kuadrantAffixNameMapper) ToEndpointName(txtDNSName, version string) (endpointName, recordType string) {
 	// legacy
 	if version != txtFormatVersion {
-		return pr.legacyMappers[version].toEndpointName(txtDNSName, version)
+		return pr.legacyMappers[version].ToEndpointName(txtDNSName, version)
 	}
 
 	// ID-recordType-endpoint
@@ -74,7 +74,7 @@ func (pr kuadrantAffixNameMapper) toEndpointName(txtDNSName, version string) (en
 	return endpointName, recordType
 }
 
-func (pr kuadrantAffixNameMapper) toTXTName(endpointDNSName, id, recordType string) string {
+func (pr kuadrantAffixNameMapper) ToTXTName(endpointDNSName, id, recordType string) string {
 	prefix := pr.prefix
 	if !strings.HasSuffix(prefix, affixSeparator) {
 		prefix = prefix + affixSeparator

--- a/internal/external-dns/registry/name_mapper_test.go
+++ b/internal/external-dns/registry/name_mapper_test.go
@@ -9,7 +9,7 @@ import (
 
 // ExternalDNS only
 func TestDropPrefix(t *testing.T) {
-	mapper := newExternalDNSAffixNameMapper("foo-", "", "").(externalDNSAffixNameMapper)
+	mapper := NewExternalDNSAffixNameMapper("foo-", "", "").(externalDNSAffixNameMapper)
 
 	tests := []struct {
 		txtName          string
@@ -39,7 +39,7 @@ func TestDropPrefix(t *testing.T) {
 }
 
 func TestDropSuffix(t *testing.T) {
-	mapper := newExternalDNSAffixNameMapper("", "-foo", "").(externalDNSAffixNameMapper)
+	mapper := NewExternalDNSAffixNameMapper("", "-foo", "").(externalDNSAffixNameMapper)
 
 	tests := []struct {
 		txtName      string
@@ -70,7 +70,7 @@ func TestDropSuffix(t *testing.T) {
 }
 
 func TestExtractRecordTypeDefaultPosition(t *testing.T) {
-	mapper := newExternalDNSAffixNameMapper("", "-foo", "").(externalDNSAffixNameMapper)
+	mapper := NewExternalDNSAffixNameMapper("", "-foo", "").(externalDNSAffixNameMapper)
 
 	tests := []struct {
 		input        string
@@ -111,7 +111,7 @@ func TestExtractRecordTypeDefaultPosition(t *testing.T) {
 func TestToTXTName(t *testing.T) {
 	tests := []struct {
 		name       string
-		mapper     nameMapper
+		mapper     NameMapper
 		domain     string
 		txtDomain  string
 		recordType string
@@ -129,7 +129,7 @@ func TestToTXTName(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.txtDomain, tc.mapper.toTXTName(tc.domain, tc.id, tc.recordType))
+			assert.Equal(t, tc.txtDomain, tc.mapper.ToTXTName(tc.domain, tc.id, tc.recordType))
 		})
 	}
 }
@@ -137,7 +137,7 @@ func TestToTXTName(t *testing.T) {
 func TestToEndpointsName(t *testing.T) {
 	tests := []struct {
 		name               string
-		mapper             nameMapper
+		mapper             NameMapper
 		txtName            string
 		expectedDomain     string
 		expectedRecordType string
@@ -236,7 +236,7 @@ func TestToEndpointsName(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			domain, recordType := tc.mapper.toEndpointName(tc.txtName, tc.version)
+			domain, recordType := tc.mapper.ToEndpointName(tc.txtName, tc.version)
 			assert.Equal(t, tc.expectedDomain, domain)
 			assert.Equal(t, tc.expectedRecordType, recordType)
 		})

--- a/internal/external-dns/registry/txt_test.go
+++ b/internal/external-dns/registry/txt_test.go
@@ -63,7 +63,7 @@ func testTXTRegistryNew(t *testing.T) {
 	_, err = NewTXTRegistry(context.Background(), p, "txt", "txt", "owner", time.Hour, "", []string{}, []string{}, false, nil)
 	require.Error(t, err)
 
-	_, ok := r.mapper.(nameMapper)
+	_, ok := r.mapper.(NameMapper)
 	require.True(t, ok)
 	assert.Equal(t, "owner", r.ownerID)
 	assert.Equal(t, p, r.provider)
@@ -81,7 +81,7 @@ func testTXTRegistryNew(t *testing.T) {
 	r, err = NewTXTRegistry(context.Background(), p, "", "", "owner", time.Hour, "", []string{}, []string{}, true, aesKey)
 	require.NoError(t, err)
 
-	_, ok = r.mapper.(nameMapper)
+	_, ok = r.mapper.(NameMapper)
 	assert.True(t, ok)
 }
 

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -67,6 +67,7 @@ func RegisteredDefaultProviders() []string {
 // It determines which provider implementation to use by introspecting the given ProviderAccessor resource.
 type Factory interface {
 	ProviderFor(context.Context, v1alpha1.ProviderAccessor, Config) (Provider, error)
+	ProviderForSecret(ctx context.Context, pSecret *v1.Secret, pConfig Config) (Provider, error)
 }
 
 // factory is the default Factory implementation
@@ -109,7 +110,7 @@ func (f *factory) ProviderFor(ctx context.Context, pa v1alpha1.ProviderAccessor,
 			return nil, err
 		}
 
-		provider, err = f.providerForSecret(ctx, pSecret, c)
+		provider, err = f.ProviderForSecret(ctx, pSecret, c)
 		if err != nil {
 			return nil, err
 		}
@@ -129,7 +130,7 @@ func (f *factory) delegationProviderFor(ctx context.Context, pa v1alpha1.Provide
 	return f.delegationProviderFunc(ctx, f.dynamicClient, pa, pConfig)
 }
 
-func (f *factory) providerForSecret(ctx context.Context, pSecret *v1.Secret, pConfig Config) (Provider, error) {
+func (f *factory) ProviderForSecret(ctx context.Context, pSecret *v1.Secret, pConfig Config) (Provider, error) {
 	logger := log.FromContext(ctx)
 
 	providerName, err := NameForProviderSecret(pSecret)


### PR DESCRIPTION
I'm also modifying existing commands to make everything more... friendly. 
To verify 
1. `make build-cli` 
2. `make cp-cli`
3. Create a provider secret for aws 
4. `./bin/kubectl-dns delete-old-txt [provider-secret-name] -n  [namespace]` (no domain filter to see all existing records)
5. checkout an old version of dns-operator by `git checkout 3e5ec5bbcf4401cdd58448632fa1311acc2ea6ba`
6. `make run`
7. deploy a DNSRecord 
8.  `./bin/kubectl-dns delete-old-txt [provider-secret-name] -n [namespace] -d [your-domain]` 
9. agree to a clenup
10. Check with the provider to see old records are gone 

