### PR TITLE
feat: dispatch chart sync to kuadrant-operator

### DIFF
--- a/.github/workflows/dispatch-chart-sync.yaml
+++ b/.github/workflows/dispatch-chart-sync.yaml
@@ -1,0 +1,30 @@
+# Notifies the kuadrant-operator repo when this component's Helm chart changes.
+# Sends a repository_dispatch event containing the component name, source branch,
+# actor, and commit URL. The kuadrant-operator's sync-component-chart workflow
+# receives this event, syncs the updated chart, and creates a PR.
+
+name: Dispatch chart sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
+          repository: Kuadrant/kuadrant-operator
+          event-type: component-chart-sync
+          client-payload: >-
+            {
+              "component": "dns-operator",
+              "ref": "${{ github.ref_name }}",
+              "actor": "${{ github.actor }}",
+              "commit-url": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+            }


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that dispatches a `component-chart-sync` event to `Kuadrant/kuadrant-operator` when the Helm chart content changes on `main`.

The dispatch payload includes the component name, source branch, actor, and commit URL for PR traceability.

Relates to https://github.com/Kuadrant/kuadrant-operator/issues/2155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated chart synchronisation notifications when chart files change on the main branch.
  * Included relevant source branch, contributor, and commit details in synchronisation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->