### PR TITLE
Pin github actions with ratchet

### DIFF
--- a/.github/workflows/build-coredns-images.yaml
+++ b/.github/workflows/build-coredns-images.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Add latest tag
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.COREDNS_PLUGIN_NAME }}
           tags: ${{ env.IMG_TAGS }}
@@ -55,7 +55,7 @@ jobs:
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -19,7 +19,7 @@ jobs:
       image: ${{ steps.push-to-quay.outputs.registry-path }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Read release string version
         id: release
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ github.ref_name }}
@@ -59,7 +59,7 @@ jobs:
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
@@ -79,7 +79,7 @@ jobs:
       image: ${{ steps.push-to-quay.outputs.registry-path }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Install yq tool
         run: |
           # following sub-shells running make target should have yq already installed
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
@@ -117,7 +117,7 @@ jobs:
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
@@ -137,7 +137,7 @@ jobs:
       image: ${{ steps.push-to-quay.outputs.registry-path }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Install yq tool
         run: |
           # following sub-shells running make target should have yq already installed
@@ -161,7 +161,7 @@ jobs:
 
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
@@ -176,7 +176,7 @@ jobs:
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -24,7 +24,7 @@ jobs:
       build-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Read release string version
         id: release
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ env.IMG_TAGS }}
@@ -64,7 +64,7 @@ jobs:
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
@@ -83,7 +83,7 @@ jobs:
       bundle-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Run make bundle
         run: make bundle IMG=${{ needs.build.outputs.build-image }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
@@ -109,7 +109,7 @@ jobs:
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
 
       - name: Run make catalog-build
         run: make catalog-build BUNDLE_IMG=${{ needs.build-bundle.outputs.bundle-image }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
@@ -153,7 +153,7 @@ jobs:
       - name: Push Image
         if: github.repository_owner == 'kuadrant'
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/ci-e2e-0.yaml
+++ b/.github/workflows/ci-e2e-0.yaml
@@ -47,7 +47,7 @@ on:
         default: false
         type: boolean
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
   pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
@@ -67,9 +67,9 @@ jobs:
     outputs:
       should_skip_e2e: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.4.1
+        uses: fkirc/skip-duplicate-actions@f75dd6564bb646f95277dc8c3b80612e46a4a1ea # ratchet:fkirc/skip-duplicate-actions@v3.4.1
         with:
           cancel_others: false
           paths_ignore: '["**/*.md", "**/*.adoc", "LICENSE"]'
@@ -83,7 +83,7 @@ jobs:
       - name: Get User Permission
         if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request' }}
         id: checkAccess
-        uses: actions-cool/check-user-permission@v2
+        uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # ratchet:actions-cool/check-user-permission@v2
         with:
           require: write
           username: ${{ github.triggering_actor }}
@@ -96,10 +96,10 @@ jobs:
           echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
           echo "Job originally triggered by ${{ github.actor }}"
           exit 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -171,7 +171,7 @@ jobs:
         run: |
           kubectl run -q curl --image=curlimages/curl --rm -it --restart=Never --namespace dns-operator-system -- curl -XGET http://dns-operator-controller-manager-metrics-service:8080/metrics > metrics.txt
           cat metrics.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: metrics
           path: metrics.txt
@@ -186,9 +186,9 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ e2e-test-suite ]
+    needs: [e2e-test-suite]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.4.1
+        uses: fkirc/skip-duplicate-actions@f75dd6564bb646f95277dc8c3b80612e46a4a1ea # ratchet:fkirc/skip-duplicate-actions@v3.4.1
         with:
           cancel_others: false
           paths_ignore: '["**/*.md", "**/*.adoc", "LICENSE"]'
@@ -35,12 +35,12 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # ratchet:golangci/golangci-lint-action@v8
         with:
           version: v2.12.2
           only-new-issues: true
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -69,9 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -86,9 +86,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -103,9 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -120,9 +120,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -137,9 +137,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -154,9 +154,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -164,14 +164,30 @@ jobs:
       - name: Verify generate command
         run: |
           make verify-go-mod
+  verify-ratchet:
+    name: Verify ratchet
+    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: pre-job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Run make verify-ratchet
+        run: |
+          make verify-ratchet
   unit-test-suite:
     name: Unit Test Suite
     if: needs.pre-job.outputs.should_skip != 'true'
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -184,8 +200,8 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -198,8 +214,8 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -211,9 +227,9 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ lint, verify-code, verify-manifests, verify-bundle, verify-helm-build, verify-imports, verify-generate, verify-go-mod, unit-test-suite, integration-test-suite, coredns-unit-test-suite]
+    needs: [lint, verify-code, verify-manifests, verify-bundle, verify-helm-build, verify-imports, verify-generate, verify-go-mod, verify-ratchet, unit-test-suite, integration-test-suite, coredns-unit-test-suite]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/.github/workflows/delete-release-helm-chart.yaml
+++ b/.github/workflows/delete-release-helm-chart.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
       - name: Parse Tag
         run: |
           tag=${{ github.event.release.tag_name || inputs.operatorTag }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       operatorTag:
-          description: Operator bundle version tag
-          default: v0.0.0
-          type: string
+        description: Operator bundle version tag
+        default: v0.0.0
+        type: string
 jobs:
   chart_release:
     runs-on: ubuntu-latest
@@ -19,53 +19,53 @@ jobs:
       contents: write
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.ref }}
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
-    - name: Configure GPG Key
-      run: |
-        mkdir -p ~/.gnupg
-        echo -n "$GPG_SIGNING_KEY" | base64 -d > ~/.gnupg/pubring.gpg
-      env:
-        GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
+      - name: Configure GPG Key
+        run: |
+          mkdir -p ~/.gnupg
+          echo -n "$GPG_SIGNING_KEY" | base64 -d > ~/.gnupg/pubring.gpg
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
 
