### PR TITLE
chore(deps): Upgrade Go to 1.25.9 in CoreDNS plugin

### DIFF
--- a/coredns/plugin/go.mod
+++ b/coredns/plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/dns-operator/coredns/plugin
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/coredns/caddy v1.1.4-0.20250930002214-15135a999495


### PR DESCRIPTION
## Summary

- Upgrades Go version in CoreDNS plugin from 1.25.0 to 1.25.9
- Addresses CVE-2026-33810: crypto/x509 certificate validation bypass

## Details

CVE-2026-33810 affects Go's `crypto/x509` package where excluded DNS constraints are not correctly applied to wildcard DNS SANs that use different case than the constraint. This only affects validation of otherwise trusted certificate chains.

The fix is included in Go 1.25.9 (released April 2026).

## Changes

- Updated `coredns/plugin/go.mod` to use Go 1.25.9
- The existing Dockerfile already pulls `golang:1.25` which will automatically use the latest patch version (1.25.9)

## Test Plan

- [ ] Build CoreDNS plugin binary: `cd coredns/plugin && make build`
- [ ] Build CoreDNS plugin container: `cd coredns/plugin && make docker-build`
- [ ] Verify Go version in built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version for the plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->