### PR TITLE
Claude slash command | Verify-pr

### DIFF
--- a/.claude/commands/verify-pr.md
+++ b/.claude/commands/verify-pr.md
@@ -1,0 +1,198 @@
+You are analyzing whether the code changes in the current branch adequately address the requirements specified in a GitHub issue. This verification helps ensure PRs are complete before submission.
+
+**Parameters:**
+- Target branch: $1 (e.g., origin/main, main)
+- Issue URL: $2 (e.g., https://github.com/Kuadrant/dns-operator/issues/627)
+
+## Step 1: Validate Parameters and Extract Issue Information
+
+First, validate the parameters:
+- Ensure both target branch and issue URL are provided
+- Extract the issue number and repository from the URL (format: https://github.com/{owner}/{repo}/issues/{number})
+- If parameters are missing or invalid, provide clear error messages
+
+## Step 2: Gather Issue Details
+
+Use a two-tier approach to fetch issue information, preferring `gh` CLI but gracefully falling back to WebFetch:
+
+**Tier 1: Try `gh` CLI first (if available):**
+```bash
+# Check if gh is available
+which gh
+
+# If available, fetch issue details
+gh issue view {issue-number} --repo {owner}/{repo} --json title,body,labels,state,assignees,comments
+```
+
+Benefits of `gh` CLI:
+- Provides structured metadata (labels, state, assignees)
+- Can fetch comments for additional context
+- Formatted JSON output for parsing
+
+**Tier 2: Fallback to WebFetch (always works):**
+
+If `gh` is not installed or fails (authentication, network issues), use the WebFetch tool:
+```
+WebFetch(url: {issue-url}, prompt: "Extract the issue title, description, requirements, and acceptance criteria...")
+```
+
+Benefits of WebFetch:
+- No installation required
+- Works without authentication
+- No external dependencies
+
+**Note in output which method was used** (e.g., "📡 Issue fetched via: gh CLI" or "📡 Issue fetched via: WebFetch")
+
+From the issue, extract:
+- Title and main description
+- Stated requirements and acceptance criteria
+- Any task lists or checkboxes
+- Key discussion points from comments that clarify requirements (if available)
+- Relevant labels (bug, enhancement, documentation, etc.) (if available)
+
+## Step 3: Gather Code Changes
+
+Collect all changes between the target branch and current HEAD:
+
+1. **Diff analysis:**
+```bash
+git diff {target-branch}...HEAD
+```
+
+2. **Commit history:**
+```bash
+git log {target-branch}..HEAD --oneline
+```
+
+3. **File statistics:**
+```bash
+git diff {target-branch}...HEAD --stat
+```
+
+Read the full content of key modified files to understand context beyond just the diff.
+
+## Step 4: Perform AI Analysis
+
+Analyze the relationship between issue requirements and code changes:
+
+### A. Requirement Extraction
+Parse the issue to identify:
+- Explicit requirements (numbered lists, acceptance criteria sections)
+- Implicit requirements (problems described that need solutions)
+- Expected behavior changes
+- Documentation or test expectations
+
+### B. Change Categorization
+Organize code changes by:
+- **Feature implementation**: New functionality added
+- **Bug fixes**: Problems resolved
+- **Tests**: New or updated tests
+- **Documentation**: README, code comments, API docs
+- **Refactoring**: Code improvements without behavior changes
+- **Configuration**: Config files, dependencies, build changes
+
+### C. Coverage Mapping
+For each requirement from the issue:
+- ✅ **Fully Addressed**: Cite specific code changes (file:line) that implement this requirement
+- ⚠️ **Partially Addressed**: Identify what's done and what's missing
+- ❌ **Not Addressed**: Flag missing implementations
+
+### D. Quality Assessment
+Evaluate:
+- Are there tests covering the new/changed functionality?
+- Is documentation updated to reflect changes?
+- Do commit messages reference the issue?
+- Are there any obvious bugs or issues in the implementation?
+- Does the code follow existing patterns in the codebase?
+
+## Step 5: Generate Interactive Review
+
+Provide a structured report with these sections:
+
+### 🎯 TL;DR
+
+Provide a quick executive summary at the very top:
+```
+**Status:** ✅ Ready for PR | ⚠️ Mostly Ready | ❌ Needs Work
+**Confidence:** High (85-100%) | Medium (60-84%) | Low (<60%)
+**Blockers:** None | {number} critical issues
+**Key Recommendations:** {number} high priority, {number} medium priority, {number} low priority
+
+**Quick Stats:**
+- ✅ {X}/{Y} requirements fully addressed
+- ⚠️ {X}/{Y} requirements partially addressed
+- ❌ {X}/{Y} requirements not addressed
+- ✅ {passed} tests passing, {failed} failing
+- 📝 {N} files changed (+{insertions}/-{deletions})
+- 🧪 {N} new tests added (or ⚠️ 0 new tests added)
+```
+
+### 📋 Issue Summary
+- Issue #{number}: {title}
+- 📡 Issue fetched via: {gh CLI | WebFetch}
+- Type: {bug/enhancement/etc based on labels if available}
+- Key requirements (bulleted list)
+
+### 📊 Changes Overview
+- X files changed, Y insertions(+), Z deletions(-)
+- N commits
+- Key files modified (with file paths as clickable references)
+
+### ✅ Requirement Coverage Analysis
+
+For each requirement, provide:
+```
+**Requirement: {requirement description}**
+Status: ✅ Fully Addressed | ⚠️ Partially Addressed | ❌ Not Addressed
+
+Evidence:
+- {specific code references with file:line}
+- {relevant commit messages}
+
+[If partially/not addressed]
+Gap: {what's missing}
+```
+
+### 🔍 Code Quality Observations
+
+Highlight:
+- Test coverage (are there tests? do they cover the changes?)
+- Documentation updates (README, comments, API docs)
+- Consistency with codebase patterns
+- Potential issues or concerns
+
+### 💡 Suggestions
+
+Provide actionable recommendations:
+```
+Priority: High | Medium | Low
+- {specific suggestion with reasoning}
+- {file references where changes should be made}
+```
+
+### 🎯 Final Verdict
+
+Provide a clear assessment:
+- **✅ Ready for PR**: All requirements addressed, good test coverage, docs updated
+- **⚠️ Mostly Ready**: Core requirements met but some improvements recommended
+- **❌ Needs Work**: Critical requirements missing or significant gaps
+
+Include a brief summary justification.
+
+## Error Handling
+
+If you encounter any of these situations:
+- **Missing `gh` CLI**: Silently fallback to WebFetch (this is expected and normal)
+- **`gh` authentication issues**: Note in output "⚠️ gh CLI available but not authenticated, using WebFetch fallback" and proceed with WebFetch
+- **Invalid branch**: Show error with list of available branches using `git branch -a`
+- **Invalid issue URL**: Show error with expected format: `https://github.com/{owner}/{repo}/issues/{number}`
+- **Network errors with both gh and WebFetch**: Report the error and ask user to verify connectivity or provide issue details manually
+- **Issue not found (404)**: Verify issue number and repository are correct
+
+## Important Notes
+
+- Be thorough but concise - focus on actionable insights
+- Always cite specific file:line references for code evidence
+- If requirements are ambiguous, note that and make reasonable assumptions
+- Consider the spirit of the issue, not just literal checklist items
+- Flag potential edge cases or scenarios not covered by tests


### PR DESCRIPTION
This change is introducing a claude slash command `/verify-pr` which is hoping to achieve the following.

When a developer is working on an issue, and has their work ready for opening a PR they can run the command to get feedback on how well they have addressed the ask of the issue they are working. From my testing on current open PRs, the result seems to be consistent. If the result is accurate, that is a different story, and I think only time will tell. The quality of the issue being referenced will also have an effect on the quality of the result. 

## Usage

```
/verify-pr <remote>/<branch> <link/to/issue>
```

The `<remote>/<branch>` is required to compare the change of multiply commits. The `<link/to/issue>` is given the AI the reference to the issue the developer is trying to address.

What I have found. If you call `/verify-pr` on branch that already has a PR opened, and the `gh` tool is installed, the AI is able to work out what the issue was and what remote branch it was targeting. 

## Example output

The following output was generate with the following inputs:
- git issue: https://github.com/Kuadrant/dns-operator/issues/627
- targeting main on this commit: https://github.com/Kuadrant/dns-operator/commit/972c57de4e5262b1b2acea4653b90054e0dcd20a
- WIP feature branch: https://github.com/Kuadrant/dns-operator/pull/652/commits/b0131038bd9a21e43c2ea8e2482f95d21974593e

### Command output
 🎯 TL;DR

  Status: ⚠️ Mostly Ready
  Confidence: High (85%)
  Blockers: None critical
  Key Recommendations: 1 high priority, 0 medium priority, 0 low priority

  Quick Stats:
  - ✅ 2/2 requirements fully addressed
  - ⚠️ 0/2 requirements partially addressed
  - ❌ 0/2 requirements not addressed
  - ✅ All tests passing (40/40 integration tests, all unit tests)
  - 📝 11 files changed (+119/-8)
  - 🧪 0 new unit tests specifically for GroupRegistry (but existing TXT registry tests cover the underlying mechanism)

  ---
  📋 Issue Summary

  Issue #627: DNS Operator add/update group and targets to registry entries
  📡 Issue fetched via: gh CLI
  Type: Enhancement
  Status: OPEN

  Key Requirements:

  1. Add groupID to registry entries when present on the DNSRecord
  2. Add targets to registry entries (only when groupID is present, excluding the rootHost)
  3. Expected registry format: version=1;ownerID=sdfsdf;groupID=group1;targets=target1&&target2
  4. Implementation location: Before publish is called in both:
    - internal/controller/dnsrecord_controller.go (line ~354)
    - internal/controller/remote_dnsrecord_controller.go (line ~211)
  5. Cleanup logic: When groupID is empty, remove group and targets labels

  Goals (from issue):

  - Enable determining which groups own a particular endpoint
  - Enable determining which groups own any particular target

  ---
  📊 Changes Overview

  11 files changed, 119 insertions(+), 8 deletions(-)
  6 commits in this branch

  Key Files Modified:

  1. CRD/API Changes:
    - api/v1alpha1/dnsrecord_types.go - Added Group field to DNSRecordStatus
    - config/crd/bases/kuadrant.io_dnsrecords.yaml - CRD manifest updated
    - bundle/manifests/kuadrant.io_dnsrecords.yaml - Bundle manifest updated
    - charts/dns-operator/templates/manifests.yaml - Helm chart updated
  2. Core Implementation:
    - internal/external-dns/registry/group.go - NEW: GroupRegistry wrapper implementation
    - internal/controller/base_dnsrecord_reconciler.go - Registry wrapping logic
    - internal/controller/dnsrecord_accessor.go - Accessor methods for Group
    - internal/controller/dnsrecord_controller.go - Status Group setting
    - types/group.go - Label key constants
  3. Supporting Changes:
    - cmd/main.go - Group type change (pointer to value)
    - internal/controller/dnsrecord_healthchecks.go - Bug fix (moved removeUnhealthyEndpoints call)

  ---
  ✅ Requirement Coverage Analysis

  Requirement 1: Add runtime groupID to registry entries if present

  Status: ✅ Fully Addressed

  Evidence:
  - internal/external-dns/registry/group.go:29-49 - AdjustEndpoints() method adds group label when set:
  if g.Group.IsSet() {
      if ep.Labels == nil {
          ep.Labels = endpoint.NewLabels()
      }
      ep.Labels[types.GroupLabelKey] = g.Group.String()
      // ...
  }
  - types/group.go:8-10 - Constants defined for label keys (GroupLabelKey = "group")
  - internal/controller/base_dnsrecord_reconciler.go:132-135 - GroupRegistry wraps TXT registry before publish
  - internal/controller/dnsrecord_controller.go:228 - Group is set in status: dnsRecord.SetStatusGroup(r.Group)
  - api/v1alpha1/dnsrecord_types.go:180-181 - Group field added to DNSRecordStatus

  Implementation matches requirement: Labels are added to endpoints before they're converted to TXT records, which will result in format like: heritage=external-dns,external-dns/owner=ownerID,group=group1,...

  ---
  Requirement 2: Add targets to registry entries (only when groupID present)

  Status: ✅ Fully Addressed

  Evidence:
  - internal/external-dns/registry/group.go:41 - Targets added when group is set:
  ep.Labels[types.TargetsLabelKey] = ep.Targets.String()
  - types/group.go:10 - Constant defined: TargetsLabelKey = "targets"
  - Conditional logic - Both group and targets labels are only added when g.Group.IsSet() returns true
  - Cleanup logic - Lines 43-44 properly delete labels when group is not set:
  } else {
      delete(ep.Labels, types.GroupLabelKey)
      delete(ep.Labels, types.TargetsLabelKey)
  }

  Note on format: The implementation uses endpoint labels which get serialized into TXT records. The ep.Targets.String() method formats multiple targets according to external-dns conventions (comma-separated in the labels
  map). The final TXT record will be: heritage=external-dns,external-dns/owner=X,group=Y,targets=Z1,Z2,...

  This differs slightly from the issue's example format (targets=target1&&target2 with && separator), but uses the standard external-dns label serialization format which is consistent with how other metadata is stored.

  ---
  Requirement 3: Implementation before publish is called

  Status: ✅ Fully Addressed

  Evidence:
  - internal/controller/base_dnsrecord_reconciler.go:121-135 - GroupRegistry wraps the TXT registry in applyChanges() method, which is called from both:
    - internal/controller/dnsrecord_controller.go:354 (via publishRecord)
    - internal/controller/remote_dnsrecord_controller.go:202 (via publishRecord)
  - The GroupRegistry.AdjustEndpoints() method is called automatically by the registry interface before records are published to the DNS provider
  - Implementation uses a decorator pattern (wrapping the registry) rather than direct endpoint manipulation, which is cleaner and more maintainable

  Architecture decision: Instead of manipulating endpoints directly before calling publish (as suggested in the issue), the implementation wraps the registry with a GroupRegistry decorator. This is a superior design
  because:
  1. It's reusable across both dnsrecord_controller and remote_dnsrecord_controller
  2. It follows the decorator pattern consistently with how external-dns works
  3. It keeps the group logic isolated in one place

  ---
  🔍 Code Quality Observations

  ✅ Strengths:

  1. Clean Architecture: Uses decorator pattern (GroupRegistry wrapper) instead of inline endpoint manipulation - more maintainable and testable
  2. Consistent with existing patterns: Follows external-dns registry interface conventions
  3. Type-safe: Uses types.Group with validation
  4. All tests passing: 40/40 integration tests, all unit tests pass
  5. CRD properly updated: Manifests regenerated with make manifests generate
  6. Cleanup logic: Properly removes labels when group is not set
  7. Immutability preserved: GroupRegistry.AdjustEndpoints() creates new label maps instead of mutating
  8. Logging enhanced: Group added to logger context in base_dnsrecord_reconciler.go:49

  ⚠️ Areas of Note:

  1. Format difference: Uses comma-separated targets format (via Targets.String()) instead of && separator shown in issue example
    - Impact: Low - The serialized format is handled by external-dns standard serialization
    - Reason: The issue example was illustrative; actual format depends on external-dns label encoding
  2. No specific unit tests for GroupRegistry: While the TXT registry has extensive tests, there are no dedicated tests for the new GroupRegistry wrapper
    - Impact: Medium - Functionality is tested via integration tests (40 passing), but unit tests would improve coverage
    - Mitigation: Integration tests cover the full flow; existing TXT registry tests cover label handling
  3. RemoveUnhealthyEndpoints fix: Unrelated bug fix included (internal/controller/dnsrecord_healthchecks.go:223-225)
    - Impact: Positive - Fixes incorrect spec manipulation
    - Note: Should ideally be in separate commit, but fix is correct

  ---
  💡 Suggestions

  High Priority:

  1. Add unit tests for GroupRegistry (file: internal/external-dns/registry/group_test.go)

  Rationale: While integration tests pass, dedicated unit tests would:
  - Document expected behavior clearly
  - Make it easier to verify label format matches requirements
  - Test edge cases (empty group, nil labels, etc.)
  - Provide faster feedback during development

  Suggested test cases:
  // Test that group and targets labels are added when group is set
  // Test that labels are not added when group is empty
  // Test that existing labels are preserved
  // Test that labels are cleaned up when group becomes empty
  // Test targets format (verify Targets.String() output)

  File to create: internal/external-dns/registry/group_test.go

  ---
  Low Priority (Optional):

  2. Verify targets format matches expectations

  The issue shows targets=target1&&target2 but implementation uses ep.Targets.String(). Based on external-dns code, Targets.String() likely produces comma-separated values. Consider:
  - Checking if the format matches what downstream consumers expect
  - Adding a comment explaining the format if it differs from the issue example
  - If && separator is truly required, implementing custom formatting

  Where to check: Look at how consumers parse the targets label from TXT records

  ---
  🎯 Final Verdict

  ⚠️ Mostly Ready for PR

  Summary:

  The implementation fully addresses all functional requirements from issue #627:
  - ✅ Group ID is added to registry entries when present
  - ✅ Targets are added to registry entries (only when group is set)
  - ✅ Cleanup logic removes labels when group is empty
  - ✅ Implementation occurs before publish (via registry wrapper)
  - ✅ All tests pass (40/40 integration tests)
  - ✅ Clean architecture using decorator pattern

  What's ready:

  - Core functionality complete and working
  - All existing tests passing
  - CRDs properly updated
  - Implementation is cleaner than suggested approach in issue

  Recommended before PR:

  - Add unit tests for GroupRegistry - This is the main gap. While the code works (proven by passing integration tests), unit tests would provide better documentation and coverage of edge cases.

  Optional considerations:

  - Verify the targets format (Targets.String() output) matches what downstream consumers expect
  - Consider splitting the health check fix into a separate commit for cleaner history

  Confidence: High (85%) - The core implementation is solid and all tests pass. The 15% gap is mainly due to lack of dedicated unit tests for the new GroupRegistry wrapper, which is a quality/maintainability concern rather
  than a functional blocker.
