### PR TITLE
internal/provider: gate the TLD early-exit on the ICANN flag

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -146,14 +146,8 @@ func findDNSZoneForHost(originalHost, host string, zones []DNSZone, denyApex boo
 		return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, host)
 	}
 	host = strings.ToLower(host)
-	// Bail out only if the host equals an ICANN TLD (e.g. `com`, `org`). The
-	// Go public suffix list also contains privately-managed domains such as
-	// `httpbin.org`, `github.io`, `amazonaws.com`, `azurewebsites.net` - for
-	// those, PublicSuffix returns the host itself but the second return
-	// value (`icann`) is false. Ignoring that flag rejected any DNSRecord
-	// whose rootHost happened to appear in the private suffix list, even
-	// when a matching zone was explicitly provisioned in the provider
-	// secret.
+	// Only reject if the host is an ICANN TLD. Private suffixes (e.g.
+	// `s3.amazonaws.com`, `github.io`) should proceed to zone matching.
 	tld, icann := publicsuffix.PublicSuffix(host)
 	if icann && host == tld {
 		return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, originalHost)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -146,11 +146,16 @@ func findDNSZoneForHost(originalHost, host string, zones []DNSZone, denyApex boo
 		return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, host)
 	}
 	host = strings.ToLower(host)
-	//get the TLD from this host
-	tld, _ := publicsuffix.PublicSuffix(host)
-
-	//The host is a TLD, so we now know `originalHost` can't possibly have a valid `DNSZone` available.
-	if host == tld {
+	// Bail out only if the host equals an ICANN TLD (e.g. `com`, `org`). The
+	// Go public suffix list also contains privately-managed domains such as
+	// `httpbin.org`, `github.io`, `amazonaws.com`, `azurewebsites.net` - for
+	// those, PublicSuffix returns the host itself but the second return
+	// value (`icann`) is false. Ignoring that flag rejected any DNSRecord
+	// whose rootHost happened to appear in the private suffix list, even
+	// when a matching zone was explicitly provisioned in the provider
+	// secret.
+	tld, icann := publicsuffix.PublicSuffix(host)
+	if icann && host == tld {
 		return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, originalHost)
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -210,6 +210,74 @@ func Test_findDNSZoneForHost(t *testing.T) {
 			wantErr:       true,
 			expectedErrIs: ErrMultipleZonesFound,
 		},
+
+		// Private suffix coverage (per #762 review). The Go public suffix list
+		// also contains privately-managed suffixes such as `httpbin.org`,
+		// `github.io`, and `s3.amazonaws.com`. These should NOT be rejected as
+		// TLDs — only ICANN suffixes (e.g. `com`, `co.uk`) are rejected.
+		{
+			name: "private suffix as host with matching zone (httpbin.org)",
+			host: "httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "httpbin.org", ID: "zone-1"},
+			},
+			denyApex:      false,
+			wantZone:      "httpbin.org",
+			wantSubdomain: "",
+			wantErr:       false,
+		},
+		{
+			name: "subdomain of a private suffix matches its parent zone",
+			host: "sub.httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "httpbin.org", ID: "zone-1"},
+			},
+			denyApex:      false,
+			wantZone:      "httpbin.org",
+			wantSubdomain: "sub",
+			wantErr:       false,
+		},
+		{
+			name: "multi-label private suffix as host with matching zone (s3.amazonaws.com)",
+			host: "s3.amazonaws.com",
+			zones: []DNSZone{
+				{DNSName: "s3.amazonaws.com", ID: "zone-1"},
+			},
+			denyApex:      false,
+			wantZone:      "s3.amazonaws.com",
+			wantSubdomain: "",
+			wantErr:       false,
+		},
+		{
+			name: "private suffix host with no matching zone returns ErrNoZoneForHost",
+			host: "httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "example.com"},
+			},
+			denyApex:      false,
+			wantErr:       true,
+			expectedErrIs: ErrNoZoneForHost,
+		},
+		{
+			name: "private suffix as host with denyApex=true returns ErrApexDomainNotAllowed",
+			host: "httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "httpbin.org", ID: "zone-1"},
+			},
+			denyApex:      true,
+			wantErr:       true,
+			expectedErrIs: ErrApexDomainNotAllowed,
+		},
+		{
+			name: "ICANN TLD `co.uk` still rejected as host (no regression)",
+			host: "co.uk",
+			zones: []DNSZone{
+				{DNSName: "example.co.uk"},
+			},
+			denyApex:      false,
+			wantErr:       true,
+			expectedErrIs: ErrNoZoneForHost,
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
## What

`findDNSZoneForHost` in `internal/provider/provider.go` asks `publicsuffix.PublicSuffix(host)` for the "TLD" and then bails out of zone matching when the host equals that value:

```go
tld, _ := publicsuffix.PublicSuffix(host)

// The host is a TLD, so we now know `originalHost` can't possibly have a valid `DNSZone` available.
if host == tld {
    return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, originalHost)
}
```

The Go public suffix list is not just the ICANN TLD set — it also contains privately-managed domains like `httpbin.org`, `github.io`, `amazonaws.com`, `azurewebsites.net`. For those, `PublicSuffix` returns the host itself and the *second* return value (`icann`) is `false`, so the early-exit fires before zone matching is attempted.

Concretely, with

```yaml
ZONES=httpbin.org

# DNSRecord
rootHost: httpbin.org
```

the CoreDNS provider path rejects the authoritative record with `no zone for host: httpbin.org`, the `kuadrant.io/coredns-zone-name` label is never added, and the CoreDNS plugin never discovers the record. Subdomains like `simple.k.example.com` are unaffected because `PublicSuffix("simple.k.example.com")` returns `com`, which doesn't equal the host, so zone matching proceeds.

Per #761.

## Fix

Read the `icann` return value the check actually meant to rely on, and only bail out when the host is an ICANN-managed TLD:

```go
tld, icann := publicsuffix.PublicSuffix(host)
if icann && host == tld {
    return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, originalHost)
}
```

- `example.com` → `tld="com"`, `icann=true`, `host != tld` → zone matching proceeds (unchanged).
- `com` → `tld="com"`, `icann=true`, `host == tld` → reject with `ErrNoZoneForHost` (unchanged).
- `httpbin.org` → `tld="httpbin.org"`, `icann=false`, check skipped → zone matching proceeds, the CoreDNS zone in the provider secret matches, authoritative record succeeds (previously rejected).

## Scope

One-line logic change; no new imports (`icann` is already returned by `publicsuffix.PublicSuffix`, we were just throwing it away). No DNSRecord that currently resolves stops resolving.

Fixes #761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS zone resolution now recognises privately managed public suffixes (e.g. subdomains under private suffixes), avoiding unnecessary "no zone" failures while still rejecting disallowed ICANN apex hosts.
* **Tests**
  * Expanded tests to cover private-suffix resolution, apex-deny behaviour, and a regression case ensuring ICANN suffix rejection remains enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->