### PR TITLE
chore(coredns): Update toolchain to go1.24.12

### DIFF
--- a/coredns/plugin/go.mod
+++ b/coredns/plugin/go.mod
@@ -2,6 +2,8 @@ module github.com/kuadrant/dns-operator/coredns/plugin
 
 go 1.24.0
 
+toolchain go1.24.12
+
 require (
 	github.com/coredns/caddy v1.1.4-0.20250930002214-15135a999495
 	github.com/coredns/coredns v1.13.1


### PR DESCRIPTION
Fixes various CVEs including GO-2025-4155 (crypto/x509 DoS)