### PR TITLE
Fix cli release workflow

### DIFF
--- a/.github/workflows/upload-cli.yml
+++ b/.github/workflows/upload-cli.yml
@@ -1,12 +1,22 @@
-name: Release CLI
+name: Upload CLI binary
 on:
   release:
     types:
-      - published
+      - created
+  workflow_dispatch:
+    inputs:
+      operatorTag:
+        description: Release tag
+        default: v0.0.0
+        type: string
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   release-matrix:
-    name: Release dns-operator CLI Binary
+    name: Upload dns-operator CLI Binary
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,7 +30,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: ./go.mod
           project_path: ./cmd/plugin/
           binary_name: kubectl-dns
+          release_tag: ${{ github.event.release.tag_name || inputs.operatorTag }}
           ldflags: -X "main.gitSHA=${{ github.sha }}" -X "main.version=${{ github.ref_name }}"


### PR DESCRIPTION
## What
Fix the automatic run of the workflow by using the correct trigger and adding permissions. 
Also, add an option to run it manually and upload the binary afterwards. 

## Verification 
You can see an example of a successful run with the release trigger on [this](https://github.com/maksymvavilov/dns-operator/releases/tag/auto-add-binary) release using [this](https://github.com/maksymvavilov/dns-operator/actions/runs/18492714750) run. 
An example of the manual run (automatic workflow run was [cancelled](https://github.com/maksymvavilov/dns-operator/actions/runs/18492675943)) on [this](https://github.com/maksymvavilov/dns-operator/releases/tag/add-binary-afterwards) release using this [run](https://github.com/maksymvavilov/dns-operator/actions/runs/18492778646).

You can also check that the shaa of this pr (9ec6eebd3a45c9aeaab567d66a651d74e957bbf3) is the same as the shaa on the main on my [fork](https://github.com/maksymvavilov/dns-operator), where the workflow was triggered 