### PR TITLE
chore(deps): Upgrade Go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/dns-operator
 
-go 1.25.8
+go 1.25.9
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
## Summary
- Bump Go version from 1.25.8 to 1.25.9

### CVEs resolved

| CVE | Package | CVSS | Fixed in |
|-----|---------|------|----------|
| CVE-2026-32280 | `crypto/x509` | 7.5 (High) | 1.25.9 |
| CVE-2026-33810 | `crypto/x509` | Not scored | 1.25.9 |
| CVE-2026-32282 | `internal/syscall/unix` | 7.8 (High) | 1.25.9 |