### PR TITLE
add yaml output for cli

### DIFF
--- a/cmd/plugin/output/formatter_test.go
+++ b/cmd/plugin/output/formatter_test.go
@@ -1,0 +1,108 @@
+//go:build unit
+
+package output
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type trait struct {
+	Name          string
+	WhenDisplayed []string
+}
+
+type cat struct {
+	Name      string
+	Cuteness  int
+	Traits    []trait
+	Relatives map[string]string
+}
+
+var testSuzanne = cat{
+	Name:     "Suzanne",
+	Cuteness: 10,
+	Traits: []trait{
+		{
+			Name:          "cuddly",
+			WhenDisplayed: []string{"morning", "afternoon: 13:05 exactly"},
+		},
+		{
+			Name:          "sleepy",
+			WhenDisplayed: []string{"every, single, time"},
+		},
+	},
+	Relatives: map[string]string{
+		"mother":  "Joane",
+		"father":  "Sam",
+		"Brother": "Dingus",
+	},
+}
+
+var testJoane = cat{
+	Name:     "Joane",
+	Cuteness: 8,
+	Traits: []trait{
+		{
+			Name:          "cuddly",
+			WhenDisplayed: []string{"morning", "afternoon"},
+		},
+	},
+	Relatives: map[string]string{
+		"daughter": "Suzanne",
+		"son":      "Dingus",
+		"husband":  "Sam",
+	},
+}
+
+var testSam = cat{
+	Name:     "Sam",
+	Cuteness: 9,
+	Traits: []trait{
+		{
+			Name:          "cuddly",
+			WhenDisplayed: []string{"morning", "afternoon"},
+		},
+	},
+	Relatives: map[string]string{
+		"daughter": "Suzanne",
+		"son":      "Dingus",
+		"wife":     "Joane",
+	},
+}
+
+// testCats is all three cats for use in tests that need the full set
+var testCats = []cat{testSuzanne, testJoane, testSam}
+
+func buildTestTable(cats []cat) PrintableTable {
+	table := PrintableTable{
+		Headers: []string{"name", "cuteness", "traits", "relatives"},
+	}
+	for _, c := range cats {
+		var traitNames []string
+		for _, t := range c.Traits {
+			traitNames = append(traitNames, t.Name)
+		}
+
+		keys := make([]string, 0, len(c.Relatives))
+		for k := range c.Relatives {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var relativeParts []string
+		for _, k := range keys {
+			relativeParts = append(relativeParts, k+": "+c.Relatives[k])
+		}
+
+		table.Data = append(table.Data, []string{
+			c.Name,
+			strconv.Itoa(c.Cuteness),
+			strings.Join(traitNames, ", "),
+			strings.Join(relativeParts, "; "),
+		})
+	}
+	return table
+}
+
+var testTable = buildTestTable(testCats)

--- a/cmd/plugin/output/json.go
+++ b/cmd/plugin/output/json.go
@@ -1,6 +1,9 @@
 package output
 
+import "io"
+
 type JSONOutputFormatter struct {
+	_ io.Writer
 }
 
 var _ OutputFormatter = &JSONOutputFormatter{}

--- a/cmd/plugin/output/text_test.go
+++ b/cmd/plugin/output/text_test.go
@@ -1,0 +1,147 @@
+//go:build unit
+
+package output
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func newTextFormatter() (*TextOutputFormatter, *bytes.Buffer) {
+	var buf bytes.Buffer
+	f := &TextOutputFormatter{w: &buf}
+	return f, &buf
+}
+
+func TestTextPrint(t *testing.T) {
+	f, buf := newTextFormatter()
+	f.Print("cat")
+
+	got := buf.String()
+	if got != "cat\n" {
+		t.Errorf("expected %q, got %q", "cat\n", got)
+	}
+}
+
+func TestTextPrintMultiple(t *testing.T) {
+	f, buf := newTextFormatter()
+	f.Print("cat")
+	f.Print("another cat")
+	f.Print("more cats")
+
+	got := buf.String()
+	expected := "cat\nanother cat\nmore cats\n"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestTextError(t *testing.T) {
+	f, buf := newTextFormatter()
+	f.Error(errors.New("oops"), "cat error")
+
+	got := buf.String()
+	expected := "cat error: oops\n"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestTextPrintObject(t *testing.T) {
+	for _, tc := range testCats {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, buf := newTextFormatter()
+			f.PrintObject(tc)
+
+			got := buf.String()
+
+			// Text formatter marshals structs as YAML
+			if !strings.Contains(got, "name: "+tc.Name) {
+				t.Errorf("expected output to contain 'name: %s', got: %q", tc.Name, got)
+			}
+		})
+	}
+}
+
+func TestTextPrintTable(t *testing.T) {
+	f, buf := newTextFormatter()
+	f.PrintTable(testTable)
+
+	got := buf.String()
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+
+	// First line should be headers
+	if len(lines) < 1 {
+		t.Fatal("expected at least a header line")
+	}
+	if !strings.Contains(lines[0], "name") || !strings.Contains(lines[0], "cuteness") {
+		t.Errorf("expected header line to contain column names, got: %q", lines[0])
+	}
+
+	// Should have header + one row per cat
+	expectedLines := len(testCats) + 1
+	if len(lines) != expectedLines {
+		t.Fatalf("expected %d lines (1 header + %d rows), got %d", expectedLines, len(testCats), len(lines))
+	}
+
+	// Each data row should contain the corresponding cat's name
+	for i, tc := range testCats {
+		if !strings.Contains(lines[i+1], tc.Name) {
+			t.Errorf("expected row %d to contain %q, got: %q", i, tc.Name, lines[i+1])
+		}
+	}
+}
+
+func TestTextPrintTableMismatchedColumns(t *testing.T) {
+	f, buf := newTextFormatter()
+	table := PrintableTable{
+		Headers: []string{"name", "cuteness"},
+		Data: [][]string{
+			{"Suzanne", "10", "extra"},
+		},
+	}
+	f.PrintTable(table)
+
+	got := buf.String()
+	if !strings.Contains(got, "Can't print table") {
+		t.Errorf("expected error message about mismatched columns, got: %q", got)
+	}
+}
+
+func TestTextFullSequence(t *testing.T) {
+	f, buf := newTextFormatter()
+
+	f.Print("cat")
+	f.Print("another cat")
+	f.Print("more cats")
+	f.Error(errors.New("oops"), "cat error")
+	f.PrintObject(testSuzanne)
+	f.Print("another cat")
+	f.Print("more cats")
+	f.PrintTable(testTable)
+
+	got := buf.String()
+
+	// Verify key elements are present in order
+	elements := []string{
+		"cat\n",
+		"another cat\n",
+		"more cats\n",
+		"cat error: oops\n",
+		"name: Suzanne",
+		"another cat\n",
+		"more cats\n",
+		"Suzanne",
+	}
+
+	lastIdx := 0
+	for _, elem := range elements {
+		idx := strings.Index(got[lastIdx:], elem)
+		if idx == -1 {
+			t.Errorf("expected output to contain %q after position %d\nfull output:\n%s", elem, lastIdx, got)
+		}
+		lastIdx += idx + len(elem)
+	}
+}

--- a/cmd/plugin/output/yaml_test.go
+++ b/cmd/plugin/output/yaml_test.go
@@ -1,0 +1,233 @@
+//go:build unit
+
+package output
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func newYAMLFormatter() (*YAMLOutputFormatter, *bytes.Buffer) {
+	var buf bytes.Buffer
+	f := &YAMLOutputFormatter{w: &buf}
+	return f, &buf
+}
+
+func TestYAMLPrint(t *testing.T) {
+	f, buf := newYAMLFormatter()
+	f.Print("cat")
+
+	got := buf.String()
+	if !strings.HasPrefix(got, "---\n") {
+		t.Errorf("expected output to start with file separator, got: %q", got)
+	}
+
+	// Verify the message is properly marshalled YAML
+	content := strings.TrimPrefix(got, "---\n")
+	var parsed map[string]string
+	if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("output after separator is not valid YAML: %v\ncontent: %q", err, content)
+	}
+	if parsed["message"] != "cat" {
+		t.Errorf("expected message 'cat', got %q", parsed["message"])
+	}
+}
+
+func TestYAMLPrintMultiple(t *testing.T) {
+	f, buf := newYAMLFormatter()
+	f.Print("cat")
+	f.Print("another cat")
+	f.Print("more cats")
+
+	got := buf.String()
+	documents := strings.Split(got, "---\n")
+
+	// First element is empty (before first ---)
+	if documents[0] != "" {
+		t.Errorf("expected empty string before first separator, got %q", documents[0])
+	}
+
+	expectedMessages := []string{"cat", "another cat", "more cats"}
+	for i, expected := range expectedMessages {
+		var parsed map[string]string
+		if err := yaml.Unmarshal([]byte(documents[i+1]), &parsed); err != nil {
+			t.Fatalf("document %d is not valid YAML: %v", i, err)
+		}
+		if parsed["message"] != expected {
+			t.Errorf("document %d: expected message %q, got %q", i, expected, parsed["message"])
+		}
+	}
+}
+
+func TestYAMLError(t *testing.T) {
+	f, buf := newYAMLFormatter()
+	f.Error(errors.New("oops"), "cat error")
+
+	got := buf.String()
+	if !strings.HasPrefix(got, "---\n") {
+		t.Errorf("expected output to start with file separator, got: %q", got)
+	}
+
+	content := strings.TrimPrefix(got, "---\n")
+	var parsed map[string]string
+	if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("output after separator is not valid YAML: %v\ncontent: %q", err, content)
+	}
+	if parsed["error"] != "oops" {
+		t.Errorf("expected error 'oops', got %q", parsed["error"])
+	}
+	if parsed["message"] != "cat error" {
+		t.Errorf("expected message 'cat error', got %q", parsed["message"])
+	}
+}
+
+func TestYAMLPrintObject(t *testing.T) {
+	for _, tc := range testCats {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, buf := newYAMLFormatter()
+			f.PrintObject(tc)
+
+			got := buf.String()
+			if !strings.HasPrefix(got, "---\n") {
+				t.Errorf("expected output to start with file separator, got: %q", got)
+			}
+
+			content := strings.TrimPrefix(got, "---\n")
+			var parsed cat
+			if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+				t.Fatalf("output after separator is not valid YAML: %v\ncontent: %q", err, content)
+			}
+			if parsed.Name != tc.Name {
+				t.Errorf("expected Name %q, got %q", tc.Name, parsed.Name)
+			}
+			if parsed.Cuteness != tc.Cuteness {
+				t.Errorf("expected Cuteness %d, got %d", tc.Cuteness, parsed.Cuteness)
+			}
+			if len(parsed.Traits) != len(tc.Traits) {
+				t.Errorf("expected %d traits, got %d", len(tc.Traits), len(parsed.Traits))
+			}
+			if len(parsed.Relatives) != len(tc.Relatives) {
+				t.Errorf("expected %d relatives, got %d", len(tc.Relatives), len(parsed.Relatives))
+			}
+		})
+	}
+}
+
+func TestYAMLPrintTable(t *testing.T) {
+	f, buf := newYAMLFormatter()
+	f.PrintTable(testTable)
+
+	got := buf.String()
+	if !strings.HasPrefix(got, "---\n") {
+		t.Errorf("expected output to start with file separator, got: %q", got)
+	}
+
+	content := strings.TrimPrefix(got, "---\n")
+	var parsed []map[string]string
+	if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("output after separator is not valid YAML: %v\ncontent: %q", err, content)
+	}
+	if len(parsed) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(parsed))
+	}
+	if parsed[0]["name"] != "Suzanne" {
+		t.Errorf("expected first row name 'Suzanne', got %q", parsed[0]["name"])
+	}
+	if parsed[0]["cuteness"] != "10" {
+		t.Errorf("expected first row cuteness '10', got %q", parsed[0]["cuteness"])
+	}
+	if parsed[1]["name"] != "Joane" {
+		t.Errorf("expected second row name 'Joane', got %q", parsed[1]["name"])
+	}
+	if parsed[2]["name"] != "Sam" {
+		t.Errorf("expected third row name 'Sam', got %q", parsed[2]["name"])
+	}
+}
+
+func TestYAMLPrintTableMismatchedColumns(t *testing.T) {
+	f, buf := newYAMLFormatter()
+	table := PrintableTable{
+		Headers: []string{"name", "cuteness"},
+		Data: [][]string{
+			{"Suzanne", "10", "extra"},
+		},
+	}
+	f.PrintTable(table)
+
+	got := buf.String()
+	if !strings.HasPrefix(got, "---\n") {
+		t.Errorf("expected output to start with file separator, got: %q", got)
+	}
+	if !strings.Contains(got, "error printing table") {
+		t.Errorf("expected error message about mismatched columns, got: %q", got)
+	}
+}
+
+func TestYAMLPrintSpecialCharacters(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{name: "colon in message", message: "value: with colon"},
+		{name: "quotes in message", message: `contains "quotes"`},
+		{name: "comma in message", message: "one, two, three"},
+		{name: "hash in message", message: "# not a comment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, buf := newYAMLFormatter()
+			f.Print(tt.message)
+
+			got := buf.String()
+			content := strings.TrimPrefix(got, "---\n")
+			var parsed map[string]string
+			if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+				t.Fatalf("output is not valid YAML: %v\ncontent: %q", err, content)
+			}
+			if parsed["message"] != tt.message {
+				t.Errorf("expected message %q, got %q", tt.message, parsed["message"])
+			}
+		})
+	}
+}
+
+func TestYAMLFullSequence(t *testing.T) {
+	f, buf := newYAMLFormatter()
+
+	f.Print("cat")
+	f.Print("another cat")
+	f.Print("more cats")
+	f.Error(errors.New("oops"), "cat error")
+	f.PrintObject(testSuzanne)
+	f.Print("another cat")
+	f.Print("more cats")
+	f.PrintTable(testTable)
+
+	got := buf.String()
+
+	// Every section must start with ---
+	documents := strings.Split(got, "---\n")
+
+	// First element is empty (before first ---)
+	if documents[0] != "" {
+		t.Errorf("expected empty string before first separator, got %q", documents[0])
+	}
+
+	// Should have 8 documents (3 prints + 1 error + 1 object + 2 prints + 1 table)
+	if len(documents)-1 != 8 {
+		t.Fatalf("expected 8 YAML documents, got %d", len(documents)-1)
+	}
+
+	// Verify each document is valid YAML
+	for i := 1; i < len(documents); i++ {
+		var parsed interface{}
+		if err := yaml.Unmarshal([]byte(documents[i]), &parsed); err != nil {
+			t.Errorf("document %d is not valid YAML: %v\ncontent: %q", i-1, err, documents[i])
+		}
+	}
+}

