### PR TITLE
fix(coredns): add warnings when CRD missing

### DIFF
--- a/coredns/plugin/k8s.go
+++ b/coredns/plugin/k8s.go
@@ -61,63 +61,82 @@ type KubeController struct {
 	labelFilter string
 }
 
-func newKubeController(ctx context.Context, c *dnsop.DNSRecordClient, zones map[string]*Zone) *KubeController {
+func newKubeController(ctx context.Context, c dnsop.Interface, zones map[string]*Zone) *KubeController {
 	ctrl := &KubeController{
 		client: c,
 	}
 
-	if existDNSRecordCRDs(ctx, c) {
-		for origin, zone := range zones {
-			labelSelector := labels.SelectorFromSet(map[string]string{
-				zoneNameLabel: stripClosingDot(origin),
-			})
-
-			var namespaces []string
-			if w := os.Getenv(watchNamespacesEnvVar); w != "" {
-				namespaces = strings.Split(w, ",")
-			} else {
-				namespaces = []string{core.NamespaceAll}
-			}
-
-			log.Infof("creating zone informer for %s with label selector %s and namespaces %s", origin, labelSelector.String(), namespaces)
-
-			zi := zoneInformers{
-				informers:  make([]cache.SharedInformer, 0, len(namespaces)),
-				zone:       zone,
-				zoneOrigin: origin,
-			}
-
-			for _, ns := range namespaces {
-				informer := cache.NewSharedInformer(
-					&cache.ListWatch{
-						ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-							opts.LabelSelector = labelSelector.String()
-							return c.DNSRecords(ns).List(ctx, opts)
-						},
-						WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-							opts.LabelSelector = labelSelector.String()
-							return c.DNSRecords(ns).Watch(ctx, opts)
-						},
-					},
-					&v1alpha1.DNSRecord{},
-					defaultResyncPeriod,
-				)
-				_, _ = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}) {
-						zi.refreshZone()
-					},
-					UpdateFunc: func(old, new interface{}) {
-						zi.refreshZone()
-					},
-					DeleteFunc: func(obj interface{}) {
-						zi.refreshZone()
-					},
-				})
-				zi.informers = append(zi.informers, informer)
-			}
-
-			ctrl.controllers = append(ctrl.controllers, zi)
+	if !existDNSRecordCRDs(ctx, c) {
+		if len(zones) > 0 {
+			log.Warningf("Zones are configured but DNSRecord CRDs are not available. Zones will be empty and serve only default SOA/NS records.")
 		}
+		return ctrl
+	}
+
+	if len(zones) == 0 {
+		log.Warningf("No zones configured for the kuadrant plugin. No DNS records will be served.")
+		return ctrl
+	}
+
+	for origin, zone := range zones {
+		if zone == nil {
+			log.Errorf("Zone %s has nil value, skipping zone informer creation", origin)
+			continue
+		}
+
+		labelSelector := labels.SelectorFromSet(map[string]string{
+			zoneNameLabel: stripClosingDot(origin),
+		})
+
+		var namespaces []string
+		if w := os.Getenv(watchNamespacesEnvVar); w != "" {
+			namespaces = strings.Split(w, ",")
+		} else {
+			namespaces = []string{core.NamespaceAll}
+		}
+
+		log.Infof("creating zone informer for %s with label selector %s and namespaces %s", origin, labelSelector.String(), namespaces)
+
+		zi := zoneInformers{
+			informers:  make([]cache.SharedInformer, 0, len(namespaces)),
+			zone:       zone,
+			zoneOrigin: origin,
+		}
+
+		for _, ns := range namespaces {
+			informer := cache.NewSharedInformer(
+				&cache.ListWatch{
+					ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+						opts.LabelSelector = labelSelector.String()
+						return c.DNSRecords(ns).List(ctx, opts)
+					},
+					WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+						opts.LabelSelector = labelSelector.String()
+						return c.DNSRecords(ns).Watch(ctx, opts)
+					},
+				},
+				&v1alpha1.DNSRecord{},
+				defaultResyncPeriod,
+			)
+			_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					zi.refreshZone()
+				},
+				UpdateFunc: func(old, new interface{}) {
+					zi.refreshZone()
+				},
+				DeleteFunc: func(obj interface{}) {
+					zi.refreshZone()
+				},
+			})
+			if err != nil {
+				log.Errorf("Failed to add event handler for zone %s in namespace %s: %v. This zone will not be updated when DNSRecords change.", origin, ns, err)
+				continue
+			}
+			zi.informers = append(zi.informers, informer)
+		}
+
+		ctrl.controllers = append(ctrl.controllers, zi)
 	}
 	return ctrl
 }
