### PR TITLE
Add race checker to testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 # Ginkgo options
-DEFAULT_GINKGO_FLAGS ?= -v
+DEFAULT_GINKGO_FLAGS ?= -v --race
 GINKGO_FLAGS ?= $(DEFAULT_GINKGO_FLAGS)
 
 # To enable set flag to true
@@ -162,7 +162,7 @@ test-unit: manifests generate fmt vet ## Run unit tests.
 .PHONY: test-integration
 test-integration: GINKGO_FLAGS=
 test-integration: manifests generate fmt vet envtest ginkgo ## Run integration tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) $(GINKGO_FLAGS) -tags=integration ./internal/controller -coverprofile cover-integration.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) $(GINKGO_FLAGS) -tags=integration ./internal/controller -coverprofile cover-integration.out --race
 
 .PHONY: test-e2e
 test-e2e: ginkgo


### PR DESCRIPTION
Closes https://github.com/Kuadrant/dns-operator/issues/572

I have run the `make test-unit` and `make test-integration` and all test cases passed with the new flag.
I did not run e2e tests locally but github pipeline passed so I consider them working too.

So in the end no data races were found, nice!