### PR TITLE
gh-599 rename remaining references

### DIFF
--- a/.github/workflows/upload-cli.yml
+++ b/.github/workflows/upload-cli.yml
@@ -31,6 +31,6 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           project_path: ./cmd/plugin/
-          binary_name: kubectl-dns
+          binary_name: kubectl_kuadrant-dns
           release_tag: ${{ github.event.release.tag_name || inputs.operatorTag }}
           ldflags: -X "main.gitSHA=${{ github.sha }}" -X "main.version=${{ github.ref_name }}"

--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 HELM ?= $(LOCALBIN)/helm
 KUBE_BURNER ?= $(LOCALBIN)/kube-burner
-KUBECTL_DNS ?= $(LOCALBIN)/kubectl-dns
+KUBECTL_DNS ?= $(LOCALBIN)/kubectl_kuadrant-dns
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
@@ -525,7 +525,7 @@ $(KUBE_BURNER):
 	}
 
 .PHONY: kubectl-dns
-kubectl-dns: $(KUBECTL_DNS) ## Build the kubectl-dns locally if required.
+kubectl-dns: $(KUBECTL_DNS) ## Build the kubectl_kuadrant-dns locally if required.
 $(KUBECTL_DNS):
 	$(MAKE) build-cli
 

--- a/cmd/plugin/secret_generation.go
+++ b/cmd/plugin/secret_generation.go
@@ -109,7 +109,7 @@ func addClusterSecret(_ *cobra.Command, _ []string) error {
 
 	dirtyStr := os.Getenv("KUBECTL_DNS_DIRTY")
 	if strings.Compare(strings.ToLower(dirtyStr), "true") == 0 {
-		log.V(1).Info("kubectl-dns running in dirty mode")
+		log.V(1).Info("kubectl_kuadrant-dns running in dirty mode")
 		generateSecretFlags.dirty = true
 	}
 

--- a/docs/dns_record_delegation.md
+++ b/docs/dns_record_delegation.md
@@ -11,8 +11,8 @@ This is not strictly necessary as the default delegation role is primary.
 Multi cluster communication is done via a secret with the label `kuadrant.io/multicluster-kubeconfig=true`.
 These secrets are created within the same namespace as the dns-operator deployment.
 The secret contains a kubeconfig that allow access to a cluster with multi cluster setup, and there will be one secret pre cluster.
-The `kubectl-dns` plugin provides a command to help with the secret generation.
-See `kubectl-dns add-cluster-secret --help` for more information.
+The `kubectl_kuadrant-dns` plugin provides a command to help with the secret generation.
+See `kubectl_kuadrant-dns add-cluster-secret --help` for more information.
 If there are multiply **primary clusters**, each cluster must have the same cluster connection secrets, and a cluster connection secrets to the other **primary cluster**.
 The **primary cluster B** will generate an identical **authoritative dns record** to **primary cluster A**
 

--- a/internal/external-dns/registry/README.md
+++ b/internal/external-dns/registry/README.md
@@ -24,4 +24,4 @@ The TXT registry structure above is not the first iteration. It could happen tha
 
 To migrate, run a newer version of the dns-operator. It will be able to read the old format and save that metadata into the new format of records. The logic gives precedence to the new format, meaning that once the new set of TXTs is created, the old ones are effectively ignored. 
 
-Once migrated to clean up, consider using the `kubectl-dns` plugin. See `kubectl  dns prune-legacy-txt-records --help` for more details. You will need to specify the name of the provider secret (unless you have a default secret configured - this is what it will look for in case no secret is provided). 
+Once migrated to clean up, consider using the `kubectl_kuadrant-dns` plugin. See `kubectl kuadrant-dns prune-legacy-txt-records --help` for more details. You will need to specify the name of the provider secret (unless you have a default secret configured - this is what it will look for in case no secret is provided). 

--- a/make/cli.mk
+++ b/make/cli.mk
@@ -19,4 +19,4 @@ build-cli: fmt vet
 
 .PHONY: cp-cli
 cp-cli:
-	cp ./bin/kubectl-dns $(HOME)/.local/bin
+	cp ./bin/kubectl_kuadrant-dns $(HOME)/.local/bin

--- a/make/kubeconfig-secret.mk
+++ b/make/kubeconfig-secret.mk
@@ -26,7 +26,7 @@ kubeconfig-secret-create-kind-internal: kubectl-dns ## Create a kubeconfig secre
 		-v $(shell pwd):/tmp/dns-operator:z \
 		--network kind \
 		-e KUBECONFIG=/tmp/dns-operator/tmp/kubeconfigs/kuadrant-local-all.internal.kubeconfig alpine/k8s:1.30.13 \
-		/tmp/dns-operator/bin/kubectl-dns add-cluster-secret --context $(REMOTE_CONTEXT) --service-account $(SERVICE_ACCOUNT) --namespace $(NAMESPACE) --name $(NAME)
+		/tmp/dns-operator/bin/kubectl_kuadrant-dns add-cluster-secret --context $(REMOTE_CONTEXT) --service-account $(SERVICE_ACCOUNT) --namespace $(NAMESPACE) --name $(NAME)
 
 .PHONY: kubeconfig-secret-delete
 kubeconfig-secret-delete: NAMESPACE=dns-operator-system


### PR DESCRIPTION
Seems like I've missed quite a few references to the old name of the cli 