### PR TITLE
chore(coredns plugin): Re-Implement zone lookup

### DIFF
--- a/coredns/plugin/Dockerfile
+++ b/coredns/plugin/Dockerfile
@@ -25,6 +25,7 @@ COPY kuadrant.go kuadrant.go
 COPY setup.go setup.go
 COPY weighted.go weighted.go
 COPY zone.go zone.go
+COPY lookup.go lookup.go
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/coredns/plugin/go.mod
+++ b/coredns/plugin/go.mod
@@ -79,5 +79,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/coredns/coredns => github.com/kuadrant/coredns v1.1.4-0.20250924192513-137cd0a65ece

--- a/coredns/plugin/go.sum
+++ b/coredns/plugin/go.sum
@@ -8,6 +8,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
 github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
+github.com/coredns/coredns v1.11.1 h1:IYBM+j/Xx3nTV4HE1s626G9msmJZSdKL9k0ZagYcZFQ=
+github.com/coredns/coredns v1.11.1/go.mod h1:X0ac9RLzd/WAxKuEe3A52miPSm6XjfoxVNAjEQgjphk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -76,8 +78,6 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kuadrant/coredns v1.1.4-0.20250924192513-137cd0a65ece h1:WegYxjPYIw+noNX4KN+m786cEllwkzqRuw2PqBqaSFM=
-github.com/kuadrant/coredns v1.1.4-0.20250924192513-137cd0a65ece/go.mod h1:+b5ox41QtlWkRdyubMTGbu3dKNb4EuTehgkBFCkVcas=
 github.com/kuadrant/dns-operator v0.12.0 h1:b14C0xO+8XvFh79dmU2VGv9nDrh7N7QW+dBl+/xvZrw=
 github.com/kuadrant/dns-operator v0.12.0/go.mod h1:7JmHQZJC9JUwzb0ZCZRml6qy6oDkOGU+lMeX2+2cgu0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/coredns/plugin/kuadrant.go
+++ b/coredns/plugin/kuadrant.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/file"
 	"github.com/coredns/coredns/plugin/transfer"
 	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"
@@ -55,9 +54,9 @@ func (k *Kuadrant) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return dns.RcodeRefused, nil
 	}
 
