### PR TITLE
add in pprof option for the controller

### DIFF
--- a/bundle/manifests/dns-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/dns-operator-controller-manager-metrics-service_v1_service.yaml
@@ -10,6 +10,9 @@ spec:
   - name: metrics
     port: 8080
     targetPort: metrics
+  - name: pprof
+    port: 8082
+    targetPort: pprof
   selector:
     control-plane: dns-operator-controller-manager
 status:

--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -59,7 +59,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/dns-operator:latest
-    createdAt: "2025-12-09T19:04:52Z"
+    createdAt: "2026-01-12T12:15:54Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -179,6 +179,8 @@ spec:
                 ports:
                 - containerPort: 8080
                   name: metrics
+                - containerPort: 8082
+                  name: pprof
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -887,6 +887,9 @@ spec:
   - name: metrics
     port: 8080
     targetPort: metrics
+  - name: pprof
+    port: 8082
+    targetPort: pprof
   selector:
     control-plane: dns-operator-controller-manager
 ---
@@ -943,6 +946,8 @@ spec:
         ports:
         - containerPort: 8080
           name: metrics
+        - containerPort: 8082
+          name: pprof
         readinessProbe:
           httpGet:
             path: /readyz

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,7 @@ var (
 	metricsAddr            string
 	enableLeaderElection   bool
 	probeAddr              string
+	pprofAddr              string
 	minRequeueTime         time.Duration
 	validFor               time.Duration
 	maxRequeueTime         time.Duration
@@ -83,10 +84,11 @@ var (
 	logMode                string
 	logLevel               string
 
-	// represents booth flag and envar key
+	// represents both flag and envar key
 	metricsAddrKey            = variableKey("metrics-bind-address")
 	enableLeaderElectionKey   = variableKey("leader-elect")
 	probeAddrKey              = variableKey("health-probe-bind-address")
+	pprofAddressKey           = variableKey("pprof-bind-address")
 	minRequeueTimeKey         = variableKey("min-requeue-time")
 	validForKey               = variableKey("valid-for")
 	maxRequeueTimeKey         = variableKey("max-requeue-time")
@@ -129,6 +131,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, metricsAddrKey.Flag(), ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, probeAddrKey.Flag(), ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, pprofAddressKey.Flag(), ":8082", "The address the pprof endpoints can be reached at.")
 	flag.BoolVar(&enableLeaderElection, enableLeaderElectionKey.Flag(), false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -169,6 +172,13 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "a3f98d6c.kuadrant.io",
+		// make pprof info available at /debug/pprof/${type} where type is one of (goroutine, heap, threadcreate block mutex, profile, trace)
+		// https://pkg.go.dev/runtime/pprof
+		PprofBindAddress: pprofAddr,
+	}
+
+	if pprofAddr != "" {
+		setupLog.Info("Pprof configured", "listening", pprofAddr)
 	}
 
 	if watchNamespaces != "" {

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -7,10 +7,12 @@ spec:
   template:
     spec:
       containers:
-      - name: manager
-        args:
-          - "--metrics-bind-address=:8080"
-          - "--leader-elect"
-        ports:
-          - containerPort: 8080
-            name: metrics
+        - name: manager
+          args:
+            - '--metrics-bind-address=:8080'
+            - '--leader-elect'
+          ports:
+            - containerPort: 8080
+              name: metrics
+            - containerPort: 8082
+              name: pprof

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -8,8 +8,11 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: metrics
-    port: 8080
-    targetPort: metrics
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+    - name: pprof
+      port: 8082
+      targetPort: pprof
   selector:
     control-plane: dns-operator-controller-manager

--- a/test/scale/kubeburner-object-templates/dns-operator/dns-operator-deployment.yaml
+++ b/test/scale/kubeburner-object-templates/dns-operator/dns-operator-deployment.yaml
@@ -17,45 +17,47 @@ spec:
         control-plane: dns-operator-controller-manager
     spec:
       containers:
-      - args:
-        - --leader-elect
-        - --metrics-bind-address=:8080
-        - --provider=aws,google,inmemory,azure
-        - --log-level=debug
-        command:
-        - /manager
-        env:
-        - name: WATCH_NAMESPACES
-          value: scale-test-{{.Iteration}},kuadrant-dns-operator-{{.Iteration}}
-        image: quay.io/kuadrant/dns-operator:latest
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: manager
-        ports:
-          - containerPort: 8080
-            name: metrics
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 200m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
+        - args:
+            - --leader-elect
+            - --metrics-bind-address=:8080
+            - --provider=aws,google,inmemory,azure
+            - --log-level=debug
+          command:
+            - /manager
+          env:
+            - name: WATCH_NAMESPACES
+              value: scale-test-{{.Iteration}},kuadrant-dns-operator-{{.Iteration}}
+          image: quay.io/kuadrant/dns-operator:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: metrics
+            - containerPort: 8082
+              name: pprof
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager


### PR DESCRIPTION
will expose the pprof http server endpoints at :8082 by default.

Signed-off-by: craig <cbrookes@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: DISABLED