### PR TITLE
feat: add USE_IMAGE_DIGESTS flag and file-based catalog

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -107,6 +107,7 @@ jobs:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
           platforms: linux/amd64,linux/arm64,linux/s390x
+          build-args: QUAY_IMAGE_EXPIRY=never
           dockerfiles: |
             ./bundle.Dockerfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ tmp
 config/local-setup/**/*.env
 
 *.log
+
+# Catalogs
+/catalog/dns-operator-catalog
+/catalog/dns-operator-catalog.Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,12 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # quay.io/kuadrant/dns-operator-bundle:$VERSION and quay.io/kuadrant/dns-operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= quay.io/kuadrant/dns-operator
 
+# IMAGE_TAG defines the image tag for bundle and catalog images.
+IMAGE_TAG ?= latest
+
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:latest
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(IMAGE_TAG)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
@@ -59,7 +62,7 @@ endif
 OPERATOR_SDK_VERSION ?= v1.33.0
 
 # Image URL to use all building/pushing image targets
-DEFAULT_IMG ?= $(IMAGE_TAG_BASE):latest
+DEFAULT_IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
 IMG ?= $(DEFAULT_IMG)
 
 # CoreDNS image targets
@@ -394,12 +397,6 @@ install-olm: operator-sdk
 uninstall-olm: operator-sdk
 	$(OPERATOR_SDK) olm uninstall
 
-deploy-catalog: kustomize yq ## Deploy operator to the K8s cluster specified in ~/.kube/config using OLM catalog image.
-	$(KUSTOMIZE) build config/deploy/olm | $(KUBECTL) apply -f -
-
-undeploy-catalog: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config using OLM catalog image.
-	$(KUSTOMIZE) build config/deploy/olm | $(KUBECTL) delete -f -
-
 ##@ Build Dependencies
 
 ## Location to install dependencies to
@@ -549,6 +546,7 @@ bundle: manifests manifests-gen-base-csv set-image-refs operator-sdk ## Generate
 	$(MAKE) bundle-post-generate
 	$(OPERATOR_SDK) bundle validate ./bundle
 	$(MAKE) bundle-ignore-createdAt
+	echo "$$QUAY_EXPIRY_TIME_LABEL" >> bundle.Dockerfile
 
 bundle-operator-image-url: $(YQ) ## Read operator image reference URL from the manifest bundle.
 	@$(YQ) '.metadata.annotations.containerImage' bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -571,10 +569,14 @@ bundle-post-generate:
 	@if [ "$(CHANNELS)" != "" ]; then\
 		V="$(CHANNELS)" $(YQ) eval '.spec.channel = strenv(V)' -i config/deploy/olm/subscription.yaml; \
 	fi
+ifeq ($(USE_IMAGE_DIGESTS),true)
+	# Deduplicate relatedImages and remove name field (operator-sdk --use-image-digests creates duplicates)
+	$(YQ) -i '.spec.relatedImages |= unique_by(.image) | del(.spec.relatedImages[].name)' bundle/manifests/dns-operator.clusterserviceversion.yaml
+endif
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_TOOL) build --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
@@ -597,34 +599,9 @@ OPM = $(shell which opm)
 endif
 endif
 
-# A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
-# These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
-# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:latest
-
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
-FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
-endif
-
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	mkdir -p tmp/catalog
-	cd tmp/catalog && $(OPM) index add --container-tool docker --mode semver --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT) --generate
-	cd tmp/catalog && docker build -t $(CATALOG_IMG) -f index.Dockerfile .
-
-print-bundle-image: ## Pring bundle images.
+.PHONY: print-bundle-image
+print-bundle-image: ## Print bundle image.
 	@echo $(BUNDLE_IMG)
-
-# Push the catalog image.
-.PHONY: catalog-push
-catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 ##@ Release
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -18,3 +18,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY=never
+LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}

