### PR TITLE
prepare-release: v0.17.1

### DIFF
--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -58,14 +58,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/dns-operator:v0.17.0
-    createdAt: "2026-05-28T08:04:09Z"
+    containerImage: quay.io/kuadrant/dns-operator:v0.17.1
+    createdAt: "2026-07-15T08:28:11Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/kuadrant/dns-operator
     support: kuadrant
-  name: dns-operator.v0.17.0
+  name: dns-operator.v0.17.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -168,7 +168,7 @@ spec:
                 envFrom:
                 - configMapRef:
                     name: dns-operator-controller-env
-                image: quay.io/kuadrant/dns-operator:v0.17.0
+                image: quay.io/kuadrant/dns-operator:v0.17.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -264,4 +264,4 @@ spec:
   minKubeVersion: 1.8.0
   provider:
     name: Red Hat
-  version: 0.17.0
+  version: 0.17.1

--- a/charts/dns-operator/Chart.yaml
+++ b/charts/dns-operator/Chart.yaml
@@ -12,8 +12,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
-version: "0.17.0"
-appVersion: "0.17.0"
+version: "0.17.1"
+appVersion: "0.17.1"
 maintainers:
   - email: mnairn@redhat.com
     name: Michael Nairn

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -938,7 +938,7 @@ spec:
         envFrom:
         - configMapRef:
             name: dns-operator-controller-env
-        image: quay.io/kuadrant/dns-operator:v0.17.0
+        image: quay.io/kuadrant/dns-operator:v0.17.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/coredns/kustomization.yaml
+++ b/config/coredns/kustomization.yaml
@@ -64,4 +64,4 @@ configMapGenerator:
 images:
   - name: quay.io/kuadrant/coredns-kuadrant
     newName: quay.io/kuadrant/coredns-kuadrant
-    newTag: v0.17.0
+    newTag: v0.17.1

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,6 +4,6 @@ metadata:
   name: dns-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/dns-operator-catalog:v0.17.0
+  image: quay.io/kuadrant/dns-operator-catalog:v0.17.1
   displayName: DNS Operators
   publisher: grpc

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: quay.io/kuadrant/dns-operator
-    newTag: v0.17.0
+    newTag: v0.17.1

--- a/config/manifests/bases/dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dns-operator.clusterserviceversion.yaml
@@ -5,11 +5,11 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/dns-operator:v0.17.0
+    containerImage: quay.io/kuadrant/dns-operator:v0.17.1
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     repository: https://github.com/kuadrant/dns-operator
     support: kuadrant
-  name: dns-operator.v0.17.0
+  name: dns-operator.v0.17.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -61,4 +61,4 @@ spec:
   minKubeVersion: 1.8.0
   provider:
     name: Red Hat
-  version: 0.17.0
+  version: 0.17.1

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,8 +1,8 @@
 #Release default values
-IMG=quay.io/kuadrant/dns-operator:v0.17.0
-BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:v0.17.0
-CATALOG_IMG=quay.io/kuadrant/dns-operator-catalog:v0.17.0
-COREDNS_IMG=quay.io/kuadrant/coredns-kuadrant:v0.17.0
+IMG=quay.io/kuadrant/dns-operator:v0.17.1
+BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:v0.17.1
+CATALOG_IMG=quay.io/kuadrant/dns-operator-catalog:v0.17.1
+COREDNS_IMG=quay.io/kuadrant/coredns-kuadrant:v0.17.1
 CHANNELS=stable
 BUNDLE_CHANNELS=--channels=stable
-VERSION=0.17.0
+VERSION=0.17.1


### PR DESCRIPTION
Generated release manifests for v0.17.1 via `make prepare-release VERSION=0.17.1 CHANNELS=stable`.

Once merged, tag and release v0.17.1 from the release branch.