### PR TITLE
Set operator group at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
+COPY types/ types/
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -40,7 +40,7 @@ metadata:
           "spec": {
             "endpoints": [
               {
-                "dnsName": "dnsrecord-simple.example.com",
+                "dnsName": "dnsrecord-simple.kuadrant.local",
                 "recordTTL": 60,
                 "recordType": "A",
                 "targets": [
@@ -50,8 +50,9 @@ metadata:
               }
             ],
             "providerRef": {
-              "name": "dns-provider-creds"
-            }
+              "name": "dns-provider-credentials-inmemory"
+            },
+            "rootHost": "dnsrecord-simple.kuadrant.local"
           }
         }
       ]

--- a/config/samples/kuadrant.io_v1alpha1_dnsrecord.yaml
+++ b/config/samples/kuadrant.io_v1alpha1_dnsrecord.yaml
@@ -10,11 +10,12 @@ metadata:
   name: dnsrecord-sample
 spec:
   providerRef:
-    name: dns-provider-creds
+    name: dns-provider-credentials-inmemory 
   endpoints:
-    - dnsName: dnsrecord-simple.example.com
+    - dnsName: dnsrecord-simple.kuadrant.local
       recordTTL: 60
       recordType: A
       targets:
         - 52.215.108.61
         - 52.30.101.221
+  rootHost: dnsrecord-simple.kuadrant.local

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -47,6 +47,7 @@ import (
 	externaldnsregistry "github.com/kuadrant/dns-operator/internal/external-dns/registry"
 	"github.com/kuadrant/dns-operator/internal/metrics"
 	"github.com/kuadrant/dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/types"
 )
 
 const (
@@ -82,6 +83,7 @@ type DNSRecordReconciler struct {
 	Scheme          *runtime.Scheme
 	ProviderFactory provider.Factory
 	DelegationRole  string
+	Group           *types.Group
 }
 
 func postReconcile(ctx context.Context, name, ns string) {
@@ -114,6 +116,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger := baseLogger
 
 	logger.Info("Reconciling DNSRecord")
+	logger.V(1).Info("temporary to prove the data is being passed", "group", r.Group)
 
 	reconcileStart = metav1.Now()
 	probes := &v1alpha1.DNSHealthCheckProbeList{}

--- a/internal/controller/remote_dnsrecord_controller.go
+++ b/internal/controller/remote_dnsrecord_controller.go
@@ -50,6 +50,7 @@ import (
 	externaldnsregistry "github.com/kuadrant/dns-operator/internal/external-dns/registry"
 	"github.com/kuadrant/dns-operator/internal/metrics"
 	"github.com/kuadrant/dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/types"
 )
 
 // RemoteDNSRecordReconciler reconciles a DNSRecord object on a remote cluster.
@@ -57,6 +58,7 @@ type RemoteDNSRecordReconciler struct {
 	Scheme          *runtime.Scheme
 	ProviderFactory provider.Factory
 	DelegationRole  string
+	Group           *types.Group
 
 	clusterUID string
 	mgr        mcmanager.Manager
@@ -91,6 +93,7 @@ func (r *RemoteDNSRecordReconciler) Reconcile(ctx context.Context, req mcreconci
 	logger := baseLogger
 
 	logger.Info("Remote Reconcile", "req", req.String())
+	logger.V(1).Info("temporary to prove the data is being passed", "group", r.Group)
 
 	defer r.postReconcile(ctx, req.Name, req.Namespace, req.ClusterName)
 

--- a/types/group.go
+++ b/types/group.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Group string type used for DNS Failover
+type Group string
+
+func (g *Group) String() string {
+	return string(*g)
+}
+
+func (g *Group) Set(val string) error {
+	temp := Group(val)
+	err := temp.Validate()
+	if err != nil {
+		return err
+	}
+	*g = temp
+	return nil
+}
+
+// Validate ensure the group set conforms to the required format
+func (g *Group) Validate() error {
+	invalid := ";&, \"'"
+	if strings.ContainsAny(g.String(), invalid) {
+		return fmt.Errorf("Group value can not contain: \"%s\"", invalid)
+	}
+	return nil
+}
+
+// IsSet checks if group is not empty
+func (g *Group) IsSet() bool {
+	if len(g.String()) > 0 {
+		return true
+	}
+	return false
+}

--- a/types/group_test.go
+++ b/types/group_test.go
@@ -1,0 +1,97 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_ValidateGroup(t *testing.T) {
+	RegisterTestingT(t)
+
+	scenarios := []struct {
+		Name   string
+		Group  Group
+		Verify func(error)
+	}{
+		{
+			Name:  "Valid string",
+			Group: "valid",
+			Verify: func(err error) {
+				Expect(err).To(BeNil())
+			},
+		},
+		{
+			Name:  "InValid string (contains: ;)",
+			Group: "invalid;",
+			Verify: func(err error) {
+				Expect(err).NotTo(BeNil())
+			},
+		},
+		{
+			Name:  "InValid string (contains: &)",
+			Group: "invalid&",
+			Verify: func(err error) {
+				Expect(err).NotTo(BeNil())
+			},
+		},
+		{
+			Name:  "InValid string (contains: [SPACE])",
+			Group: "invalid ",
+			Verify: func(err error) {
+				Expect(err).NotTo(BeNil())
+			},
+		},
+		{
+			Name:  "InValid string (contains: \")",
+			Group: "invalid\"",
+			Verify: func(err error) {
+				Expect(err).NotTo(BeNil())
+			},
+		},
+		{
+			Name:  "InValid string (contains: ')",
+			Group: "invalid'",
+			Verify: func(err error) {
+				Expect(err).NotTo(BeNil())
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			scenario.Verify(scenario.Group.Validate())
+		})
+	}
+}
+
+func Test_GroupIsSet(t *testing.T) {
+	RegisterTestingT(t)
+
+	scenarios := []struct {
+		Name   string
+		Group  Group
+		Verify func(bool)
+	}{
+		{
+			Name:  "IsSet == true",
+			Group: "valid",
+			Verify: func(b bool) {
+				Expect(b).To(BeTrue())
+			},
+		},
+		{
+			Name:  "IsSet != true",
+			Group: "",
+			Verify: func(b bool) {
+				Expect(b).NotTo(BeTrue())
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			scenario.Verify(scenario.Group.IsSet())
+		})
+	}
+}


### PR DESCRIPTION

Closes: #626

This adds the "group" as argument for lunching the dns-operator. The argument is past to the both reconciles `dnsrecord_controller` and `remote_dnsrecrd_controller`. A debug log statement was added to each reconcile to for validation. 

# Verification

There are three cases that need covered.
1. When no argument is given, the group should be not set.
2. Adding `--group=my-group` to the dns-operator deployment. Logs will so the group that was added.
3. Adding `GROUP=my-group` to the deployment configmap. Logs will show the group that was added. 

## String Validation
There are a number of invalid characters that should not be allowed in the finished string.
Initially the first characters were `;`, `&` and `[SPACE]`. But I extend the list to include `,`, `'` and `"`.