### PR TITLE
Refactor CLI logging

### DIFF
--- a/cmd/plugin/common/logging.go
+++ b/cmd/plugin/common/logging.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"os"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
+
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func NewLogger(verboseness int) logr.Logger {
+	var level zapcore.Level
+
+	switch verboseness {
+	case 1:
+		level = zapcore.InfoLevel
+	case 2:
+		level = zapcore.DebugLevel
+	default:
+		level = zapcore.ErrorLevel
+	}
+
+	return zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stderr), zap.Level(level))
+}

--- a/cmd/plugin/common/logging_test.go
+++ b/cmd/plugin/common/logging_test.go
@@ -1,0 +1,52 @@
+//go:build unit
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/kuadrant/dns-operator/cmd/plugin/common"
+)
+
+func TestNewLogger(t *testing.T) {
+	tests := []struct {
+		name            string
+		verboseness     int
+		expectV0Enabled bool
+		expectV1Enabled bool
+	}{
+		{
+			name:            "verboseness set to default (error level)",
+			verboseness:     0,
+			expectV0Enabled: false,
+			expectV1Enabled: false,
+		},
+		{
+			name:            "verboseness set to info",
+			verboseness:     1,
+			expectV0Enabled: true,
+			expectV1Enabled: false,
+		},
+		{
+			name:            "verboseness set to debug",
+			verboseness:     2,
+			expectV0Enabled: true,
+			expectV1Enabled: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := common.NewLogger(tt.verboseness)
+
+			v0Enabled := logger.V(0).Enabled()
+			if v0Enabled != tt.expectV0Enabled {
+				t.Errorf("V(0) Info level: got enabled=%v, want enabled=%v", v0Enabled, tt.expectV0Enabled)
+			}
+
+			v1Enabled := logger.V(1).Enabled()
+			if v1Enabled != tt.expectV1Enabled {
+				t.Errorf("V(1) Debug level: got enabled=%v, want enabled=%v", v1Enabled, tt.expectV1Enabled)
+			}
+		})
+	}
+}

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -8,13 +8,13 @@ import (
 	"github.com/spf13/cobra"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/kuadrant/dns-operator/cmd/plugin/common"
 	"github.com/kuadrant/dns-operator/cmd/plugin/failover"
 )
 
 var (
-	verbose bool
+	verbose int
 	gitSHA  string // value injected in compilation-time with go linker
 	version string // value injected in compilation-time with go linker
 	log     = logf.Log
@@ -25,7 +25,7 @@ var rootCMD = &cobra.Command{
 	Short: "DNS Operator command line utility",
 	Long:  "DNS Operator command line utility",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		logf.SetLogger(zap.New(zap.UseDevMode(verbose), zap.WriteTo(os.Stdout)))
+		logf.SetLogger(common.NewLogger(verbose))
 		cmd.SetContext(context.Background())
 	},
 }
@@ -42,8 +42,7 @@ var versionCMD = &cobra.Command{
 
 func init() {
 	rootCMD.SetArgs(os.Args[1:])
-	rootCMD.PersistentFlags().BoolVarP(&verbose, "verbose", "v", true, "verbose output")
-
+	rootCMD.PersistentFlags().IntVarP(&verbose, "verbose", "v", 0, "verbosity level: 0 (errors only), 1 (+ info), 2 (+ debug)")
 	rootCMD.AddCommand(versionCMD, cleanupOldTXTCMD, getZoneRecordsCMD, addClusterSecretCMD, removeOwnerCMD)
 	rootCMD.AddCommand(failover.AddActiveGroupCMD)
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,14 @@ This record is responsible for informing controllers which DNS Groups are curren
 The DNS Group commands are intended to be run with a secret that has list permissions across all zones 
 and write permissions in the relevant zones.
 
+### Global Flags
+
+--verbose / -v Set the log level for the cli. All logs are sent to standard error. 
+
+- level 0: default level, error logs will be exposed
+- level 1: error, and info logs will be exposed
+- level 2: error, info, and debug logs will be exposed
+
 ### add-active-group 
 Will fetch a list of zones that are an exact match of a domain (the `--domain` flag).
 You can specify `*.<domain>` to match all zones that end with `<domain>`.


### PR DESCRIPTION

Closes: #601

# Overview

This PR refactors the CLI logging system to provide a better default user experience with cleaner output while maintaining debugging capabilities when needed. The changes implement a verbosity-level system
that controls log output granularity and ensures logs are properly directed to stderr.

# Changes

## Core Functionality:
- Introduced new NewLogger() function in cmd/plugin/common/logging.go that creates a configured logger based on verbosity level
- Replaced boolean --verbose flag with integer-based verbosity levels (0-2), in line with the method in kubectl.
- Changed log output destination from stdout to stderr
- Enabled human-readable console format (instead of JSON) using zap's dev mode

## Verbosity Levels:
- Level 0 (default): Error logs only - minimal output for production use
- Level 1: Error + Info logs - standard operational visibility
- Level 2: Error + Info + Debug logs - full debugging output


# Breaking Changes

The --verbose / -v flag has changed from a boolean to an integer parameter.

**Before:**
```sh
kubectl-kuadrant-dns get-zone-records -v
```

**After:**
```sh
kubectl-kuadrant-dns get-zone-records -v 1
```

Users who previously used -v as a boolean flag will need to update their scripts/commands to specify a verbosity level (typically -v 1).

# Usage Examples

## Default: errors only
```sh
kubectl-kuadrant-dns get-zone-records --name myrecord --namespace default
```

## Info level: show operational messages
```sh
kubectl-kuadrant-dns get-zone-records --name myrecord --namespace default -v 1
```

## Debug level: full diagnostic output
```sh
kubectl-kuadrant-dns get-zone-records --name myrecord --namespace default -v 2
```

# Log Output Behavior

All log messages now go to stderr, leaving stdout clean for actual command output. This allows for proper output redirection:

## Redirect data to file, see logs in terminal
```sh
kubectl-kuadrant-dns get-zone-records --name myrecord > records.txt
```

## Suppress logs entirely
```sh
kubectl-kuadrant-dns get-zone-records --name myrecord 2>/dev/null > records.txt
```

# Testing

- Unit tests added in cmd/plugin/common/logging_test.go covering all verbosity levels
- Tests verify correct log level enablement for each verbosity setting
- All existing tests pass with new logging system

# Technical Details

The implementation uses the zap logger with:
- Development mode (UseDevMode(true)): Human-readable console output
- Stderr output (WriteTo(os.Stderr)): Proper separation of logs from data
- Level-based filtering: Configurable via verbosity flag
  - Level 0 → zapcore.ErrorLevel
  - Level 1 → zapcore.InfoLevel
  - Level 2 → zapcore.DebugLevel

# Documentation

Updated docs/cli.md with:
- Global flags section explaining verbosity levels
- Clear description of what each level exposes
- Note that all logs go to stderr

