### PR TITLE
Enable s390x support

### DIFF
--- a/.github/workflows/build-coredns-images.yaml
+++ b/.github/workflows/build-coredns-images.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           image: ${{ env.COREDNS_PLUGIN_NAME }}
           tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           context: ./coredns/plugin
           dockerfiles: |
             ./coredns/plugin/Dockerfile

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ github.ref_name }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           build-args: |
             GIT_SHA=${{ github.sha }}
             DIRTY=false
@@ -106,7 +106,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           dockerfiles: |
             ./bundle.Dockerfile
 
@@ -164,7 +164,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           context: ./tmp/catalog
           dockerfiles: |
             ./tmp/catalog/index.Dockerfile

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           build-args: |
             GIT_SHA=${{ github.sha }}
             DIRTY=false
@@ -99,7 +99,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           dockerfiles: |
             ./bundle.Dockerfile
 
@@ -142,7 +142,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           context: ./tmp/catalog
           dockerfiles: |
             ./tmp/catalog/index.Dockerfile

--- a/.github/workflows/upload-cli.yml
+++ b/.github/workflows/upload-cli.yml
@@ -20,9 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64
+        # build and publish in parallel: linux/amd64, linux/arm64, linux/s390x, darwin/amd64, darwin/arm64
         goos: [linux, darwin]
-        goarch: [amd64, arm64]
+        goarch: [amd64, arm64, s390x]
+        exclude:
+          - goos: darwin
+            goarch: s390x
     steps:
       - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1


### PR DESCRIPTION
## Add s390x architecture support

### Summary

Enables building and publishing container images and CLI binaries for **linux/s390x** (IBM Z / LinuxONE) in addition to existing amd64 and arm64.

### Changes

- **`.github/workflows/build-images.yaml`** — Added `linux/s390x` to `platforms` for operator, bundle, and catalog image builds.
- **`.github/workflows/build-images-for-tag-release.yaml`** — Added `linux/s390x` to `platforms` for operator, bundle, and catalog builds on tag release.
- **`.github/workflows/build-coredns-images.yaml`** — Added `linux/s390x` to `platforms` for the CoreDNS plugin image.
- **`.github/workflows/upload-cli.yml`** — Added `s390x` to the CLI build matrix for Linux and excluded the invalid `darwin/s390x` combination.

### Why no code or Dockerfile changes

- Dockerfiles already use `TARGETOS` / `TARGETARCH` and `CGO_ENABLED=0`, so they are multi-arch ready.
- Base images (golang, distroless/static, debian) and Go support s390x.
- Makefile `PLATFORMS` already included s390x for `make docker-buildx`.
- CI already installs `qemu-user-static` for cross-builds.