### PR TITLE
remove replaces generating code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,17 +125,12 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: manifests-gen-base-csv
-REPLACES_VERSION ?= ""
 manifests-gen-base-csv: yq ## Generate base CSV for the current configuration (VERSION, IMG, CHANNELS etc..)
 	$(YQ) -i '.metadata.annotations.containerImage = "$(IMG)"' config/manifests/bases/dns-operator.clusterserviceversion.yaml
 	$(YQ) -i '.metadata.name = "dns-operator.v$(VERSION)"' config/manifests/bases/dns-operator.clusterserviceversion.yaml
 	$(YQ) -i '.spec.version = "$(VERSION)"' config/manifests/bases/dns-operator.clusterserviceversion.yaml
-	@if [ "$(REPLACES_VERSION)" != "" ]; then\
-		$(YQ) -i '.spec.replaces = "dns-operator.v$(REPLACES_VERSION)"' config/manifests/bases/dns-operator.clusterserviceversion.yaml; \
-	 else \
-		$(YQ) -i 'del(.spec.replaces)' config/manifests/bases/dns-operator.clusterserviceversion.yaml; \
-	fi
-
+	$(YQ) -i 'del(.spec.replaces)' config/manifests/bases/dns-operator.clusterserviceversion.yaml
+	
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
@@ -627,8 +622,7 @@ RELEASE_FILE = $(shell pwd)/make/release.mk
 prepare-release: IMG_TAG=v$(VERSION)
 prepare-release: ## Generates a makefile that will override environment variables for a specific release and runs bundle.
 	echo -e "#Release default values\\nIMG=$(IMAGE_TAG_BASE):$(IMG_TAG)\nBUNDLE_IMG=$(IMAGE_TAG_BASE)-bundle:$(IMG_TAG)\n\
-	CATALOG_IMG=$(IMAGE_TAG_BASE)-catalog:$(IMG_TAG)\nCHANNELS=$(CHANNELS)\nBUNDLE_CHANNELS=--channels=$(CHANNELS)\n\
-	VERSION=$(VERSION)\nREPLACES_VERSION=$(REPLACES_VERSION)" > $(RELEASE_FILE)
+	CATALOG_IMG=$(IMAGE_TAG_BASE)-catalog:$(IMG_TAG)\nCHANNELS=$(CHANNELS)\nBUNDLE_CHANNELS=--channels=$(CHANNELS)" > $(RELEASE_FILE)
 	$(MAKE) bundle
 	$(MAKE) helm-build VERSION=$(VERSION)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,7 +8,7 @@ git checkout -b release-0.2
 ```
 2. Run prepare release:
 ```sh
-make prepare-release IMG_TAG=release-0.2 VERSION=0.2.0-dev CHANNELS=alpha REPLACES_VERSION=0.1.0
+make prepare-release IMG_TAG=release-0.2 VERSION=0.2.0-dev CHANNELS=alpha
 ```
 3. Verify local changes, commit and push:
 ```sh
@@ -22,7 +22,7 @@ git push upstream release-0.2
 
 6. Run prepare release for final version
 ```sh
-make prepare-release VERSION=0.2.0 CHANNELS=stable REPLACES_VERSION=0.1.0
+make prepare-release VERSION=0.2.0 CHANNELS=stable
 ```
 7. Verify local changes, commit, push and tag:
 ```sh
@@ -44,7 +44,7 @@ git checkout release-0.2
 ```
 2. Run prepare release:
 ```sh
-make prepare-release VERSION=0.2.1 CHANNELS=stable REPLACES_VERSION=0.2.0
+make prepare-release VERSION=0.2.1 CHANNELS=stable
 ```
 3. Verify local changes, commit and push:
 ```sh


### PR DESCRIPTION
confirm the change:

run: 
```
make prepare-release IMG_TAG=release-0.3 VERSION=0.3.0-dev CHANNELS=alpha
```

See that the output clusterserviceversion file has no replaces field present.