### PR TITLE
fix: restore catalog prerequisite to catalog-build target

### DIFF
--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -52,7 +52,7 @@ catalog: opm ## Generate catalog content and validate.
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 # Ref https://olm.operatorframework.io/docs/tasks/creating-a-catalog/#catalog-creation-with-raw-file-based-catalogs
 .PHONY: catalog-build
-catalog-build: ## Build a catalog image.
+catalog-build: catalog ## Build a catalog image.
 	# Build the Catalog
 	$(CONTAINER_TOOL) build catalog -f catalog/dns-operator-catalog.Dockerfile -t $(CATALOG_IMG)
 


### PR DESCRIPTION
# Summary

Restores the `catalog` prerequisite on the `catalog-build` Makefile target, which was accidentally dropped in #773.

Without this dependency, `make catalog-build` skips catalog generation (dockerfile, operator.yaml, and OPM validation) and attempts to build a container image from potentially missing or stale catalog artifacts. This broke both local `make catalog-build` invocations and CI catalog image builds.

# Changes

- Added `catalog` as a prerequisite to the `catalog-build` target in `make/catalog.mk`, restoring the dependency chain: `catalog-build` -> `catalog` -> `opm` / `$(CATALOG_DOCKERFILE)` / `$(CATALOG_FILE)`.

# Test plan

- [ ] Run `make catalog-build` from a clean checkout and confirm it generates catalog content before building the image
- [ ] Verify CI `build-catalog` job passes on this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the catalog image build process so the catalog content is generated first, helping ensure builds use the latest generated assets.
  * Kept the existing image build and tagging behaviour unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->