### PR TITLE
fix: persist DEFAULT_CHANNEL in prepare-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -612,6 +612,9 @@ prepare-release: ## Generates a makefile that will override environment variable
 	echo -e "#Release default values\\nIMG=$(IMAGE_TAG_BASE):$(IMG_TAG)\nBUNDLE_IMG=$(IMAGE_TAG_BASE)-bundle:$(IMG_TAG)\n\
 	CATALOG_IMG=$(IMAGE_TAG_BASE)-catalog:$(IMG_TAG)\nCOREDNS_IMG=$(COREDNS_IMAGE_TAG_BASE):$(IMG_TAG)\nCHANNELS=$(CHANNELS)\n\
 	BUNDLE_CHANNELS=--channels=$(CHANNELS)\nVERSION=$(VERSION)" > $(RELEASE_FILE)
+ifneq ($(origin DEFAULT_CHANNEL), undefined)
+	echo -e "DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)\nBUNDLE_DEFAULT_CHANNEL=--default-channel=$(DEFAULT_CHANNEL)" >> $(RELEASE_FILE)
+endif
 	$(MAKE) set-image-refs
 	$(MAKE) bundle
 	$(MAKE) helm-build VERSION=$(VERSION)


### PR DESCRIPTION
## Summary
- Add `DEFAULT_CHANNEL` and `BUNDLE_DEFAULT_CHANNEL` to the values written to `make/release.mk` by the `prepare-release` target

## Why
`prepare-release` already persisted `CHANNELS`/`BUNDLE_CHANNELS` into `make/release.mk`, but never did the same for `DEFAULT_CHANNEL`/`BUNDLE_DEFAULT_CHANNEL`. This meant any subsequent `make bundle` invocation on a release branch silently fell back to the Makefile default (unset), producing bundles without an explicit `channel.default.v1` annotation.

Same class of bug fixed for limitador-operator in Kuadrant/limitador-operator#268 / Kuadrant/limitador-operator#269.

## Test plan
- [ ] `make prepare-release VERSION=0.0.0-test CHANNELS=stable DEFAULT_CHANNEL=stable` writes both channel values to `make/release.mk`
- [ ] Generated `bundle.Dockerfile` and `bundle/metadata/annotations.yaml` contain `channel.default.v1=stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release preparation now preserves the configured default update channel in generated release settings.
  - Bundled releases are configured to use the selected default channel automatically.
  - This ensures release packages and update settings remain aligned with the chosen distribution channel, reducing the risk of releases being published or delivered through an unintended channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->