### PR TITLE
Refactor default TTL in EndpointsBuilder

### DIFF
--- a/test/e2e/healthcheck_test.go
+++ b/test/e2e/healthcheck_test.go
@@ -20,6 +20,7 @@ import (
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	builder "github.com/kuadrant/dns-operator/pkg/builder"
 	. "github.com/kuadrant/dns-operator/test/e2e/helpers"
 )
 
@@ -40,7 +41,7 @@ func createDNSRecordWithHealthCheck(testID string, namespace string, hostname st
 					DNSName:    hostname,
 					Targets:    []string{targetIP},
 					RecordType: "A",
-					RecordTTL:  60,
+					RecordTTL:  builder.DefaultTTL,
 				},
 			},
 			HealthCheck: &v1alpha1.HealthCheckSpec{

--- a/test/e2e/multi_record_test.go
+++ b/test/e2e/multi_record_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
 	"github.com/kuadrant/dns-operator/internal/common/hash"
 	"github.com/kuadrant/dns-operator/internal/provider"
+	builder "github.com/kuadrant/dns-operator/pkg/builder"
 	. "github.com/kuadrant/dns-operator/test/e2e/helpers"
 )
 
@@ -172,7 +173,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 											config.testTargetIP,
 										},
 										RecordType: "A",
-										RecordTTL:  60,
+										RecordTTL:  builder.DefaultTTL,
 									},
 								},
 								HealthCheck: nil,
@@ -252,7 +253,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"Targets":       ConsistOf(allTargetIps),
 					"RecordType":    Equal("A"),
 					"SetIdentifier": Equal(""),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 				})),
 			}
 
@@ -322,7 +323,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"Targets":       Not(ContainElement(recordToDelete.config.testTargetIP)),
 					"RecordType":    Equal("A"),
 					"SetIdentifier": Equal(""),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 				})),
 			}
 			if txtRegistryEnabled {
@@ -471,7 +472,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 											config.testTargetIP,
 										},
 										RecordType: "A",
-										RecordTTL:  60,
+										RecordTTL:  builder.DefaultTTL,
 									},
 									{
 										DNSName: testHostname,
@@ -479,7 +480,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 											klbHostName,
 										},
 										RecordType: "CNAME",
-										RecordTTL:  300,
+										RecordTTL:  builder.DefaultLoadBalancedTTL,
 									},
 									{
 										DNSName: geoKlbHostName,
@@ -487,7 +488,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 											clusterKlbHostName,
 										},
 										RecordType:    "CNAME",
-										RecordTTL:     60,
+										RecordTTL:     builder.DefaultTTL,
 										SetIdentifier: clusterKlbHostName,
 										ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 											{
@@ -502,7 +503,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 											geoKlbHostName,
 										},
 										RecordType:    "CNAME",
-										RecordTTL:     300,
+										RecordTTL:     builder.DefaultLoadBalancedTTL,
 										SetIdentifier: config.testGeoCode,
 										ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 											{
@@ -517,7 +518,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 											defaultGeoKlbHostName,
 										},
 										RecordType:    "CNAME",
-										RecordTTL:     300,
+										RecordTTL:     builder.DefaultLoadBalancedTTL,
 										SetIdentifier: "default",
 										ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 											{
@@ -679,7 +680,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 				"Targets":       ConsistOf(testRecords[0].config.hostnames.klb),
 				"RecordType":    Equal("CNAME"),
 				"SetIdentifier": Equal(""),
-				"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+				"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 			}))))
 			totalEndpointsChecked++
 			// common endpoint should be owner by all owners - check for txt record per owner
@@ -720,7 +721,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"Targets":          ConsistOf(allKlbGeoHostnames),
 					"RecordType":       Equal("CNAME"),
 					"SetIdentifier":    Equal(""),
-					"RecordTTL":        Equal(externaldnsendpoint.TTL(300)),
+					"RecordTTL":        Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 					"ProviderSpecific": ContainElements(gcpGeoProps),
 				}))))
 				totalEndpointsChecked++
@@ -754,7 +755,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"Targets":          ConsistOf(allKlbGeoHostnames),
 					"RecordType":       Equal("CNAME"),
 					"SetIdentifier":    Equal(""),
-					"RecordTTL":        Equal(externaldnsendpoint.TTL(300)),
+					"RecordTTL":        Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 					"ProviderSpecific": ContainElements(gcpGeoProps),
 				}))))
 				totalEndpointsChecked++
@@ -788,7 +789,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 						"Targets":       ConsistOf(geoKlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(geoCode),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "alias", Value: "false"},
 							{Name: awsGeoCodeKey, Value: awsGeoCodeValue},
