### PR TITLE
fix: derive setup-envtest version from controller-runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,6 +426,7 @@ KUBECTL_DNS ?= $(LOCALBIN)/kubectl-kuadrant_dns
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
+ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime 2>/dev/null | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 OPENSHIFT_GOIMPORTS_VERSION ?= c70783e636f2213cac683f6865d88c5edace3157
 KIND_VERSION = v0.30.0
 ACT_VERSION = latest
@@ -453,7 +454,7 @@ $(CONTROLLER_GEN): | $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): | $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK) ## Download govulncheck locally if necessary.


### PR DESCRIPTION
## Summary
Dynamically derives `ENVTEST_VERSION` from the controller-runtime module version to maintain compatibility with Go 1.25.8 and automatically stay in sync with controller-runtime updates.

## Problem
As of 2026-03-31, `setup-envtest@latest` requires Go >= 1.26.0, causing installation failures in environments with Go 1.25.8 and `GOTOOLCHAIN=local`:

```
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: 
  sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260331165415-bce0ec74ad73 
  requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=local)
```

## Solution
- Dynamically derive `ENVTEST_VERSION` from controller-runtime module version using shell command
- Follows the same pattern as [authorino-operator](https://github.com/Kuadrant/authorino-operator/blob/main/Makefile#L145-L146)
- Currently resolves to `release-0.21` (matching controller-runtime `v0.21.0`)
- Automatically stays in sync when controller-runtime is bumped

```makefile
ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime 2>/dev/null | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
```

## Benefits
- No manual maintenance when controller-runtime is updated
- Prevents version mismatches between controller-runtime and setup-envtest
- Maintains compatibility with current Go version

## Test plan
- [x] `make envtest` succeeds with Go 1.25.8
- [x] `make test-integration` passes (verified ENVTEST_VERSION resolves to `release-0.21`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pin the environment test tool to a derived stable release (based on the controller-runtime module) instead of installing the latest, ensuring consistent, reproducible envtest artifacts and more reliable development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->