### PR TITLE
fix: gate TLD early-exit on ICANN flag in findDNSZoneForHost

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -146,11 +146,10 @@ func findDNSZoneForHost(originalHost, host string, zones []DNSZone, denyApex boo
 		return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, host)
 	}
 	host = strings.ToLower(host)
-	//get the TLD from this host
-	tld, _ := publicsuffix.PublicSuffix(host)
-
-	//The host is a TLD, so we now know `originalHost` can't possibly have a valid `DNSZone` available.
-	if host == tld {
+	// Only reject if the host is an ICANN TLD. Private suffixes (e.g.
+	// `s3.amazonaws.com`, `github.io`) should proceed to zone matching.
+	tld, icann := publicsuffix.PublicSuffix(host)
+	if icann && host == tld {
 		return nil, "", fmt.Errorf("%w: %s", ErrNoZoneForHost, originalHost)
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -210,6 +210,74 @@ func Test_findDNSZoneForHost(t *testing.T) {
 			wantErr:       true,
 			expectedErrIs: ErrMultipleZonesFound,
 		},
+
+		// Private suffix coverage. The Go public suffix list also contains
+		// privately-managed suffixes such as `httpbin.org`, `github.io`, and
+		// `s3.amazonaws.com`. These should NOT be rejected as TLDs — only
+		// ICANN suffixes (e.g. `com`, `co.uk`) are rejected.
+		{
+			name: "private suffix as host with matching zone (httpbin.org)",
+			host: "httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "httpbin.org", ID: "zone-1"},
+			},
+			denyApex:      false,
+			wantZone:      "httpbin.org",
+			wantSubdomain: "",
+			wantErr:       false,
+		},
+		{
+			name: "subdomain of a private suffix matches its parent zone",
+			host: "sub.httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "httpbin.org", ID: "zone-1"},
+			},
+			denyApex:      false,
+			wantZone:      "httpbin.org",
+			wantSubdomain: "sub",
+			wantErr:       false,
+		},
+		{
+			name: "multi-label private suffix as host with matching zone (s3.amazonaws.com)",
+			host: "s3.amazonaws.com",
+			zones: []DNSZone{
+				{DNSName: "s3.amazonaws.com", ID: "zone-1"},
+			},
+			denyApex:      false,
+			wantZone:      "s3.amazonaws.com",
+			wantSubdomain: "",
+			wantErr:       false,
+		},
+		{
+			name: "private suffix host with no matching zone returns ErrNoZoneForHost",
+			host: "httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "example.com"},
+			},
+			denyApex:      false,
+			wantErr:       true,
+			expectedErrIs: ErrNoZoneForHost,
+		},
+		{
+			name: "private suffix as host with denyApex=true returns ErrApexDomainNotAllowed",
+			host: "httpbin.org",
+			zones: []DNSZone{
+				{DNSName: "httpbin.org", ID: "zone-1"},
+			},
+			denyApex:      true,
+			wantErr:       true,
+			expectedErrIs: ErrApexDomainNotAllowed,
+		},
+		{
+			name: "ICANN TLD `co.uk` still rejected as host (no regression)",
+			host: "co.uk",
+			zones: []DNSZone{
+				{DNSName: "example.co.uk"},
+			},
+			denyApex:      false,
+			wantErr:       true,
+			expectedErrIs: ErrNoZoneForHost,
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
## Summary

`findDNSZoneForHost` in `internal/provider/provider.go` uses `publicsuffix.PublicSuffix(host)` to detect TLDs and bail out early. However, the Go public suffix list includes privately-managed domains (`httpbin.org`, `github.io`, `s3.amazonaws.com`), causing valid hosts to be rejected before zone matching.

The fix reads the `icann` return value and only rejects when the suffix is ICANN-managed:

```go
tld, icann := publicsuffix.PublicSuffix(host)
if icann && host == tld {
```

- ICANN TLDs (`com`, `co.uk`) are still rejected (unchanged)
- Private suffixes (`httpbin.org`, `s3.amazonaws.com`) now proceed to zone matching

## How to Review

- `internal/provider/provider.go` — one-line logic change at the `PublicSuffix` call site
- `internal/provider/provider_test.go` — six new test cases covering private suffix scenarios and ICANN regression

## Test Plan

- [x] All 19 `Test_findDNSZoneForHost` cases pass (`go test -tags unit ./internal/provider/`)
- [x] Verify CoreDNS provider path with `ZONES=httpbin.org` and `rootHost: httpbin.org`

## Credit

Based on the work by @SAY-5 in #762, which was blocked on commit signing.

Fixes #761
Supersedes #762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS zone matching for private suffixes (e.g., s3.amazonaws.com, github.io). These domains now correctly match configured zones instead of being rejected, whilst ICANN top-level domains remain properly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->