### PR TITLE
fix: bump Dockerfile to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mirror.gcr.io/library/golang:1.25 AS builder
+FROM mirror.gcr.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Dockerfile uses golang:1.25 but go.mod requires Go 1.26.4. Build fails with GOTOOLCHAIN=local.