-    - name: Package Helm Chart
-      run: |
-        GPG_KEY_UID="Kuadrant Development Team" \
-        make helm-package-sign
+      - name: Package Helm Chart
+        run: |
+          GPG_KEY_UID="Kuadrant Development Team" \
+          make helm-package-sign
 
-    - name: Parse Tag
-      run: |
-        tag=${{ github.event.release.tag_name || inputs.operatorTag }}
-        echo "OPERATOR_VERSION=${tag#v}" >> $GITHUB_ENV
-        echo "OPERATOR_TAG=${tag}" >> $GITHUB_ENV
+      - name: Parse Tag
+        run: |
+          tag=${{ github.event.release.tag_name || inputs.operatorTag }}
+          echo "OPERATOR_VERSION=${tag#v}" >> $GITHUB_ENV
+          echo "OPERATOR_TAG=${tag}" >> $GITHUB_ENV
 
-    - name: Upload package to GitHub Release
-      uses: svenstaro/upload-release-action@v2
-      id: upload-chart
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: dns-operator-${{ env.OPERATOR_VERSION }}.tgz
-        asset_name: chart-dns-operator-${{ env.OPERATOR_VERSION }}.tgz
-        tag: ${{ env.OPERATOR_TAG }}
-        overwrite: true
+      - name: Upload package to GitHub Release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # ratchet:svenstaro/upload-release-action@v2
+        id: upload-chart
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dns-operator-${{ env.OPERATOR_VERSION }}.tgz
+          asset_name: chart-dns-operator-${{ env.OPERATOR_VERSION }}.tgz
+          tag: ${{ env.OPERATOR_TAG }}
+          overwrite: true
 
-    - name: Upload provenance file to GitHub Release
-      uses: svenstaro/upload-release-action@v2
-      id: upload-prov-file
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: dns-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
-        asset_name: chart-dns-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
-        tag: ${{ env.OPERATOR_TAG }}
-        overwrite: true
+      - name: Upload provenance file to GitHub Release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # ratchet:svenstaro/upload-release-action@v2
+        id: upload-prov-file
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dns-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          asset_name: chart-dns-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          tag: ${{ env.OPERATOR_TAG }}
+          overwrite: true
 
-    - name: Sync Helm Chart with repository
-      run: |
-        make helm-sync-package-created \
-          VERSION=${{env.OPERATOR_VERSION}} \
-          HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
-          BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}
+      - name: Sync Helm Chart with repository
+        run: |
+          make helm-sync-package-created \
+            VERSION=${{env.OPERATOR_VERSION}} \
+            HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
+            BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}

--- a/.github/workflows/upload-cli.yml
+++ b/.github/workflows/upload-cli.yml
@@ -29,8 +29,8 @@ jobs:
           - goos: darwin
             goarch: ppc64le
     steps:
