### PR TITLE
fix(regression): premature record reconcile check

### DIFF
--- a/internal/controller/base_dnsrecord_reconciler.go
+++ b/internal/controller/base_dnsrecord_reconciler.go
@@ -77,10 +77,10 @@ func (r *BaseDNSRecordReconciler) getDNSProvider(ctx context.Context, dnsRecord 
 }
 
 // deleteRecord deletes record(s) in the DNSProvider(i.e. route53) zone (dnsRecord.GetZoneID()).
-func deleteRecord(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider provider.Provider) (bool, error) {
+func (r *BaseDNSRecordReconciler) deleteRecord(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider provider.Provider) (bool, error) {
 	logger := log.FromContext(ctx)
 
-	hadChanges, err := applyChanges(ctx, dnsRecord, dnsProvider, true)
+	hadChanges, err := r.applyChanges(ctx, dnsRecord, dnsProvider, true)
 	if err != nil {
 		if strings.Contains(err.Error(), "was not found") || strings.Contains(err.Error(), "notFound") {
 			logger.Info("Record not found in zone, continuing")
@@ -98,9 +98,9 @@ func deleteRecord(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider 
 
 // publishRecord publishes record(s) to the DNSProvider(i.e. route53) zone (dnsRecord.GetZoneID()).
 // returns if it had changes, if record is healthy and an error. If had no changes - the healthy bool can be ignored
-func publishRecord(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider provider.Provider) (bool, error) {
+func (r *BaseDNSRecordReconciler) publishRecord(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider provider.Provider) (bool, error) {
 	logger := log.FromContext(ctx)
-	hadChanges, err := applyChanges(ctx, dnsRecord, dnsProvider, false)
+	hadChanges, err := r.applyChanges(ctx, dnsRecord, dnsProvider, false)
 	if err != nil {
 		return hadChanges, err
 	}
@@ -111,7 +111,7 @@ func publishRecord(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider
 
 // applyChanges creates the Plan and applies it to the registry. Returns true only if the Plan had no errors and there were changes to apply.
 // The error is nil only if the changes were successfully applied or there were no changes to be made.
-func applyChanges(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider provider.Provider, isDelete bool) (bool, error) {
+func (r *BaseDNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord DNSRecordAccessor, dnsProvider provider.Provider, isDelete bool) (bool, error) {
 	logger := log.FromContext(ctx)
 	//ToDo We can't use GetRootHost() here as it currently removes any wildcard prefix which needs to be maintained in this scenario.
 	rootDomainName := dnsRecord.GetSpec().RootHost

--- a/internal/controller/remote_dnsrecord_controller.go
+++ b/internal/controller/remote_dnsrecord_controller.go
@@ -140,7 +140,7 @@ func (r *RemoteDNSRecordReconciler) Reconcile(ctx context.Context, req mcreconci
 				return r.updateStatus(ctx, cl.GetClient(), previous, dnsRecord, err)
 			}
 
-			_, err = deleteRecord(ctx, dnsRecord, dnsProvider)
+			_, err = r.deleteRecord(ctx, dnsRecord, dnsProvider)
 			if err != nil {
 				logger.Error(err, "Failed to delete DNSRecord")
 				return ctrl.Result{}, err
@@ -199,7 +199,7 @@ func (r *RemoteDNSRecordReconciler) Reconcile(ctx context.Context, req mcreconci
 	}
 
 	// Publish the record
-	_, err = publishRecord(ctx, dnsRecord, dnsProvider)
+	_, err = r.publishRecord(ctx, dnsRecord, dnsProvider)
 	if err != nil {
 		logger.Error(err, "Failed to publish record")
 		dnsRecord.SetStatusCondition(string(v1alpha1.ConditionTypeReady), metav1.ConditionFalse,


### PR DESCRIPTION
Adds back the check for premature record reconcile to the `publishRecord` step of the local DNSRecord reconcile.

Removed in error in https://github.com/Kuadrant/dns-operator/pull/629

Note: There are obviously no tests that test any of this!!!