### PR TITLE
use correct zone name when delegating

### DIFF
--- a/internal/provider/endpoint/authoritative_dnsrecord.go
+++ b/internal/provider/endpoint/authoritative_dnsrecord.go
@@ -62,9 +62,14 @@ func (p AuthoritativeDNSRecordProvider) DNSZoneForHost(ctx context.Context, _ st
 		return nil, err
 	}
 
+	zoneDomainName := aRecord.Status.ZoneDomainName
+	if zoneDomainName == "" {
+		return nil, fmt.Errorf("Authoritative zone does not yet have a zone domain name set")
+	}
+
 	zone := &provider.DNSZone{
 		ID:      aRecord.GetName(),
-		DNSName: aRecord.GetRootHost(),
+		DNSName: zoneDomainName,
 	}
 
 	return zone, nil


### PR DESCRIPTION
Use the zone name from the provider when delegating, rather than the zone name of the authoritative record.