-      - uses: actions/checkout@v4
-      - uses: wangyoucao577/go-release-action@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - uses: wangyoucao577/go-release-action@279495102627de7960cbc33434ab01a12bae144b # ratchet:wangyoucao577/go-release-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,10 @@ imports: openshift-goimports ## Run openshift goimports against code.
 	$(OPENSHIFT_GOIMPORTS) -m github.com/kuadrant/dns-operator -i github.com/kuadrant
 	$(OPENSHIFT_GOIMPORTS) -p coredns/plugin -m github.com/kuadrant/coredns-kuadrant -i github.com/kuadrant
 
+.PHONY: ratchet-pin
+ratchet-pin: ratchet ## Pin GitHub Actions to commit SHAs.
+	$(RATCHET) pin $$(find .github/workflows -name '*.yaml' -o -name '*.yml')
+
 .PHONY: test
 test: test-unit test-integration ## Run tests.
 
@@ -419,6 +423,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 HELM ?= $(LOCALBIN)/helm
 KUBE_BURNER ?= $(LOCALBIN)/kube-burner
 KUBECTL_DNS ?= $(LOCALBIN)/kubectl-kuadrant_dns
+RATCHET ?= $(LOCALBIN)/ratchet
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
@@ -432,6 +437,7 @@ GINKGO_VERSION ?= v2.22.0
 GOLANGCI_LINT_VERSION ?= v2.12.2
 HELM_VERSION = v3.15.0
 KUBE_BURNER_VERSION = v1.11.1
+RATCHET_VERSION ?= v0.11.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -537,6 +543,14 @@ $(KUBE_BURNER):
 kubectl-dns: $(KUBECTL_DNS) ## Build the kubectl-kuadrant_dns locally if required.
 $(KUBECTL_DNS):
 	$(MAKE) build-cli
+
+RATCHET_V_BINARY := $(LOCALBIN)/ratchet-$(RATCHET_VERSION)
+.PHONY: ratchet
+ratchet: $(RATCHET_V_BINARY) ## Download ratchet locally if necessary.
+$(RATCHET_V_BINARY): | $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install github.com/sethvargo/ratchet@$(RATCHET_VERSION)
+	@mv $(LOCALBIN)/ratchet $(RATCHET_V_BINARY)
+	@ln -sf $(RATCHET_V_BINARY) $(RATCHET)
 
 
 .PHONY: bundle

--- a/make/verify.mk
+++ b/make/verify.mk
@@ -4,7 +4,7 @@
 ## Targets to verify actions that generate/modify code have been executed and output committed
 
 .PHONY: verify-all
-verify-all: verify-code verify-bundle verify-helm-build verify-imports verify-manifests verify-generate verify-go-mod verify-vulnerabilities
+verify-all: verify-code verify-bundle verify-helm-build verify-imports verify-manifests verify-generate verify-go-mod verify-vulnerabilities verify-ratchet
 
 .PHONY: verify-code
 verify-code: vet ## Verify code formatting
@@ -41,3 +41,7 @@ verify-generate: generate ## Verify generate update.
 verify-go-mod: ## Verify go.mod matches source code
 	go mod tidy
 	git diff --exit-code ./go.mod
+
+.PHONY: verify-ratchet
+verify-ratchet: ratchet ## Verify GitHub Actions are pinned to commit SHAs.
+	$(RATCHET) lint $$(find .github/workflows -name '*.yaml' -o -name '*.yml')


### PR DESCRIPTION
## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)
  - Add `ratchet-pin` and `verify-ratchet` Make targets for pinning and verifying action references
  - Add `verify-ratchet` job to the existing CI workflow to block PRs with unpinned action references

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

Already merged ratchet PRs on other components: https://github.com/Kuadrant/kuadrant-operator/pull/2057,
  https://github.com/Kuadrant/authorino/pull/642, https://github.com/Kuadrant/authorino-operator/pull/330

## Motivation
  Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * GitHub Actions used by build, CI and release workflows are now pinned to immutable commits, improving build consistency and supply-chain security.
  * Added automated checks to verify that workflow actions remain pinned.

* **Chores**
  * Added Makefile support for installing, managing and updating the workflow pinning tool.
  * Existing build, packaging and release behaviour remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->