### PR TITLE
fix: suppress yq install stdout in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ $(ACT): $(LOCALBIN)
 .PHONY: yq
 yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
+	@GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
 
 .PHONY: helm
 helm: $(HELM) ## Download helm locally if necessary.


### PR DESCRIPTION
The yq install output leaks into `make bundle-operator-image-url` stdout, causing the tag-release bundle build to fail. Adds `@` prefix to suppress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
  * Refined build command output display settings to enhance build process clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/dns-operator/pull/771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->