### PR TITLE
ci: add dependabot config for all Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+  - package-ecosystem: gomod
+    directory: /coredns/plugin
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+  - package-ecosystem: gomod
+    directory: /coredns/plugin/geoip
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci(deps):"


### PR DESCRIPTION
## Summary

Dependabot's default settings only scan the root `go.mod`. This repo has three Go modules that need independent dependency updates:

- `/` (root)
- `/coredns/plugin`
- `/coredns/plugin/geoip`

This was caught in [#790](https://github.com/Kuadrant/dns-operator/pull/790) where dependabot bumped `x/crypto` in the root module but missed the same dependency in `coredns/plugin/go.mod`.

Also adds GitHub Actions ecosystem scanning for CI workflow dependency updates.

## Changes

- Add `.github/dependabot.yml` with entries for all three Go module directories and GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly checks for updates to project dependencies and GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->