-	z.file.RLock()
-	exp := z.file.Expired
-	z.file.RUnlock()
+	z.RLock()
+	exp := z.Expired
+	z.RUnlock()
 	if exp {
 		log.Errorf("Zone %s is expired", zone)
 		return dns.RcodeServerFailure, nil
@@ -71,13 +70,13 @@ func (k *Kuadrant) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	m.Answer, m.Ns, m.Extra = answer, ns, extra
 
 	switch result {
-	case file.Success:
-	case file.NoData:
-	case file.NameError:
+	case Success:
+	case NoData:
+	case NameError:
 		m.Rcode = dns.RcodeNameError
-	case file.Delegation:
+	case Delegation:
 		m.Authoritative = false
-	case file.ServerFailure:
+	case ServerFailure:
 		// If the result is SERVFAIL and the answer is non-empty, then the SERVFAIL came from an
 		// external CNAME lookup and the answer contains the CNAME with no target record. We should
 		// write the CNAME record to the client instead of sending an empty SERVFAIL response.
@@ -102,7 +101,7 @@ func (k *Kuadrant) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 	if !ok || z == nil {
 		return nil, transfer.ErrNotAuthoritative
 	}
-	return z.file.Transfer(serial)
+	return z.Transfer(serial)
 }
 
 // Strips the closing dot unless it's "."

--- a/coredns/plugin/lookup.go
+++ b/coredns/plugin/lookup.go
@@ -1,0 +1,528 @@
+package kuadrant
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin/file/rrutil"
+	"github.com/coredns/coredns/plugin/file/tree"
+	"github.com/coredns/coredns/plugin/metadata"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	"github.com/coredns/coredns/request"
+	"github.com/miekg/dns"
+)
+
+//Modified version of coredns/plugin/file/lookup.go that includes implementation of `externalLookup` using `RRResolver` for recursive in tree CNAME lookups.
+
+// Result is the result of a Lookup
+type Result int
+
+const (
+	// Success is a successful lookup.
+	Success Result = iota
+	// NameError indicates a nameerror
+	NameError
+	// Delegation indicates the lookup resulted in a delegation.
+	Delegation
+	// NoData indicates the lookup resulted in a NODATA.
+	NoData
+	// ServerFailure indicates a server failure during the lookup.
+	ServerFailure
+)
+
+// Lookup looks up qname and qtype in the zone. When do is true DNSSEC records are included.
+// Three sets of records are returned, one for the answer, one for authority  and one for the additional section.
+func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) ([]dns.RR, []dns.RR, []dns.RR, Result) {
+	qtype := state.QType()
+	do := state.Do()
+
+	// If z is a secondary zone we might not have transferred it, meaning we have
+	// all zone context setup, except the actual record. This means (for one thing) the apex
+	// is empty and we don't have a SOA record.
+	z.RLock()
+	ap := z.Apex
+	tr := z.Tree
+	z.RUnlock()
+	if ap.SOA == nil {
+		return nil, nil, nil, ServerFailure
+	}
+
+	if qname == z.origin {
+		switch qtype {
+		case dns.TypeSOA:
+			return z.soa(do), z.ns(do), nil, Success
+		case dns.TypeNS:
+			nsrrs := z.ns(do)
+			glue := tr.Glue(nsrrs, do) // technically this isn't glue
+			return nsrrs, nil, glue, Success
+		}
+	}
+
+	var (
+		found, shot    bool
+		parts          string
+		i              int
+		elem, wildElem *tree.Elem
+	)
+
+	loop, _ := ctx.Value(dnsserver.LoopKey{}).(int)
+	if loop > 8 {
+		// We're back here for the 9th time; we have a loop and need to bail out.
+		// Note the answer we're returning will be incomplete (more cnames to be followed) or
+		// illegal (wildcard cname with multiple identical records). For now it's more important
+		// to protect ourselves then to give the client a valid answer. We return with an error
+		// to let the server handle what to do.
+		return nil, nil, nil, ServerFailure
+	}
+
+	// Lookup:
+	// * Per label from the right, look if it exists. We do this to find potential
+	//   delegation records.
+	// * If the per-label search finds nothing, we will look for the wildcard at the
+	//   level. If found we keep it around. If we don't find the complete name we will
+	//   use the wildcard.
+	//
+	// Main for-loop handles delegation and finding or not finding the qname.
+	// If found we check if it is a CNAME/DNAME and do CNAME processing
+	// We also check if we have type and do a nodata response.
+	//
+	// If not found, we check the potential wildcard, and use that for further processing.
+	// If not found and no wildcard we will process this as an NXDOMAIN response.
+	for {
+		parts, shot = z.nameFromRight(qname, i)
+		// We overshot the name, break and check if we previously found something.
+		if shot {
+			break
+		}
+
+		elem, found = tr.Search(parts)
+		if !found {
+			// Apex will always be found, when we are here we can search for a wildcard
+			// and save the result of that search. So when nothing match, but we have a
+			// wildcard we should expand the wildcard.
+
+			wildcard := replaceWithAsteriskLabel(parts)
+			if wild, found := tr.Search(wildcard); found {
+				wildElem = wild
+			}
+
+			// Keep on searching, because maybe we hit an empty-non-terminal (which aren't
+			// stored in the tree. Only when we have match the full qname (and possible wildcard
+			// we can be confident that we didn't find anything.
+			i++
+			continue
+		}
+
+		// If we see DNAME records, we should return those.
+		if dnamerrs := elem.Type(dns.TypeDNAME); dnamerrs != nil {
+			// Only one DNAME is allowed per name. We just pick the first one to synthesize from.
+			dname := dnamerrs[0]
+			if cname := synthesizeCNAME(state.Name(), dname.(*dns.DNAME)); cname != nil {
+				var (
+					answer, ns, extra []dns.RR
+					rcode             Result
+				)
+
+				// We don't need to chase CNAME chain for synthesized CNAME
+				if qtype == dns.TypeCNAME {
+					answer = []dns.RR{cname}
+					ns = z.ns(do)
+					extra = nil
+					rcode = Success
+				} else {
+					ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
+					answer, ns, extra, rcode = z.externalLookup(ctx, state, elem, []dns.RR{cname})
+				}
+
+				if do {
+					sigs := elem.Type(dns.TypeRRSIG)
+					sigs = rrutil.SubTypeSignature(sigs, dns.TypeDNAME)
+					dnamerrs = append(dnamerrs, sigs...)
+				}
+
+				// The relevant DNAME RR should be included in the answer section,
+				// if the DNAME is being employed as a substitution instruction.
+				answer = append(dnamerrs, answer...)
+
+				return answer, ns, extra, rcode
+			}
+			// The domain name that owns a DNAME record is allowed to have other RR types
+			// at that domain name, except those have restrictions on what they can coexist
+			// with (e.g. another DNAME). So there is nothing special left here.
+		}
+
+		// If we see NS records, it means the name as been delegated, and we should return the delegation.
+		if nsrrs := elem.Type(dns.TypeNS); nsrrs != nil {
+			// If the query is specifically for DS and the qname matches the delegated name, we should
+			// return the DS in the answer section and leave the rest empty, i.e. just continue the loop
+			// and continue searching.
+			if qtype == dns.TypeDS && elem.Name() == qname {
+				i++
+				continue
+			}
+
+			glue := tr.Glue(nsrrs, do)
+			if do {
+				dss := typeFromElem(elem, dns.TypeDS, do)
+				nsrrs = append(nsrrs, dss...)
+			}
+
+			if qtype == dns.TypeNS {
+				return nsrrs, nil, glue, Delegation
+			}
+
+			return nil, nsrrs, glue, Delegation
+		}
+
+		i++
+	}
+
+	// What does found and !shot mean - do we ever hit it?
+	if found && !shot {
+		return nil, nil, nil, ServerFailure
+	}
+
+	// Found entire name.
+	if found && shot {
+		if rrs := elem.Type(dns.TypeCNAME); len(rrs) > 0 && qtype != dns.TypeCNAME {
+			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
+			return z.externalLookup(ctx, state, elem, rrs)
+		}
+
+		rrs := elem.Type(qtype)
+
+		// NODATA
+		if len(rrs) == 0 {
+			ret := z.soa(do)
+			if do {
+				nsec := typeFromElem(elem, dns.TypeNSEC, do)
+				ret = append(ret, nsec...)
+			}
+			return nil, ret, nil, NoData
+		}
+
+		// Additional section processing for MX, SRV. Check response and see if any of the names are in bailiwick -
+		// if so add IP addresses to the additional section.
+		additional := z.additionalProcessing(rrs, do)
+
+		if do {
+			sigs := elem.Type(dns.TypeRRSIG)
+			sigs = rrutil.SubTypeSignature(sigs, qtype)
+			rrs = append(rrs, sigs...)
+		}
+
+		return rrs, z.ns(do), additional, Success
+	}
+
+	// Haven't found the original name.
+
+	// Found wildcard.
+	if wildElem != nil {
+		// set metadata value for the wildcard record that synthesized the result
+		metadata.SetValueFunc(ctx, "zone/wildcard", func() string {
+			return wildElem.Name()
+		})
+
+		if rrs := wildElem.TypeForWildcard(dns.TypeCNAME, qname); len(rrs) > 0 && qtype != dns.TypeCNAME {
+			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
+			return z.externalLookup(ctx, state, wildElem, rrs)
+		}
+
+		rrs := wildElem.TypeForWildcard(qtype, qname)
+
+		// NODATA response.
+		if len(rrs) == 0 {
+			ret := z.soa(do)
+			if do {
+				nsec := typeFromElem(wildElem, dns.TypeNSEC, do)
+				ret = append(ret, nsec...)
+			}
+			return nil, ret, nil, NoData
+		}
+
+		auth := z.ns(do)
+		if do {
+			// An NSEC is needed to say no longer name exists under this wildcard.
+			if deny, found := tr.Prev(qname); found {
+				nsec := typeFromElem(deny, dns.TypeNSEC, do)
+				auth = append(auth, nsec...)
+			}
+
+			sigs := wildElem.TypeForWildcard(dns.TypeRRSIG, qname)
+			sigs = rrutil.SubTypeSignature(sigs, qtype)
+			rrs = append(rrs, sigs...)
+		}
+		return rrs, auth, nil, Success
+	}
+
+	rcode := NameError
+
+	// Hacky way to get around empty-non-terminals. If a longer name does exist, but this qname, does not, it
+	// must be an empty-non-terminal. If so, we do the proper NXDOMAIN handling, but set the rcode to be success.
+	if x, found := tr.Next(qname); found {
+		if dns.IsSubDomain(qname, x.Name()) {
+			rcode = Success
+		}
+	}
+
+	ret := z.soa(do)
+	if do {
+		deny, found := tr.Prev(qname)
+		if !found {
+			goto Out
+		}
+		nsec := typeFromElem(deny, dns.TypeNSEC, do)
+		ret = append(ret, nsec...)
+
+		if rcode != NameError {
+			goto Out
+		}
+
+		ce, found := z.ClosestEncloser(qname)
+
+		// wildcard denial only for NXDOMAIN
+		if found {
+			// wildcard denial
+			wildcard := "*." + ce.Name()
+			if ss, found := tr.Prev(wildcard); found {
+				// Only add this nsec if it is different than the one already added
+				if ss.Name() != deny.Name() {
+					nsec := typeFromElem(ss, dns.TypeNSEC, do)
+					ret = append(ret, nsec...)
+				}
+			}
+		}
+	}
+Out:
+	return nil, ret, nil, rcode
+}
+
+// typeFromElem returns the type tp from e and adds signatures (if they exist) and do is true.
+func typeFromElem(elem *tree.Elem, tp uint16, do bool) []dns.RR {
+	rrs := elem.Type(tp)
+	if do {
+		sigs := elem.Type(dns.TypeRRSIG)
+		sigs = rrutil.SubTypeSignature(sigs, tp)
+		rrs = append(rrs, sigs...)
+	}
+	return rrs
+}
+
+// Modified version of `func (a Apex) soa(do bool) []dns.RR`
+func (z *Zone) soa(do bool) []dns.RR {
+	a := z.Apex
+	if do {
+		ret := append([]dns.RR{a.SOA}, a.SIGSOA...)
+		return ret
+	}
+	return []dns.RR{a.SOA}
+}
+
+// Modified version of `func (a Apex) ns(do bool) []dns.RR`
+
+func (z *Zone) ns(do bool) []dns.RR {
+	a := z.Apex
+	if do {
+		ret := append(a.NS, a.SIGNS...)
+		return ret
+	}
+	return a.NS
+}
+
+// externalLookup adds signatures and tries to resolve CNAMEs that point to external names.
+func (z *Zone) externalLookup(ctx context.Context, state request.Request, elem *tree.Elem, rrs []dns.RR) ([]dns.RR, []dns.RR, []dns.RR, Result) {
+	qtype := state.QType()
+	do := state.Do()
+
+	rrs = []dns.RR{z.RRResolver(ctx, state, rrs)}
+
+	if do {
+		sigs := elem.Type(dns.TypeRRSIG)
+		sigs = rrutil.SubTypeSignature(sigs, dns.TypeCNAME)
+		rrs = append(rrs, sigs...)
+	}
+
+	targetName := rrs[0].(*dns.CNAME).Target
+	elem, _ = z.Tree.Search(targetName)
+	if elem == nil {
+		lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
+		rrs = append(rrs, lookupRRs...)
+		return rrs, z.ns(do), nil, result
+	}
+
+	i := 0
+
+Redo:
+	cname := elem.Type(dns.TypeCNAME)
+	if len(cname) > 0 {
+
+		c := z.RRResolver(ctx, state, cname)
+		rrs = append(rrs, c)
+
+		if do {
+			sigs := elem.Type(dns.TypeRRSIG)
+			sigs = rrutil.SubTypeSignature(sigs, dns.TypeCNAME)
+			rrs = append(rrs, sigs...)
+		}
+		targetName := c.(*dns.CNAME).Target
+		elem, _ = z.Tree.Search(targetName)
+		if elem == nil {
+			lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
+			rrs = append(rrs, lookupRRs...)
+			return rrs, z.ns(do), nil, result
+		}
+
+		i++
+		if i > 8 {
+			return rrs, z.ns(do), nil, Success
+		}
+
+		goto Redo
+	}
+
+	targets := elem.Type(qtype)
+	if len(targets) > 0 {
+		rrs = append(rrs, z.RRResolver(ctx, state, targets))
+
+		if do {
+			sigs := elem.Type(dns.TypeRRSIG)
+			sigs = rrutil.SubTypeSignature(sigs, qtype)
+			rrs = append(rrs, sigs...)
+		}
+	}
+
+	return rrs, z.ns(do), nil, Success
+}
+
+func (z *Zone) doLookup(ctx context.Context, state request.Request, target string, qtype uint16) ([]dns.RR, Result) {
+	m, e := z.Upstream.Lookup(ctx, state, target, qtype)
+	if e != nil {
+		return nil, ServerFailure
+	}
+	if m == nil {
+		return nil, Success
+	}
+	if m.Rcode == dns.RcodeNameError {
+		return m.Answer, NameError
+	}
+	if m.Rcode == dns.RcodeServerFailure {
+		return m.Answer, ServerFailure
+	}
+	if m.Rcode == dns.RcodeSuccess && len(m.Answer) == 0 {
+		return m.Answer, NoData
+	}
+	return m.Answer, Success
+}
+
+// additionalProcessing checks the current answer section and retrieves A or AAAA records
+// (and possible SIGs) to need to be put in the additional section.
+func (z *Zone) additionalProcessing(answer []dns.RR, do bool) (extra []dns.RR) {
+	for _, rr := range answer {
+		name := ""
+		switch x := rr.(type) {
+		case *dns.SRV:
+			name = x.Target
+		case *dns.MX:
+			name = x.Mx
+		}
+		if len(name) == 0 || !dns.IsSubDomain(z.origin, name) {
+			continue
+		}
+
+		elem, _ := z.Tree.Search(name)
+		if elem == nil {
+			continue
+		}
+
+		sigs := elem.Type(dns.TypeRRSIG)
+		for _, addr := range []uint16{dns.TypeA, dns.TypeAAAA} {
+			if a := elem.Type(addr); a != nil {
+				extra = append(extra, a...)
+				if do {
+					sig := rrutil.SubTypeSignature(sigs, addr)
+					extra = append(extra, sig...)
+				}
+			}
+		}
+	}
+
+	return extra
+}
+
+//coredns/plugin/file/zone.go
+
+// NameFromRight returns the labels from the right, staring with the
+// origin and then i labels extra. When we are overshooting the name
+// the returned boolean is set to true.
+func (z *Zone) nameFromRight(qname string, i int) (string, bool) {
+	if i <= 0 {
+		return z.origin, false
+	}
+
+	for j := 1; j <= z.origLen; j++ {
+		if _, shot := dns.PrevLabel(qname, j); shot {
+			return qname, shot
+		}
+	}
+
+	k := 0
+	var shot bool
+	for j := 1; j <= i; j++ {
+		k, shot = dns.PrevLabel(qname, j+z.origLen)
+		if shot {
+			return qname, shot
+		}
+	}
+	return qname[k:], false
+}
+
+//coredns/plugin/file/wildcard_test.go
+
+// replaceWithAsteriskLabel replaces the left most label with '*'.
+func replaceWithAsteriskLabel(qname string) (wildcard string) {
+	i, shot := dns.NextLabel(qname, 0)
+	if shot {
+		return ""
+	}
+
+	return "*." + qname[i:]
+}
+
+//coredns/plugin/file/dname.go
+
+// substituteDNAME performs the DNAME substitution defined by RFC 6672,
+// assuming the QTYPE of the query is not DNAME. It returns an empty
+// string if there is no match.
+func substituteDNAME(qname, owner, target string) string {
+	if dns.IsSubDomain(owner, qname) && qname != owner {
+		labels := dns.SplitDomainName(qname)
+		labels = append(labels[0:len(labels)-dns.CountLabel(owner)], dns.SplitDomainName(target)...)
+
+		return dnsutil.Join(labels...)
+	}
+
+	return ""
+}
+
+// synthesizeCNAME returns a CNAME RR pointing to the resulting name of
+// the DNAME substitution. The owner name of the CNAME is the QNAME of
+// the query and the TTL is the same as the corresponding DNAME RR.
+//
+// It returns nil if the DNAME substitution has no match.
+func synthesizeCNAME(qname string, d *dns.DNAME) *dns.CNAME {
+	target := substituteDNAME(qname, d.Header().Name, d.Target)
+	if target == "" {
+		return nil
+	}
+
+	r := new(dns.CNAME)
+	r.Hdr = dns.RR_Header{
+		Name:   qname,
+		Rrtype: dns.TypeCNAME,
+		Class:  dns.ClassINET,
+		Ttl:    d.Header().Ttl,
+	}
+	r.Target = target
+
+	return r
+}

