### PR TITLE
fix(release): add set-image-refs target for consistent image management

### DIFF
--- a/config/coredns/kustomization.yaml
+++ b/config/coredns/kustomization.yaml
@@ -5,32 +5,29 @@ resources:
   - namespace.yaml
 helmCharts:
   - name: coredns
-    repo: https://coredns.github.io/helm
     releaseName: kuadrant
+    repo: https://coredns.github.io/helm
     valuesInline:
+      deployment:
+        skipConfig: true
       env:
         - name: WATCH_NAMESPACES
           value: kuadrant-coredns
+      image:
+        pullPolicy: Always
+        repository: quay.io/kuadrant/coredns-kuadrant
+        tag: latest
       isClusterService: false
-      serviceType: LoadBalancer
-      deployment:
-        skipConfig: true
       prometheus:
-        service:
-          enabled: true
         monitor:
           enabled: true
           namespace: kuadrant-coredns
-      image:
-        repository: quay.io/kuadrant/coredns-kuadrant
-        tag: latest
-        pullPolicy: Always
+        service:
+          enabled: true
+      serviceType: LoadBalancer
 patches:
   - path: k8s_prometheus_patch.yaml
-  - target:
-      kind: ClusterRole
-      name: kuadrant-coredns
-    patch: |
+  - patch: |
       - op: add
         path: /rules/-
         value:
@@ -42,6 +39,9 @@ patches:
             - get
             - list
             - watch
+    target:
+      kind: ClusterRole
+      name: kuadrant-coredns
   - patch: |
       - op: add
         path: /spec/template/spec/containers/0/env
@@ -50,22 +50,25 @@ patches:
             value: ""
     target:
       kind: Deployment
-  - target:
-      kind: Service
-      name: kuadrant-coredns
-    patch: |
+  - patch: |
       - op: add
         path: /spec/externalTrafficPolicy
         value: Local
-
+    target:
+      kind: Service
+      name: kuadrant-coredns
 configMapGenerator:
-  - name: kuadrant-coredns
-    behavior: create
+  - behavior: create
     files:
       - Corefile
+    name: kuadrant-coredns
     options:
       disableNameSuffixHash: true
       labels:
-        app.kubernetes.io/name: coredns
         app.kubernetes.io/instance: kuadrant
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: coredns
+images:
+  - name: quay.io/kuadrant/coredns-kuadrant
+    newName: quay.io/kuadrant/coredns-kuadrant
+    newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,10 +1,9 @@
 resources:
-- manager.yaml
-- metrics_service.yaml
-
+  - manager.yaml
+  - metrics_service.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: quay.io/kuadrant/dns-operator
-  newTag: latest
+  - name: controller
+    newName: quay.io/kuadrant/dns-operator
+    newTag: latest

--- a/make/coredns.mk
+++ b/make/coredns.mk
@@ -23,16 +23,16 @@ coredns-run: ## Run coredns from your host.
 
 .PHONY: coredns-docker-build
 coredns-docker-build: ## Build docker image.
-	cd ${COREDNS_PLUGIN_DIR} && $(MAKE) docker-build
+	cd ${COREDNS_PLUGIN_DIR} && $(MAKE) docker-build COREDNS_IMG=$(COREDNS_IMG)
 
 .PHONY: coredns-docker-push
 coredns-docker-push: ## Push docker image.
-	cd ${COREDNS_PLUGIN_DIR} && $(MAKE) docker-push
+	cd ${COREDNS_PLUGIN_DIR} && $(MAKE) docker-push COREDNS_IMG=$(COREDNS_IMG)
 
 .PHONY: coredns-docker-run
 coredns-docker-run: DNS_PORT=1053
 coredns-docker-run: ## Build docker image and run coredns in a container.
-	cd ${COREDNS_PLUGIN_DIR} && $(MAKE) docker-run
+	cd ${COREDNS_PLUGIN_DIR} && $(MAKE) docker-run COREDNS_IMG=$(COREDNS_IMG)
 
 .PHONY: coredns-generate-demo-geo-db
 coredns-generate-demo-geo-db: ## Generate demo geo db embedded in coredns image.
@@ -40,4 +40,4 @@ coredns-generate-demo-geo-db: ## Generate demo geo db embedded in coredns image.
 
 .PHONY: coredns-kind-load-image
 coredns-kind-load-image: ## Load image to kind cluster.
-	$(MAKE) kind-load-image IMG=quay.io/kuadrant/coredns-kuadrant:latest
+	$(MAKE) kind-load-image IMG=$(COREDNS_IMG)

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -6,9 +6,7 @@ CHART_NAME ?= dns-operator
 CHART_DIRECTORY ?= charts/$(CHART_NAME)
 
 .PHONY: helm-build
-helm-build: yq manifests kustomize operator-sdk ## Build the helm chart from kustomize manifests
-	# Replace the controller image (Should remain consistent with what `make bundle` does)
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+helm-build: manifests set-image-refs operator-sdk ## Build the helm chart from kustomize manifests
 	# Build the helm chart templates from kustomize manifests
 	$(KUSTOMIZE) build config/helm > $(CHART_DIRECTORY)/templates/manifests.yaml
 	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i $(CHART_DIRECTORY)/Chart.yaml


### PR DESCRIPTION
Add set-image-refs target for consistent image management across deploy, bundle, and helm-build. Fix CoreDNS targets to use COREDNS_IMG variable and ensure local-setup uses the locally built image.

Fixes an issue where the coredns image ref in the coredns kustomization was not updated correctly when following the release process. The `make prepare-release` command now overrides the `COREDNS_IMG` variable ensuring the coredns kustomizations on release branches/tags reference the desired image. Running the following command should now install the correct version(after this is merged):
```
./bin/kustomize build --enable-helm github.com/kuadrant/dns-operator/config/coredns?ref=v0.16.0
```