@@ -129,6 +148,14 @@ func (ctrl *KubeController) run() {
 	var synced []cache.InformerSynced
 
 	log.Infof("Starting kube controllers")
+
+	if len(ctrl.controllers) == 0 {
+		log.Warningf("No zone controllers started. DNSRecord CRDs may not be installed or no zones are configured. The plugin will serve empty zones.")
+		ctrl.hasSynced = true
+		<-stopCh
+		return
+	}
+
 	for _, ctrlZone := range ctrl.controllers {
 		for i, informer := range ctrlZone.informers {
 			log.Infof("Starting informer %v for zone %s", i, ctrlZone.zoneOrigin)
@@ -137,11 +164,13 @@ func (ctrl *KubeController) run() {
 		}
 	}
 	log.Infof("Waiting for controllers to sync")
-	if !cache.WaitForCacheSync(stopCh, synced...) {
+	if cache.WaitForCacheSync(stopCh, synced...) {
+		log.Infof("Successfully synced all required resources")
+		ctrl.hasSynced = true
+	} else {
+		log.Warningf("Failed to sync controllers")
 		ctrl.hasSynced = false
 	}
-	log.Infof("Synced all required resources")
-	ctrl.hasSynced = true
 
 	<-stopCh
 }
@@ -191,18 +220,18 @@ func (k *Kuadrant) getClientConfig() (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func existDNSRecordCRDs(ctx context.Context, c *dnsop.DNSRecordClient) bool {
+func existDNSRecordCRDs(ctx context.Context, c dnsop.Interface) bool {
 	_, err := c.DNSRecords("").List(ctx, metav1.ListOptions{})
 	return handleCRDCheckError(err, "DNSRecord", "kuadrant.io")
 }
 
 func handleCRDCheckError(err error, resourceName string, apiGroup string) bool {
 	if meta.IsNoMatchError(err) || runtime.IsNotRegisteredError(err) || apierrors.IsNotFound(err) {
-		log.Infof("%s CRDs are not found. Not syncing %s resources.", resourceName, resourceName)
+		log.Warningf("%s CRDs not found. Plugin will not serve DNS records.", resourceName)
 		return false
 	}
 	if apierrors.IsForbidden(err) {
-		log.Infof("access to `%s` is forbidden, please check RBAC. Not syncing %s resources.", apiGroup, resourceName)
+		log.Warningf("Forbidden access to %s API. Check ServiceAccount RBAC permissions.", apiGroup)
 		return false
 	}
 	if err != nil {

--- a/coredns/plugin/k8s_test.go
+++ b/coredns/plugin/k8s_test.go
@@ -1,0 +1,328 @@
+package kuadrant
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/coredns/plugin/dnsop"
+)
+
+// mockDNSRecordClient implements dnsop.Interface for testing
+type mockDNSRecordClient struct {
+	listError error
+	listFunc  func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.DNSRecordList, error)
+}
+
+func (m *mockDNSRecordClient) DNSRecords(namespace string) dnsop.DNSRecord {
+	return &mockDNSRecord{
+		listError: m.listError,
+		listFunc:  m.listFunc,
+	}
+}
+
+// mockDNSRecord implements dnsop.DNSRecord for testing
+type mockDNSRecord struct {
+	listError error
+	listFunc  func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.DNSRecordList, error)
+}
+
+func (m *mockDNSRecord) List(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.DNSRecordList, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, opts)
+	}
+	if m.listError != nil {
+		return nil, m.listError
+	}
+	return &v1alpha1.DNSRecordList{}, nil
+}
+
+func (m *mockDNSRecord) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestNewKubeController_GracefulDegradation(t *testing.T) {
+	tests := []struct {
+		name        string
+		clientError error
+		zones       map[string]*Zone
+	}{
+		{
+			name:        "NoMatchError - CRDs not registered",
+			clientError: &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{Group: "kuadrant.io", Resource: "dnsrecords"}},
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+			},
+		},
+		{
+			name:        "NotRegisteredError - CRDs not in scheme",
+			clientError: runtime.NewNotRegisteredErrForKind("test", schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "DNSRecord"}),
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+			},
+		},
+		{
+			name:        "NotFound - CRDs not found",
+			clientError: apierrors.NewNotFound(schema.GroupResource{Group: "kuadrant.io", Resource: "dnsrecords"}, ""),
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+			},
+		},
+		{
+			name:        "Forbidden - RBAC issue with zones",
+			clientError: apierrors.NewForbidden(schema.GroupResource{Group: "kuadrant.io", Resource: "dnsrecords"}, "", errors.New("forbidden")),
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+			},
+		},
+		{
+			name:        "CRDs not found - no zones configured",
+			clientError: apierrors.NewNotFound(schema.GroupResource{Group: "kuadrant.io", Resource: "dnsrecords"}, ""),
+			zones:       map[string]*Zone{},
+		},
+		{
+			name:        "CRDs exist - no zones (empty map)",
+			clientError: nil,
+			zones:       map[string]*Zone{},
+		},
+		{
+			name:        "CRDs exist - no zones (nil map)",
+			clientError: nil,
+			zones:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockDNSRecordClient{
+				listError: tt.clientError,
+			}
+
+			ctx := t.Context()
+			ctrl := newKubeController(ctx, mockClient, tt.zones)
+
+			assert.NotNil(t, ctrl, "Controller should never be nil")
+			assert.Empty(t, ctrl.controllers, "Controllers should be empty - gracefully degraded")
+			assert.Equal(t, mockClient, ctrl.client)
+		})
+	}
+}
+
+func TestNewKubeController_WithZonesAndCRDs(t *testing.T) {
+	tests := []struct {
+		name              string
+		zones             map[string]*Zone
+		expectedZoneCount int
+	}{
+		{
+			name: "single zone configured",
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+			},
+			expectedZoneCount: 1,
+		},
+		{
+			name: "multiple zones configured",
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+				"test.org.":    NewZone("test.org.", ""),
+			},
+			expectedZoneCount: 2,
+		},
+		{
+			name: "zone with custom rname",
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", "admin@example.com"),
+			},
+			expectedZoneCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockDNSRecordClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.DNSRecordList, error) {
+					return &v1alpha1.DNSRecordList{}, nil
+				},
+			}
+
+			ctx := t.Context()
+			ctrl := newKubeController(ctx, mockClient, tt.zones)
+
+			assert.NotNil(t, ctrl)
+			assert.Equal(t, mockClient, ctrl.client)
+			assert.Len(t, ctrl.controllers, tt.expectedZoneCount, "Should create one controller per zone")
+
+			// Verify each zone controller is properly set up
+			for _, zi := range ctrl.controllers {
+				assert.NotNil(t, zi.zone)
+				assert.NotEmpty(t, zi.zoneOrigin)
+				// Each zone should have at least one informer (for NamespaceAll by default)
+				assert.NotEmpty(t, zi.informers, "Each zone should have at least one informer")
+			}
+		})
+	}
+}
+
+func TestNewKubeController_MultipleNamespaces(t *testing.T) {
+	// Note: t.Setenv automatically restores the environment variable after each subtest completes.
+	// No manual t.Cleanup() is needed - it's handled internally by t.Setenv.
+	// Cannot use t.Parallel() with t.Setenv as env vars affect the whole process.
+	tests := []struct {
+		name                  string
+		namespaceEnvValue     string
+		expectedInformerCount int
+	}{
+		{
+			name:                  "single namespace",
+			namespaceEnvValue:     "default",
+			expectedInformerCount: 1,
+		},
+		{
+			name:                  "multiple namespaces",
+			namespaceEnvValue:     "default,kube-system,test",
+			expectedInformerCount: 3,
+		},
+		{
+			name:                  "no namespace env - defaults to all",
+			namespaceEnvValue:     "",
+			expectedInformerCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(watchNamespacesEnvVar, tt.namespaceEnvValue)
+
+			mockClient := &mockDNSRecordClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.DNSRecordList, error) {
+					return &v1alpha1.DNSRecordList{}, nil
+				},
+			}
+
+			zones := map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+			}
+
+			ctx := t.Context()
+			ctrl := newKubeController(ctx, mockClient, zones)
+
+			require.Len(t, ctrl.controllers, 1)
+			assert.Len(t, ctrl.controllers[0].informers, tt.expectedInformerCount)
+		})
+	}
+}
+
+func TestHandleCRDCheckError_Panic(t *testing.T) {
+	// Test that unexpected errors cause a panic
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("handleCRDCheckError should panic on unexpected errors")
+		}
+	}()
+
+	unexpectedErr := errors.New("unexpected error")
+	handleCRDCheckError(unexpectedErr, "DNSRecord", "kuadrant.io")
+}
+
+func TestNewKubeController_NilZoneValues(t *testing.T) {
+	tests := []struct {
+		name              string
+		zones             map[string]*Zone
+		expectedCtrlCount int
+	}{
+		{
+			name: "single nil zone - skipped",
+			zones: map[string]*Zone{
+				"example.com.": nil,
+			},
+			expectedCtrlCount: 0,
+		},
+		{
+			name: "mixed valid and nil zones",
+			zones: map[string]*Zone{
+				"example.com.": NewZone("example.com.", ""),
+				"bad.com.":     nil,
+				"good.org.":    NewZone("good.org.", ""),
+			},
+			expectedCtrlCount: 2,
+		},
+		{
+			name: "all nil zones",
+			zones: map[string]*Zone{
+				"bad1.com.": nil,
+				"bad2.com.": nil,
+			},
+			expectedCtrlCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockDNSRecordClient{
+				listFunc: func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.DNSRecordList, error) {
+					return &v1alpha1.DNSRecordList{}, nil
+				},
+			}
+
+			ctx := t.Context()
+			ctrl := newKubeController(ctx, mockClient, tt.zones)
+
+			assert.NotNil(t, ctrl)
+			assert.Len(t, ctrl.controllers, tt.expectedCtrlCount,
+				"Should skip nil zones and only create controllers for valid zones")
+		})
+	}
+}
+
+func TestStripClosingDot(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "domain with closing dot",
+			input:    "example.com.",
+			expected: "example.com",
+		},
+		{
+			name:     "domain without closing dot",
+			input:    "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "root domain",
+			input:    ".",
+			expected: ".",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "subdomain with closing dot",
+			input:    "api.example.com.",
+			expected: "api.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripClosingDot(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Users were not adequately warned when DNSRecord CRDs were missing, leading to silent failures where DNS queries would return NXDOMAIN without clear explanation.

- Change CRD error messages from INFO to WARNING level
- Warn when controllers start without CRDs installed
- Fix misleading "synced successfully" messages

This ensures operators receive clear, actionable feedback when the plugin cannot function due to missing CRDs or RBAC issues.

Additionally addresses:

- Unhandled error from AddEventHandler
- Use positive condition, following Go best practices.
- Improve test quality via dependency injection and remove tests that
  were providing no value.
- handle nil zone values in newKubeController

Claude was used to generate the tests.