### PR TITLE
feat: update pprof port to 8084 and add profiling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The controller can be started with any of the following flags or environmental v
 |---------------------------|---------------|---------------------------|-----------------------------------------------------------------------------------------------------------------------|---------------------------------------|
 | metrics-bind-address      | string        | METRICS_BIND_ADDRESS      | The address the metric endpoint binds to.                                                                             | ":8080"                               |
 | health-probe-bind-address | string        | HEALTH_PROBE_BIND_ADDRESS | The address the probe endpoint binds to.                                                                              | ":8081"                               |
-| pprof-bind-address        | string        | PPROF_BIND_ADDRESS        | The address the pprof endpoint binds to.                                                                              | ":8082"                               |
+| pprof-bind-address        | string        | PPROF_BIND_ADDRESS        | The address the pprof endpoint binds to.                                                                              | ":8084"                               |
 | leader-elect              | bool          | LEADER_ELECT              | Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager. | "false"                               |
 | min-requeue-time          | time.Duration | MIN_REQUEUE_TIME          | The minimal timeout between calls to the DNS Provider. Controls if we commit to the full reconcile loop               | "5s"                                  |
 | max-requeue-time          | time.Duration | MAX_REQUEUE_TIME          | The maximum times it takes between reconciliations of DNS Record. Controls how ofter record is reconciled.            | "15m"                                 |
@@ -253,6 +253,18 @@ kubectl logs -l control-plane=dns-operator-controller-manager -n dns-operator-sy
 ```
 You could use selector in the `jq` with `and`/`not`/`or` to restrict.
 
+
+## Profiling
+
+The operator supports runtime profiling via Go's built-in [pprof](https://pkg.go.dev/net/http/pprof) tooling. Enabled by default on `:8084`.
+
+Connect to a running instance:
+
+```bash
+kubectl port-forward -n dns-operator-system deploy/dns-operator-controller-manager 8084:8084
+go tool pprof -http=:8080 http://localhost:8084/debug/pprof/profile?seconds=30
+go tool pprof -http=:8080 http://localhost:8084/debug/pprof/heap
+```
 
 ## License
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -134,7 +134,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, metricsAddrKey.Flag(), ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, probeAddrKey.Flag(), ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&pprofAddr, pprofAddressKey.Flag(), ":8082", "The address the pprof endpoints can be reached at.")
+	flag.StringVar(&pprofAddr, pprofAddressKey.Flag(), ":8084", "The address the pprof endpoints can be reached at.")
 	flag.BoolVar(&enableLeaderElection, enableLeaderElectionKey.Flag(), false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")


### PR DESCRIPTION
## Summary

Updates the pprof bind address from `:8082` to `:8084` for consistency across all Kuadrant Go components, and adds a Profiling section to the README.

## Motivation

pprof is the standard mechanism for diagnosing performance issues in Go applications. The Kubernetes [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) enables profiling via `--profiling` (default: `true`), exposing the same `/debug/pprof/` endpoints. OpenShift provides [built-in tooling](https://docs.openshift.com/container-platform/4.11/scalability_and_performance/node-observability-operator.html) for collecting pprof data from cluster components.

Port 8082 conflicts with the WASM server in kuadrant-operator. Port 8084 is free across all components and is being adopted as the standard pprof port for consistency.

## Changes

- Updated `--pprof-bind-address` default from `:8082` to `:8084` in `cmd/main.go`
- Updated pprof port reference in README.md flags table
- Added `## Profiling` section to README.md with `kubectl port-forward` and `go tool pprof` usage examples