### PR TITLE
fix: bump coredns Dockerfile to Go 1.26

### DIFF
--- a/coredns/plugin/Dockerfile
+++ b/coredns/plugin/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mirror.gcr.io/library/golang:1.24 AS builder
+FROM mirror.gcr.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
CoreDNS Dockerfile uses golang:1.24 but coredns/plugin/go.mod requires Go 1.26.4. Build fails with GOTOOLCHAIN=local.