--- a/cmd/plugin/plugin.go
+++ b/cmd/plugin/plugin.go
@@ -26,7 +26,7 @@ var rootCMD = &cobra.Command{
 	Long:  "DNS Operator command line utility",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logf.SetLogger(output.NewLogger(verbose))
-		output.SetOutputFormatter(outputFormat)
+		output.SetOutputFormatter(outputFormat, os.Stdout)
 	},
 }
 


### PR DESCRIPTION
Adding the `yaml` to the active output options of the CLI. 
Noteworthy - the `text` output uses YAML to print a struct, but I chose not to reuse that code in the `yaml` formatter, as it should function a bit differently. 

The following is an example of the output generated by [this](https://gist.github.com/maksymvavilov/afe9a94ede279936474e3e9aab3407d0) test command (not included in the PR)

<details>

<summary> k kuadrant-dns test -o yaml | yq </summary>

Outputs are split into files: 
1. Three messages followed by an error 
2. Object 
3. Table 

```yaml
- message: cat
- message: another cat
- message: more cats
- error: oops
  message: cat error
---
name: Suzanne
cuteness: 10
traits:
  - name: cuddly
    whendisplayed:
      - morning
      - 'afternoon: 13:05 exactly'
  - name: sleepy
    whendisplayed:
      - every, single, time
relatives:
  Brother: Dingus
  father: Sam
  mother: Joane
---
table:
  - name: Suzanne
    cuteness: 10
    traits: cuddly, sleepy,
    relatives: 'mother: Joane; father: Sam; Brother: Dingus; '
  - name: Joane
    cuteness: 8
    traits: cuddly,
    relatives: 'daughter: Suzanne; son: Dingus; husband: Sam; '
  - name: Sam
    cuteness: 9
    traits: cuddly,
    relatives: 'daughter: Suzanne; son: Dingus; wife: Joane; '
```

</details>

The formatter categorises data into object and text categories. 
The object category (includes object and table) will always be separated with a file separator (the `---`). 
The text category will have a separator only if preceded by an object category. 

The formatter does not change the logs - they stay in the `json` format. For the commands that would display logs, one would need to separate `stdout` from `stderr` to be able to parse output into the YAML format. 

If the command had an error during the execution, the output will not be parsable. 
Example: 
<details>

<summary> k kuadrant-dns get-active-groups --providerRef dnstest-dns-provider-credentials-aws --domain mv-custom.hcpapps.net -o yaml  </summary>

The error message is formatted (not all are), and then the error is returned 

```yaml
- error: providerRef most be in the format of '<namespace>/<name>'
  message: failed to parse provider ref
Error: providerRef most be in the format of '<namespace>/<name>'
Usage:
  kuadrant-dns get-active-groups --providerRef <namespace>/<name> --domain <domain> [flags]

Flags:
  -d, --domain string        domain to which the group will belong
  -h, --help                 help for get-active-groups
      --providerRef string   A provider reference to the secret with provider credentials. Format = '<namespace>/<name>'

Global Flags:
  -o, --output string   output format text|json|yaml
  -v, --verbose int     the higher verbosity level the more restrictive output; range from -1 (debug, includes everything) to 4 (panic, most restrictive) (default 3)
```
</details>

We do not have strict guidelines on how to use the formatter, and this may lead to an output of multiple "objects" (currently, only the `prune-legacy-txt-records` will do it, and you are not supposed to run it with `-o yaml` anyway). 
or the command not outputting anything.  

<details>
<summary> Example </summary>

```bash
➜  dns-operator (gh-658) k kuadrant-dns remove-active-group us-east --providerRef dnstest/dns-provider-credentials-aws --domain mv-custom.hcpapps.net -y -o yaml                                                                                                                                                  ✭
➜  dns-operator (gh-658) k kuadrant-dns remove-active-group us-east --providerRef dnstest/dns-provider-credentials-aws --domain mv-custom.hcpapps.net -y -o yaml -v=-1                                                                                                                                            ✭
{"level":"debug","ts":"2026-01-14T14:35:37Z","msg":"initializing aws provider with config","config":{"HostDomainFilter":{},"DomainFilter":{"regexInclude":"^mv-custom.hcpapps.net$"},"ZoneTypeFilter":{},"ZoneIDFilter":{"ZoneIDs":null}}}
{"level":"debug","ts":"2026-01-14T14:35:37Z","logger":"aws-dns","msg":"Refreshing zones list cache","region":null}
{"level":"debug","ts":"2026-01-14T14:35:38Z","logger":"aws-dns","msg":"Considering zone: /hostedzone/Z034453138A8O6XLYDN07 (domain: mv-custom.hcpapps.net.)","region":null}
{"level":"debug","ts":"2026-01-14T14:35:38Z","msg":"initializing aws provider with config","config":{"HostDomainFilter":{},"DomainFilter":{"regexInclude":"^mv-custom.hcpapps.net$"},"ZoneTypeFilter":{},"ZoneIDFilter":{"ZoneIDs":["/hostedzone/Z034453138A8O6XLYDN07"]}}}
{"level":"debug","ts":"2026-01-14T14:35:38Z","logger":"aws-dns","msg":"Refreshing zones list cache","region":null}
{"level":"debug","ts":"2026-01-14T14:35:38Z","logger":"aws-dns","msg":"Considering zone: /hostedzone/Z034453138A8O6XLYDN07 (domain: mv-custom.hcpapps.net.)","region":null}
{"level":"debug","ts":"2026-01-14T14:35:38Z","logger":"remove-active-group","msg":"Found no TXT record for domain in zone mv-custom.hcpapps.net (ID /hostedzone/Z034453138A8O6XLYDN07)","domain":"mv-custom.hcpapps.net","record":"kuadrant-active-groups.mv-custom.hcpapps.net"}
```
</details>

We do not output any objects at the moment (the major use case of `-o yaml` I'd imagine). 
Apart from "parsable" one-to two-line messages:

<details>

<summary>Example</summary>

``` bash
➜  dns-operator (gh-658) k kuadrant-dns add-active-group us-east --providerRef dnstest/dns-provider-credentials-aws --domain mv-custom.hcpapps.net -y -o yaml                                                                                                                                                     ✭
- message: added group "us-east" to active groups of "mv-custom.hcpapps.net" zone
➜  dns-operator (gh-658) k kuadrant-dns add-active-group us-east --providerRef dnstest/dns-provider-credentials-aws --domain mv-custom.hcpapps.net -y -o yaml                                                                                                                                                     ✭
- message: Nothing to do
➜  dns-operator (gh-658) k kuadrant-dns add-active-group us-west --providerRef dnstest/dns-provider-credentials-aws --domain mv-custom.hcpapps.net -y -o yaml                                                                                                                                                     ✭
- message: added group "us-west" to active groups of "mv-custom.hcpapps.net" zone

```
</details>


We will have an option to be able to parse a table: 

<details>

<summary>k kuadrant-dns get-active-groups --providerRef dnstest/dns-provider-credentials-aws --domain mv-custom.hcpapps.net -o yaml | yq '.table[0]' </summary>

``` yaml
---
Zone Name: mv-custom.hcpapps.net
Zone ID: /hostedzone/Z034453138A8O6XLYDN07
Active Groups: us-east,us-west

```
</details>