@@ -832,7 +833,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"Targets":       ConsistOf(defaultGeoKlbHostName),
 					"RecordType":    Equal("CNAME"),
 					"SetIdentifier": Equal("default"),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 					"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 						{Name: "alias", Value: "false"},
 						{Name: "aws/geolocation-country-code", Value: "*"},
@@ -863,7 +864,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 						"Targets":          ConsistOf(allGeoClusterHostnames),
 						"RecordType":       Equal("CNAME"),
 						"SetIdentifier":    Equal(""),
-						"RecordTTL":        Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":        Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 						"ProviderSpecific": ContainElements(gcpWeightProps),
 					}))))
 					totalEndpointsChecked++
@@ -901,7 +902,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 						"Targets":          ConsistOf(allGeoClusterHostnames),
 						"RecordType":       Equal("CNAME"),
 						"SetIdentifier":    Equal(""),
-						"RecordTTL":        Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":        Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 						"ProviderSpecific": ContainElements(gcpWeightProps),
 					}))))
 					totalEndpointsChecked++
@@ -931,7 +932,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 							"Targets":       ConsistOf(clusterKlbHostName),
 							"RecordType":    Equal("CNAME"),
 							"SetIdentifier": Equal(clusterKlbHostName),
-							"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+							"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 							"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 								{Name: "alias", Value: "false"},
 								{Name: "aws/weight", Value: "200"},
@@ -965,7 +966,7 @@ var _ = Describe("Multi Record Test", Labels{"multi_record"}, func() {
 					"Targets":       ConsistOf(clusterTargetIP),
 					"RecordType":    Equal("A"),
 					"SetIdentifier": Equal(""),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 				}))))
 				totalEndpointsChecked++
 				if txtRegistryEnabled {

--- a/test/e2e/provider_errors_test.go
+++ b/test/e2e/provider_errors_test.go
@@ -171,7 +171,7 @@ var _ = Describe("DNSRecord Provider Errors", Labels{"provider_errors"}, func() 
 				"foo.example.com",
 			},
 			RecordType:    "CNAME",
-			RecordTTL:     300,
+			RecordTTL:     builder.DefaultLoadBalancedTTL,
 			SetIdentifier: "foo.example.com",
 			ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 				{
@@ -291,7 +291,7 @@ var _ = Describe("DNSRecord Provider Errors", Labels{"provider_errors"}, func() 
 				"foo.example.com",
 			},
 			RecordType:    "CNAME",
-			RecordTTL:     300,
+			RecordTTL:     builder.DefaultLoadBalancedTTL,
 			SetIdentifier: "foo.example.com",
 			ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 				{
@@ -406,7 +406,7 @@ func testBuildDNSRecord(name, ns, dnsProviderSecretName, ownerID, rootHost strin
 						"127.0.0.1",
 					},
 					RecordType: "A",
-					RecordTTL:  60,
+					RecordTTL:  builder.DefaultTTL,
 				},
 			},
 		},

--- a/test/e2e/single_record_test.go
+++ b/test/e2e/single_record_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
 	"github.com/kuadrant/dns-operator/internal/common/hash"
 	"github.com/kuadrant/dns-operator/internal/provider"
+	builder "github.com/kuadrant/dns-operator/pkg/builder"
 	. "github.com/kuadrant/dns-operator/test/e2e/helpers"
 )
 
@@ -176,7 +177,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 							testTargetIP,
 						},
 						RecordType: "A",
-						RecordTTL:  60,
+						RecordTTL:  builder.DefaultTTL,
 					},
 					{
 						DNSName: testHostname2,
@@ -184,7 +185,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 							testTargetIP2,
 						},
 						RecordType: "A",
-						RecordTTL:  60,
+						RecordTTL:  builder.DefaultTTL,
 					},
 				},
 				HealthCheck: nil,
@@ -230,14 +231,14 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 				"Targets":       ConsistOf(testTargetIP),
 				"RecordType":    Equal("A"),
 				"SetIdentifier": Equal(""),
-				"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+				"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 			})),
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"DNSName":       Equal(testHostname2),
 				"Targets":       ConsistOf(testTargetIP2),
 				"RecordType":    Equal("A"),
 				"SetIdentifier": Equal(""),
-				"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+				"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 			})),
 		}
 		expectedDomainOwnersMatcher := BeEmpty()
@@ -285,7 +286,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 								testTargetIP,
 							},
 							RecordType: "A",
-							RecordTTL:  60,
+							RecordTTL:  builder.DefaultTTL,
 						},
 					},
 					HealthCheck: nil,
@@ -331,7 +332,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 					"Targets":       ConsistOf(testTargetIP),
 					"RecordType":    Equal("A"),
 					"SetIdentifier": Equal(""),
-					"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+					"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 				})),
 			}
 			expectedDomainOwnersMatcher := BeEmpty()
@@ -429,7 +430,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 								testTargetIP,
 							},
 							RecordType: "A",
