### PR TITLE
fix: wildcard root hosts

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -307,7 +307,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return r.updateStatus(ctx, previous, dnsRecord, false, err)
 		}
 
-		z, err := p.DNSZoneForHost(ctx, dnsRecord.GetRootHost())
+		z, err := p.DNSZoneForHost(ctx, dnsRecord.GetSpec().RootHost)
 		if err != nil {
 			dnsRecord.SetStatusCondition(string(v1alpha1.ConditionTypeReady), metav1.ConditionFalse,
 				"DNSProviderError", fmt.Sprintf("Unable to find suitable zone in provider: %v", provider.SanitizeError(err)))

--- a/internal/controller/remote_dnsrecord_controller.go
+++ b/internal/controller/remote_dnsrecord_controller.go
@@ -175,7 +175,7 @@ func (r *RemoteDNSRecordReconciler) Reconcile(ctx context.Context, req mcreconci
 			return r.updateStatus(ctx, cl.GetClient(), previous, dnsRecord, err)
 		}
 
-		z, err := p.DNSZoneForHost(ctx, dnsRecord.GetRootHost())
+		z, err := p.DNSZoneForHost(ctx, dnsRecord.GetSpec().RootHost)
 		if err != nil {
 			dnsRecord.SetStatusCondition(string(v1alpha1.ConditionTypeReady), metav1.ConditionFalse,
 				"DNSProviderError", fmt.Sprintf("Unable to find suitable zone in provider: %v", provider.SanitizeError(err)))


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/Kuadrant/dns-operator/pull/629 where wilcard root hosts(e.g. *.example.com) that matched exactly the dns name of the zone (e.g. example.com) would fail to assign a zone correctly.