### PR TITLE
MULTIARCH-5995: add ppc64le support to the build

### DIFF
--- a/.github/workflows/build-coredns-images.yaml
+++ b/.github/workflows/build-coredns-images.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           image: ${{ env.COREDNS_PLUGIN_NAME }}
           tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           context: ./coredns/plugin
           dockerfiles: |
             ./coredns/plugin/Dockerfile

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ github.ref_name }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           build-args: |
             GIT_SHA=${{ github.sha }}
             DIRTY=false
@@ -106,7 +106,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           build-args: QUAY_IMAGE_EXPIRY=never
           dockerfiles: |
             ./bundle.Dockerfile
@@ -165,7 +165,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           context: ./tmp/catalog
           dockerfiles: |
             ./tmp/catalog/index.Dockerfile

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           build-args: |
             GIT_SHA=${{ github.sha }}
             DIRTY=false
@@ -99,7 +99,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           dockerfiles: |
             ./bundle.Dockerfile
 
@@ -142,7 +142,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           context: ./tmp/catalog
           dockerfiles: |
             ./tmp/catalog/index.Dockerfile

--- a/.github/workflows/upload-cli.yml
+++ b/.github/workflows/upload-cli.yml
@@ -20,12 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/amd64, linux/arm64, linux/s390x, darwin/amd64, darwin/arm64
+        # build and publish in parallel: linux/amd64, linux/arm64, linux/s390x, linux/ppc64le, darwin/amd64, darwin/arm64
         goos: [linux, darwin]
-        goarch: [amd64, arm64, s390x]
+        goarch: [amd64, arm64, s390x, ppc64le]
         exclude:
           - goos: darwin
             goarch: s390x
+          - goos: darwin
+            goarch: ppc64le
     steps:
       - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1


### PR DESCRIPTION
MULTIARCH-5995: add ppc64le support to the build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IBM POWER9 (linux/ppc64le) to container image build targets and the CLI binary build matrix.
  * Release workflows now produce builds for x86-64, ARM64, IBM System z and IBM POWER9; macOS exclusion rules adjusted so darwin builds omit incompatible architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->