--- a/catalog/dns-operator-channel-entry.yaml
+++ b/catalog/dns-operator-channel-entry.yaml
@@ -1,0 +1,6 @@
+---
+schema: olm.channel
+package: dns-operator
+name: stable
+entries:
+  - name: dns-operator.v0.0.0

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -1,0 +1,71 @@
+##@ Operator Catalog
+
+# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
+CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
+
+CATALOG_FILE = catalog/dns-operator-catalog/operator.yaml
+CATALOG_DOCKERFILE = catalog/dns-operator-catalog.Dockerfile
+
+# Quay image default expiry
+QUAY_IMAGE_EXPIRY ?= never
+
+# A LABEL that can be appended to a generated Dockerfile to set the Quay image expiration through Docker arguments.
+define QUAY_EXPIRY_TIME_LABEL
+
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY=never
+LABEL quay.expires-after=$${QUAY_IMAGE_EXPIRY}
+endef
+export QUAY_EXPIRY_TIME_LABEL
+
+OPM_DOCKERFILE_TAG ?= latest
+$(CATALOG_DOCKERFILE): opm
+	-mkdir -p catalog/dns-operator-catalog
+	cd catalog && $(OPM) generate dockerfile dns-operator-catalog -l quay.expires-after=$(QUAY_IMAGE_EXPIRY) -i "quay.io/operator-framework/opm:${OPM_DOCKERFILE_TAG}"
+	# Inject --pprof-addr="" into both RUN and CMD serve invocations to disable running the pprof server
+	sed -i.bak -E '/(opm".*"serve|^CMD \["serve)/s#\]$$#, "--pprof-addr="]#' $(CATALOG_DOCKERFILE) && rm -f $(CATALOG_DOCKERFILE).bak
+
+.PHONY: catalog-dockerfile
+catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
+
+$(CATALOG_FILE): opm yq
+	@echo "************************************************************"
+	@echo Build dns operator catalog
+	@echo
+	@echo BUNDLE_IMG					= $(BUNDLE_IMG)
+	@echo CHANNELS						= $(CHANNELS)
+	@echo "************************************************************"
+	@echo
+	@echo Please check this matches your expectations and override variables if needed.
+	@echo
+	./utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(CHANNELS)
+
+.PHONY: catalog
+catalog: opm ## Generate catalog content and validate.
+	# Initializing the Catalog
+	-rm -rf catalog/dns-operator-catalog
+	-rm -rf catalog/dns-operator-catalog.Dockerfile
+	$(MAKE) $(CATALOG_DOCKERFILE)
+	$(MAKE) $(CATALOG_FILE) BUNDLE_IMG=$(BUNDLE_IMG)
+	cd catalog && $(OPM) validate dns-operator-catalog
+
+# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
+# Ref https://olm.operatorframework.io/docs/tasks/creating-a-catalog/#catalog-creation-with-raw-file-based-catalogs
+.PHONY: catalog-build
+catalog-build: ## Build a catalog image.
+	# Build the Catalog
+	$(CONTAINER_TOOL) build catalog -f catalog/dns-operator-catalog.Dockerfile -t $(CATALOG_IMG)
+
+# Push the catalog image.
+.PHONY: catalog-push
+catalog-push: ## Push a catalog image.
+	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+.PHONY: deploy-catalog
+deploy-catalog: kustomize yq ## Deploy operator to the K8s cluster specified in ~/.kube/config using OLM catalog image.
+	V="$(CATALOG_IMG)" $(YQ) eval '.spec.image = strenv(V)' -i config/deploy/olm/catalogsource.yaml
+	$(KUSTOMIZE) build config/deploy/olm | $(KUBECTL) apply -f -
+
+.PHONY: undeploy-catalog
+undeploy-catalog: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config using OLM catalog image.
+	$(KUSTOMIZE) build config/deploy/olm | $(KUBECTL) delete -f -

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Generate OLM catalog file
+
+set -euo pipefail
+
+### CONSTANTS
+# Used as well in the subscription object
+DEFAULT_CHANNEL=stable
+###
+
+OPM="${1?:Error \$OPM not set. Bye}"
+YQ="${2?:Error \$YQ not set. Bye}"
+BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
+CATALOG_FILE="${4?:Error \$CATALOG_FILE not set. Bye}"
+CHANNELS="${5:-$DEFAULT_CHANNEL}"
+
+CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath "${CATALOG_FILE}")" )" && pwd )"
+CATALOG_BASEDIR="$( cd "$( dirname "$(realpath "${CATALOG_FILE_BASEDIR}")" )" && pwd )"
+
+TMP_DIR=$(mktemp -d)
+
+"${OPM}" render "${BUNDLE_IMG}" --output=yaml >> "${TMP_DIR}/dns-operator-bundle.yaml"
+
+mkdir -p "${CATALOG_FILE_BASEDIR}"
+touch "${CATALOG_FILE}"
+
+###
+# DNS Operator
+###
+# Add the package
+"${OPM}" init dns-operator --default-channel="${CHANNELS}" --output yaml >> "${CATALOG_FILE}"
+# Add a bundles to the Catalog
+cat "${TMP_DIR}/dns-operator-bundle.yaml" >> "${CATALOG_FILE}"
+# Add a channel entry for the bundle
+V=$("${YQ}" eval '.name' "${TMP_DIR}/dns-operator-bundle.yaml") \
+CHANNELS="${CHANNELS}" \
+    "${YQ}" eval '(.entries[0].name = strenv(V)) | (.name = strenv(CHANNELS))' "${CATALOG_BASEDIR}/dns-operator-channel-entry.yaml" >> "${CATALOG_FILE}"
+
+rm -rf "${TMP_DIR}"


### PR DESCRIPTION
## Summary

Adds optional USE_IMAGE_DIGESTS flag and file-based catalog (FBC) generation to bring dns-operator in line with kuadrant-operator, authorino-operator, and limitador-operator for consistency across the Kuadrant ecosystem.

## Changes

### Digest Support
- Added `USE_IMAGE_DIGESTS` flag (default: false) to enable SHA256 digest references in bundles
- Created `BUNDLE_GEN_FLAGS` variable with conditional `--use-image-digests`
- Added bundle post-generation step to deduplicate relatedImages (operator-sdk creates duplicates when using digests)
- Added `IMAGE_TAG` variable support throughout Makefile for flexible image tagging

### Bundle Expiry Support
- Added Quay image expiry label support for bundle images (matching other operators)
- Inject `QUAY_EXPIRY_TIME_LABEL` into bundle.Dockerfile during bundle generation
- Pass `QUAY_IMAGE_EXPIRY` build-arg when building bundle images
- Set bundle expiry to `never` for tag releases in CI workflow

### File-Based Catalog (FBC)
- Added catalog generation support via `make/catalog.mk` (matching other Kuadrant operators)
- Added `utils/generate-catalog.sh` for automated FBC creation
- Added `catalog/dns-operator-channel-entry.yaml` template
- Removed duplicate/old index-based catalog targets from main Makefile
- Excluded generated `catalog/` directory in .gitignore

### Consistency Improvements
These changes bring dns-operator's build and release infrastructure in line with kuadrant-operator, authorino-operator, and limitador-operator, ensuring consistent patterns across all Kuadrant components.

**Note:** CoreDNS image (`coredns-kuadrant`) is not included in relatedImages. Users requiring CoreDNS should mirror it manually. See kuadrant-operator documentation for details.

## Benefits

Digest-based references enable ImageDigestMirrorSet to redirect image pulls to internal registries, supporting disconnected/air-gapped cluster scenarios.

## Related

Related to https://github.com/Kuadrant/kuadrant-operator/issues/1894