### PR TITLE
fix: prevent deletion status flip when awaiting remote controller

### DIFF
--- a/api/v1alpha1/dnsrecord_types.go
+++ b/api/v1alpha1/dnsrecord_types.go
@@ -246,9 +246,12 @@ func (s *DNSRecordStatus) ProviderEndpointsRemoved() bool {
 }
 
 // ProviderEndpointsDeletion return true if the ready status condition has the reason set to "ProviderEndpointsDeletion"
+// or "ProviderEndpointsRemoved" (which is a progression past the deletion stage).
 func (s *DNSRecordStatus) ProviderEndpointsDeletion() bool {
 	readyCond := meta.FindStatusCondition(s.Conditions, string(ConditionTypeReady))
-	if readyCond == nil || readyCond.Reason == string(ConditionReasonProviderEndpointsDeletion) {
+	if readyCond == nil ||
+		readyCond.Reason == string(ConditionReasonProviderEndpointsDeletion) ||
+		readyCond.Reason == string(ConditionReasonProviderEndpointsRemoved) {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- `ProviderEndpointsDeletion()` now recognizes `ProviderEndpointsRemoved` as a state that has already progressed past the deletion stage, preventing a status flip loop during delegating record deletion
- This fixes the underlying delegation bug that `recordReceivedPrematurely` was masking, unblocking #778 (rework premature reconcile check)

## Problem
When deleting a delegating record with pending remote record statuses, the deletion flow would flip between `ProviderEndpointsDeletion` and `ProviderEndpointsRemoved` indefinitely:

1. Local controller sets `ProviderEndpointsRemoved` after cleanup
2. `ProviderEndpointsRemoved()` returns false (remote controller hasn't confirmed yet)
3. `ProviderEndpointsDeletion()` sees reason `ProviderEndpointsRemoved` which is not `ProviderEndpointsDeletion` → returns false
4. Deletion flow overwrites status back to `ProviderEndpointsDeletion`
5. Cycle repeats

The `recordReceivedPrematurely` check masked this by throttling reconciliation, giving remote controllers time to catch up.

## Tested locally by:
- [x] `make test-unit` — all passing
- [x] `make test-integration` — all 44 specs passing (including all delegation tests)
- [x] Verified delegation tests also pass with premature check temporarily removed, confirming this fix eliminates the masked bug

Closes #777
Part of #776