-							RecordTTL:  60,
+							RecordTTL:  builder.DefaultTTL,
 						},
 						{
 							DNSName: testHostname,
@@ -437,7 +438,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 								klbHostName,
 							},
 							RecordType: "CNAME",
-							RecordTTL:  300,
+							RecordTTL:  builder.DefaultLoadBalancedTTL,
 						},
 						{
 							DNSName: geo1KlbHostName,
@@ -445,7 +446,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 								cluster1KlbHostName,
 							},
 							RecordType:    "CNAME",
-							RecordTTL:     60,
+							RecordTTL:     builder.DefaultTTL,
 							SetIdentifier: cluster1KlbHostName,
 							ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 								{
@@ -460,7 +461,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 								geo1KlbHostName,
 							},
 							RecordType:    "CNAME",
-							RecordTTL:     300,
+							RecordTTL:     builder.DefaultLoadBalancedTTL,
 							SetIdentifier: geoCode,
 							ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 								{
@@ -475,7 +476,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 								geo1KlbHostName,
 							},
 							RecordType:    "CNAME",
-							RecordTTL:     300,
+							RecordTTL:     builder.DefaultLoadBalancedTTL,
 							SetIdentifier: "default",
 							ProviderSpecific: externaldnsendpoint.ProviderSpecific{
 								{
@@ -529,21 +530,21 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(testTargetIP),
 						"RecordType":    Equal("A"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(testHostname),
 						"Targets":       ConsistOf(klbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(geo1KlbHostName),
 						"Targets":       ConsistOf(cluster1KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "routingpolicy", Value: "weighted"},
 							{Name: cluster1KlbHostName, Value: "200"},
@@ -554,7 +555,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(geo1KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "routingpolicy", Value: "geo"},
 							{Name: geo1KlbHostName, Value: geoCode},
@@ -594,7 +595,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(testTargetIP),
 						"RecordType":    Equal("A"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -602,7 +603,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(klbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 					}))))
 				Expect(zoneEndpoints).To(ContainElement(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -610,7 +611,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(cluster1KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "routingpolicy", Value: "Weighted"},
 							{Name: cluster1KlbHostName, Value: "200"},
@@ -622,7 +623,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(geo1KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "routingpolicy", Value: "Geographic"},
 							{Name: geo1KlbHostName, Value: "WORLD"},
@@ -665,21 +666,21 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(testTargetIP),
 						"RecordType":    Equal("A"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(testHostname),
 						"Targets":       ConsistOf(klbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(geo1KlbHostName),
 						"Targets":       ConsistOf(cluster1KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(cluster1KlbHostName),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "alias", Value: "false"},
 							{Name: "aws/weight", Value: "200"},
@@ -690,7 +691,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(geo1KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(geoCode),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "alias", Value: "false"},
 							{Name: "aws/geolocation-country-code", Value: "US"},
@@ -701,7 +702,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(geo1KlbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal("default"),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "alias", Value: "false"},
 							{Name: "aws/geolocation-country-code", Value: "*"},
@@ -755,20 +756,20 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"Targets":       ConsistOf(testTargetIP),
 						"RecordType":    Equal("A"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":       Equal(testHostname),
 						"Targets":       ConsistOf(klbHostName),
 						"RecordType":    Equal("CNAME"),
 						"SetIdentifier": Equal(""),
-						"RecordTTL":     Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":     Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"DNSName":    Equal(geo1KlbHostName),
 						"Targets":    ConsistOf(cluster1KlbHostName),
 						"RecordType": Equal("CNAME"),
-						"RecordTTL":  Equal(externaldnsendpoint.TTL(60)),
+						"RecordTTL":  Equal(externaldnsendpoint.TTL(builder.DefaultTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "weight", Value: "200"},
 						}),
@@ -777,7 +778,7 @@ var _ = Describe("Single Record Test", Labels{"single_record"}, func() {
 						"DNSName":    Equal(klbHostName),
 						"Targets":    ConsistOf(geo1KlbHostName),
 						"RecordType": Equal("CNAME"),
-						"RecordTTL":  Equal(externaldnsendpoint.TTL(300)),
+						"RecordTTL":  Equal(externaldnsendpoint.TTL(builder.DefaultLoadBalancedTTL)),
 						"ProviderSpecific": Equal(externaldnsendpoint.ProviderSpecific{
 							{Name: "geo-code", Value: "US"},
 						}),


### PR DESCRIPTION
This refactor is needed for completing https://github.com/Kuadrant/kuadrant-operator/issues/1628

- Adds builder instance default TTL context
- Adds methods for changing the default TTL in context
   - Adds unit tests for the methods
- Renames `DefaultCnameTTL` to `DefaultLoadBalancedTTL` for better clarity
- Refactor tests to not use hard coded value but imports constant
