### PR TITLE
fix: maintain group labels in TXT registry for inactive records

### DIFF
--- a/internal/controller/dnsrecord_accessor.go
+++ b/internal/controller/dnsrecord_accessor.go
@@ -17,11 +17,14 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/provider"
 	"github.com/kuadrant/dns-operator/types"
 )
 
@@ -56,6 +59,7 @@ type DNSRecordAccessor interface {
 	HasProviderSecretAssigned() bool
 	IsDeleting() bool
 	IsActive() bool
+	FinalizeReconciliation(ctx context.Context, dnsProvider provider.Provider) error
 }
 
 type DNSRecord struct {
@@ -151,6 +155,11 @@ func (s *DNSRecord) SetStatusGroup(group types.Group) {
 
 func (s *DNSRecord) SetStatusActiveGroups(groups types.Groups) {
 	s.GetStatus().ActiveGroups = groups.String()
+}
+
+func (s *DNSRecord) FinalizeReconciliation(_ context.Context, _ provider.Provider) error {
+	// Base implementation does nothing
+	return nil
 }
 
 type RemoteDNSRecord struct {
@@ -269,4 +278,9 @@ func (s *RemoteDNSRecord) setStatus() {
 
 func (s *RemoteDNSRecord) HasDNSZoneAssigned() bool {
 	return s.GetStatus().ZoneID != "" && s.GetStatus().ZoneDomainName != ""
+}
+
+func (s *RemoteDNSRecord) FinalizeReconciliation(_ context.Context, _ provider.Provider) error {
+	// Base implementation does nothing
+	return nil
 }

--- a/internal/controller/remote_dnsrecord_controller.go
+++ b/internal/controller/remote_dnsrecord_controller.go
@@ -241,10 +241,12 @@ func (r *RemoteDNSRecordReconciler) Reconcile(ctx context.Context, req mcreconci
 	// process unpublish of inactive groups once active cluster has no changes to publish
 	// not to be processed by ungrouped clusters.
 	if !hadChanges && dnsRecord.GetGroup() != "" {
-		err = r.unpublishInactiveGroups(ctx, r.mgr.GetLocalManager().GetClient(), dnsRecord, dnsProvider)
-		if err != nil {
-			dnsRecord.SetStatusCondition(string(v1alpha1.ConditionTypeReady), metav1.ConditionFalse,
-				"ProviderError", fmt.Sprintf("The DNS provider failed to unpublish inactive groups: %v", provider.SanitizeError(err)))
+		if groupAdapter, ok := dnsRecord.(*GroupAdapter); ok {
+			err = groupAdapter.UnpublishInactiveGroups(ctx, dnsProvider)
+			if err != nil {
+				dnsRecord.SetStatusCondition(string(v1alpha1.ConditionTypeReady), metav1.ConditionFalse,
+					"ProviderError", fmt.Sprintf("The DNS provider failed to unpublish inactive groups: %v", provider.SanitizeError(err)))
+			}
 		}
 	}
 

--- a/internal/external-dns/registry/txt.go
+++ b/internal/external-dns/registry/txt.go
@@ -139,7 +139,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	// If we have the zones cached AND we have refreshed the cache since the
 	// last given interval, then just use the cached results.
 	if im.recordsCache != nil && time.Since(im.recordsCacheRefreshTime) < im.cacheInterval {
-		im.logger.V(1).Info("Using cached records")
+		im.logger.Info("Using cached records")
 		return im.recordsCache, nil
 	}
 
@@ -487,7 +487,7 @@ func NewLabelsFromString(labelText string, aesKey []byte) (owner, version string
 
 	// extract owner and version
 	for key, value := range labels {
-		if key == endpoint.OwnerLabelKey && strings.Contains(value, kuadrantPlan.LabelDelimiter) {
+		if key == endpoint.OwnerLabelKey {
 			// if that's an old format we will have multiple owners here - we will deal with that later
 			// we aren't sure who owns all the labels
 			owner = value


### PR DESCRIPTION
Inactive grouped records now update their TXT registry entries with accurate group values, enabling active groups to properly identify and clean up their DNS records (gh-637).

Refactors group-specific logic into GroupAdapter.PostApplyChanges for better encapsulation.

Signed-off-by: Phil Brookes <pbrookes@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED