### PR TITLE
prepare-release: v0.16.3

### DIFF
--- a/bundle/manifests/dns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dns-operator.clusterserviceversion.yaml
@@ -58,14 +58,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/dns-operator:v0.16.2
-    createdAt: "2026-05-20T15:22:37Z"
+    containerImage: quay.io/kuadrant/dns-operator:v0.16.3
+    createdAt: "2026-07-23T14:50:37Z"
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/kuadrant/dns-operator
     support: kuadrant
-  name: dns-operator.v0.16.2
+  name: dns-operator.v0.16.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -168,7 +168,7 @@ spec:
                 envFrom:
                 - configMapRef:
                     name: dns-operator-controller-env
-                image: quay.io/kuadrant/dns-operator:v0.16.2
+                image: quay.io/kuadrant/dns-operator:v0.16.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -264,4 +264,4 @@ spec:
   minKubeVersion: 1.8.0
   provider:
     name: Red Hat
-  version: 0.16.2
+  version: 0.16.3

--- a/charts/dns-operator/Chart.yaml
+++ b/charts/dns-operator/Chart.yaml
@@ -12,8 +12,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
-version: "0.16.2"
-appVersion: "0.16.2"
+version: "0.16.3"
+appVersion: "0.16.3"
 maintainers:
   - email: mnairn@redhat.com
     name: Michael Nairn

--- a/charts/dns-operator/templates/manifests.yaml
+++ b/charts/dns-operator/templates/manifests.yaml
@@ -938,7 +938,7 @@ spec:
         envFrom:
         - configMapRef:
             name: dns-operator-controller-env
-        image: quay.io/kuadrant/dns-operator:v0.16.2
+        image: quay.io/kuadrant/dns-operator:v0.16.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/coredns/kustomization.yaml
+++ b/config/coredns/kustomization.yaml
@@ -64,4 +64,4 @@ configMapGenerator:
 images:
   - name: quay.io/kuadrant/coredns-kuadrant
     newName: quay.io/kuadrant/coredns-kuadrant
-    newTag: v0.16.2
+    newTag: v0.16.3

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,6 +4,6 @@ metadata:
   name: dns-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/dns-operator-catalog:v0.16.2
+  image: quay.io/kuadrant/dns-operator-catalog:v0.16.3
   displayName: DNS Operators
   publisher: grpc

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
   - name: controller
     newName: quay.io/kuadrant/dns-operator
-    newTag: v0.16.2
+    newTag: v0.16.3

--- a/config/manifests/bases/dns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dns-operator.clusterserviceversion.yaml
@@ -5,11 +5,11 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/dns-operator:v0.16.2
+    containerImage: quay.io/kuadrant/dns-operator:v0.16.3
     description: A Kubernetes Operator to manage the lifecycle of DNS resources
     repository: https://github.com/kuadrant/dns-operator
     support: kuadrant
-  name: dns-operator.v0.16.2
+  name: dns-operator.v0.16.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -61,4 +61,4 @@ spec:
   minKubeVersion: 1.8.0
   provider:
     name: Red Hat
-  version: 0.16.2
+  version: 0.16.3

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,8 +1,8 @@
 #Release default values
-IMG=quay.io/kuadrant/dns-operator:v0.16.2
-BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:v0.16.2
-CATALOG_IMG=quay.io/kuadrant/dns-operator-catalog:v0.16.2
-COREDNS_IMG=quay.io/kuadrant/coredns-kuadrant:v0.16.2
+IMG=quay.io/kuadrant/dns-operator:v0.16.3
+BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:v0.16.3
+CATALOG_IMG=quay.io/kuadrant/dns-operator-catalog:v0.16.3
+COREDNS_IMG=quay.io/kuadrant/coredns-kuadrant:v0.16.3
 CHANNELS=stable
 BUNDLE_CHANNELS=--channels=stable
-VERSION=0.16.2
+VERSION=0.16.3


### PR DESCRIPTION
## Summary
- Version: 0.16.3
- Channels: stable
- Includes: Go 1.26.4 (CVE-2026-27145), x/net v0.55.0 (CVE-2026-33811), x/crypto v0.52.0, golangci-lint v2.12.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)