--- a/coredns/plugin/zone_test.go
+++ b/coredns/plugin/zone_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/coredns/coredns/plugin/file"
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/utils/ptr"
@@ -12,16 +13,11 @@ import (
 )
 
 func TestZone_InsertEndpoint(t *testing.T) {
-	type fields struct {
-		file   *file.Zone
-		rrData map[string]rrData
-	}
 	type args struct {
 		ep *endpoint.Endpoint
 	}
 	tests := []struct {
 		name           string
-		fields         fields
 		args           args
 		expectedRRData map[string]rrData
 	}{
@@ -206,14 +202,10 @@ func TestZone_InsertEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			z := &Zone{
-				file.NewZone("example.com", ""),
-				map[string]rrData{},
-			}
-			if tt.fields.file != nil {
-				z.file = tt.fields.file
-			}
-			if tt.fields.rrData != nil {
-				z.rrData = tt.fields.rrData
+				origin:  dns.Fqdn("example.com"),
+				origLen: dns.CountLabel(dns.Fqdn("example.com")),
+				Zone:    file.NewZone("example.com", ""),
+				rrData:  map[string]rrData{},
 			}
 			assert.NoError(t, z.InsertEndpoint(tt.args.ep), fmt.Sprintf("InsertEndpoint(%v)", tt.args.ep))
 			assert.Equal(t, tt.expectedRRData, z.rrData)


### PR DESCRIPTION
closes #592 

Removes the dependency on a forked version of CoreDNS by implementing the zone lookup directly.

Copies the coredns file plugin zone lookup logic with as few changes as possible. Includes implementation of `externalLookup` using `RRResolver` for recursive in tree CNAME lookups (main reason for the fork).

Note: The contents of `coredns/plugin/lookup.go` are largely copied unmodified from  our fork of CoreDNS.


**Verification:**

https://github.com/Kuadrant/dns-operator/tree/main/docs/coredns