### PR TITLE
CLI dry-run mode for remove-active-group

### DIFF
--- a/cmd/plugin/failover/remove-active-group.go
+++ b/cmd/plugin/failover/remove-active-group.go
@@ -1,10 +1,9 @@
 package failover
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -28,11 +27,13 @@ var RemoveActiveGroupCMD = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 }
 
+var dryRun bool
+
 func init() {
 	RemoveActiveGroupCMD.Flags().StringVar(&providerRef, "providerRef", "", "A provider reference to the secret with provider credentials. Format = '<namespace>/<name>'")
 	RemoveActiveGroupCMD.Flags().StringVarP(&domain, "domain", "d", "", "domain to which the group will belong")
 	RemoveActiveGroupCMD.Flags().BoolVarP(&assumeYes, "assumeyes", "y", false, "skip confirmation. Use at your own risk")
-
+	RemoveActiveGroupCMD.Flags().BoolVar(&dryRun, "dry-run", false, "preview the impact of removing the group without making changes")
 }
 
 func removeActiveGroup(_ *cobra.Command, args []string) error {
@@ -118,37 +119,72 @@ func removeActiveGroup(_ *cobra.Command, args []string) error {
 			continue
 		}
 
-		if !strings.Contains(groupTXTRecord.Targets[0], groupName) {
-			log.V(1).Info(fmt.Sprintf("TXT record does not contain group %s. Groups: %s. Skipping", groupTXTRecord.Targets[0], groupName))
+		if len(groupTXTRecord.Targets) == 0 {
+			log.V(1).Info("Skipping TXT record without targets", "zone", zone.DNSName, "zoneID", zone.ID, "record", groupTXTRecord.DNSName)
+			continue
+		}
+
+		currentActiveGroups, isCurrentVersion := GetActiveGroupsFromTarget(groupTXTRecord.Targets[0])
+		if !isCurrentVersion {
+			log.V(1).Info("Skipping legacy record", "group", groupName, "zone", zone.DNSName, "zoneID", zone.ID, "record", groupTXTRecord.DNSName, "target", groupTXTRecord.Targets[0])
+			continue
+		}
+
+		if !slices.Contains(currentActiveGroups, groupName) {
+			log.V(1).Info("Group not found in active groups", "group", groupName, "zone", zone.DNSName, "zoneID", zone.ID, "activeGroups", currentActiveGroups)
+			continue
+		}
+
+		log.V(1).Info("Selected zone", "zone", zone.DNSName, "zoneID", zone.ID)
+
+		if dryRun {
+			result := AnalyseGroupRemovalImpact(endpoints, groupName, currentActiveGroups)
+
+			output.Formatter.Print(fmt.Sprintf("Dry run: impact of removing group %q from zone %s (ID: %s)", groupName, zone.DNSName, zone.ID))
+
+			if len(result.RemainingGroups) == 0 {
+				output.Formatter.Print(fmt.Sprintf("  TXT record %s will be DELETED (last group)", groupTXTRecord.DNSName))
+			} else {
+				output.Formatter.Print(fmt.Sprintf("  TXT record %s will be UPDATED (remaining groups: %s)", groupTXTRecord.DNSName, strings.Join(result.RemainingGroups, ", ")))
+			}
+
+			if len(result.Endpoints) == 0 {
+				output.Formatter.Print("  No DNS endpoints will be affected")
+			} else {
+				table := output.PrintableTable{
+					Headers: []string{"Action", "DNS Name", "Type", "Current Targets", "New Targets"},
+				}
+				for _, impact := range result.Endpoints {
+					newTargets := ""
+					if impact.Action == ActionModify {
+						newTargets = strings.Join(impact.NewTargets, ", ")
+					}
+					table.Data = append(table.Data, []string{
+						string(impact.Action),
+						impact.DNSName,
+						impact.RecordType,
+						strings.Join(impact.OldTargets, ", "),
+						newTargets,
+					})
+				}
+				output.Formatter.PrintTable(table)
+			}
 			continue
 		}
 
 		output.Formatter.Print(fmt.Sprintf("Removing active group %s from the record: %s", groupName, groupTXTRecord.DNSName))
-		log.V(1).Info(fmt.Sprintf("Selected zone: %s, (ID: %s)", zone.DNSName, zone.ID))
 
-		var answer string
 		if !assumeYes {
 			output.Formatter.Print("Do you want to proceed? [Y/N]")
-
-			reader := bufio.NewReader(os.Stdin)
-			answer, err = reader.ReadString('\n')
-			if err != nil {
-				log.Error(err, "failed to read answer", "answer", answer)
-			}
-			answer = strings.TrimSpace(strings.ToLower(answer))
 		}
 
-		// delete group
-		if answer == "y" || assumeYes {
+		if assumeYes || inputYes(log) {
 			changes := &plan.Changes{}
 
 			oldGroupRecord := groupTXTRecord.DeepCopy()
 			groupTXTRecord = RemoveGroupFromActiveGroups(groupName, groupTXTRecord)
 
-			activeGroups, isCurrentVersion := GetActiveGroupsFromTarget(groupTXTRecord.Targets[0])
-			if !isCurrentVersion {
-				log.V(1).Info(fmt.Sprintf("Skipping removal of active group %s; This is a legacy record: %s", groupName, groupTXTRecord.Targets[0]))
-			}
+			activeGroups, _ := GetActiveGroupsFromTarget(groupTXTRecord.Targets[0])
 
 			if len(activeGroups) == 0 {
 				changes.Delete = append(changes.Delete, oldGroupRecord)

--- a/cmd/plugin/failover/shared.go
+++ b/cmd/plugin/failover/shared.go
@@ -13,6 +13,9 @@ import (
 	"sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/cmd/plugin/common"
+	internalcommon "github.com/kuadrant/dns-operator/internal/common"
+	"github.com/kuadrant/dns-operator/internal/external-dns/registry"
+	"github.com/kuadrant/dns-operator/types"
 )
 
 const (
@@ -140,4 +143,98 @@ func GetDomainRegexp(domain string) (*regexp.Regexp, error) {
 		return nil, err
 	}
 	return domainRegexp, nil
+}
+
+type Action string
+
+const (
+	ActionDelete Action = "DELETE"
+	ActionModify Action = "MODIFY"
+)
+
+type EndpointImpact struct {
+	DNSName    string
+	RecordType string
+	Action     Action
+	OldTargets []string
+	NewTargets []string
+}
+
+type GroupRemovalImpact struct {
+	RemainingGroups []string
+	Endpoints       []EndpointImpact
+}
+
+// AnalyseGroupRemovalImpact determines which DNS endpoints would be affected
+// if the given group were removed from the active groups list. It mirrors the
+// analysis logic in the controller's unpublishInactiveGroups function.
+func AnalyseGroupRemovalImpact(endpoints []*endpoint.Endpoint, groupToRemove string, currentActiveGroups []string) GroupRemovalImpact {
+	managedRecordTypes := []string{endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME}
+
+	var remainingGroups []string
+	postRemovalGroups := types.Groups{}
+	for _, g := range currentActiveGroups {
+		if g != groupToRemove {
+			postRemovalGroups = append(postRemovalGroups, types.Group(g))
+			remainingGroups = append(remainingGroups, g)
+		}
+	}
+
+	registryMap := registry.TxtRecordsToRegistryMap(endpoints, internalcommon.TxtRegistryPrefix, internalcommon.TxtRegistrySuffix, internalcommon.TxtRegistryWildcardReplacement, []byte(internalcommon.TxtRegistryEncryptAESKey))
+
+	var impacts []EndpointImpact
+
+	for _, ep := range endpoints {
+		if !slices.Contains(managedRecordTypes, ep.RecordType) {
+			continue
+		}
+
+		registryHost, ok := registryMap.Hosts[ep.DNSName]
+		if !ok {
+			continue
+		}
+
+		if !registryHost.HasAnyGroup(postRemovalGroups) && len(registryHost.UngroupedOwners) == 0 {
+			impacts = append(impacts, EndpointImpact{
+				DNSName:    ep.DNSName,
+				RecordType: ep.RecordType,
+				Action:     ActionDelete,
+				OldTargets: ep.Targets,
+			})
+			continue
+		}
+
+		inactiveTargets := registryHost.GetOtherGroupsTargets(postRemovalGroups)
+		activeTargets := registryHost.GetGroupsTargets(postRemovalGroups)
+		ungroupedTargets := registryHost.GetUngroupedTargets()
+
+		var newTargets []string
+		for _, t := range ep.Targets {
+			if !slices.Contains(inactiveTargets, t) || slices.Contains(activeTargets, t) || slices.Contains(ungroupedTargets, t) {
+				newTargets = append(newTargets, t)
+			}
+		}
+
+		if len(newTargets) == 0 {
+			impacts = append(impacts, EndpointImpact{
+				DNSName:    ep.DNSName,
+				RecordType: ep.RecordType,
+				Action:     ActionDelete,
+				OldTargets: ep.Targets,
+			})
+		} else if !slices.Equal(newTargets, ep.Targets) {
+			impacts = append(impacts, EndpointImpact{
+				DNSName:    ep.DNSName,
+				RecordType: ep.RecordType,
+				Action:     ActionModify,
+				OldTargets: ep.Targets,
+				NewTargets: newTargets,
+			})
+		}
+	}
+
+	return GroupRemovalImpact{
+		RemainingGroups: remainingGroups,
+		Endpoints:       impacts,
+	}
 }

--- a/cmd/plugin/failover/shared_test.go
+++ b/cmd/plugin/failover/shared_test.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/external-dns/endpoint"
+
+	"github.com/kuadrant/dns-operator/internal/common/hash"
 )
 
 func TestGenerateGroupTXTRecord(t *testing.T) {
@@ -229,6 +232,206 @@ func TestRemoveGroupFromActiveGroups(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := RemoveGroupFromActiveGroups(tt.group, &endpoint.Endpoint{Targets: endpoint.Targets{tt.target}}); got.Targets[0] != tt.want {
 				t.Errorf("RemoveGroupFromActiveGroups() = %s, want %s", got.Targets[0], tt.want)
+			}
+		})
+	}
+}
+
+func TestAnalyseGroupRemovalImpact(t *testing.T) {
+	// Helper to build a TXT registry record for a host with owner, group, and targets.
+	// TXT record naming follows the kuadrant- prefix convention:
+	// kuadrant-<base36hash(ownerID,8)>-<lowercase(recordType)>-<host>
+	txtRecord := func(host, recordType, owner, group, targets string) *endpoint.Endpoint {
+		label := fmt.Sprintf("\"heritage=external-dns,external-dns/owner=%s,external-dns/version=1", owner)
+		if group != "" {
+			label += ",external-dns/group=" + group
+		}
+		if targets != "" {
+			label += ",external-dns/targets=" + targets
+		}
+		label += "\""
+
+		ownerHash := hash.ToBase36HashLen(owner, 8)
+		txtName := fmt.Sprintf("kuadrant-%s-%s-%s", ownerHash, strings.ToLower(recordType), host)
+
+		return endpoint.NewEndpoint(txtName, endpoint.RecordTypeTXT, label)
+	}
+
+	tests := []struct {
+		name                string
+		endpoints           []*endpoint.Endpoint
+		groupToRemove       string
+		currentActiveGroups []string
+		wantRemainingGroups []string
+		wantImpacts         []EndpointImpact
+	}{
+		{
+			name:                "no managed endpoints",
+			endpoints:           []*endpoint.Endpoint{},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1", "group2"},
+			wantRemainingGroups: []string{"group2"},
+			wantImpacts:         nil,
+		},
+		{
+			name: "endpoint with only the removed group is deleted",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner1", "group1", "1.2.3.4"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1"},
+			wantRemainingGroups: nil,
+			wantImpacts: []EndpointImpact{
+				{
+					DNSName:    "foo.example.com",
+					RecordType: endpoint.RecordTypeA,
+					Action:     ActionDelete,
+					OldTargets: []string{"1.2.3.4"},
+				},
+			},
+		},
+		{
+			name: "endpoint with remaining active group is not affected",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner1", "group2", "1.2.3.4"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1", "group2"},
+			wantRemainingGroups: []string{"group2"},
+			wantImpacts:         nil,
+		},
+		{
+			name: "endpoint with mixed groups is modified",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4", "5.6.7.8"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner1", "group1", "1.2.3.4"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner2", "group2", "5.6.7.8"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1", "group2"},
+			wantRemainingGroups: []string{"group2"},
+			wantImpacts: []EndpointImpact{
+				{
+					DNSName:    "foo.example.com",
+					RecordType: endpoint.RecordTypeA,
+					Action:     ActionModify,
+					OldTargets: []string{"1.2.3.4", "5.6.7.8"},
+					NewTargets: []string{"5.6.7.8"},
+				},
+			},
+		},
+		{
+			name: "endpoint with ungrouped owner is kept",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4", "9.9.9.9"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner1", "group1", "1.2.3.4"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner2", "", "9.9.9.9"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1"},
+			wantRemainingGroups: nil,
+			wantImpacts: []EndpointImpact{
+				{
+					DNSName:    "foo.example.com",
+					RecordType: endpoint.RecordTypeA,
+					Action:     ActionModify,
+					OldTargets: []string{"1.2.3.4", "9.9.9.9"},
+					NewTargets: []string{"9.9.9.9"},
+				},
+			},
+		},
+		{
+			name: "non-managed record types are ignored",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "some-value"),
+				txtRecord("foo.example.com", endpoint.RecordTypeTXT, "owner1", "group1", "some-value"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1"},
+			wantRemainingGroups: nil,
+			wantImpacts:         nil,
+		},
+		{
+			name: "endpoint with no registry entry is ignored",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1"},
+			wantRemainingGroups: nil,
+			wantImpacts:         nil,
+		},
+		{
+			name: "shared target between removed and remaining group is kept",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4", "5.6.7.8"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner1", "group1", "1.2.3.4"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner2", "group2", "1.2.3.4;5.6.7.8"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1", "group2"},
+			wantRemainingGroups: []string{"group2"},
+			wantImpacts:         nil,
+		},
+		{
+			name: "multiple endpoints affected",
+			endpoints: []*endpoint.Endpoint{
+				endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+				endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "target.example.com"),
+				txtRecord("foo.example.com", endpoint.RecordTypeA, "owner1", "group1", "1.2.3.4"),
+				txtRecord("bar.example.com", endpoint.RecordTypeCNAME, "owner2", "group1", "target.example.com"),
+			},
+			groupToRemove:       "group1",
+			currentActiveGroups: []string{"group1"},
+			wantRemainingGroups: nil,
+			wantImpacts: []EndpointImpact{
+				{
+					DNSName:    "foo.example.com",
+					RecordType: endpoint.RecordTypeA,
+					Action:     ActionDelete,
+					OldTargets: []string{"1.2.3.4"},
+				},
+				{
+					DNSName:    "bar.example.com",
+					RecordType: endpoint.RecordTypeCNAME,
+					Action:     ActionDelete,
+					OldTargets: []string{"target.example.com"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AnalyseGroupRemovalImpact(tt.endpoints, tt.groupToRemove, tt.currentActiveGroups)
+			if !slices.Equal(result.RemainingGroups, tt.wantRemainingGroups) {
+				t.Errorf("RemainingGroups = %v, want %v", result.RemainingGroups, tt.wantRemainingGroups)
+			}
+			got := result.Endpoints
+			if len(got) == 0 && len(tt.wantImpacts) == 0 {
+				return
+			}
+			if len(got) != len(tt.wantImpacts) {
+				t.Fatalf("AnalyseGroupRemovalImpact() returned %d impacts, want %d\ngot: %+v", len(got), len(tt.wantImpacts), got)
+			}
+			for i, want := range tt.wantImpacts {
+				if got[i].DNSName != want.DNSName {
+					t.Errorf("impact[%d].DNSName = %s, want %s", i, got[i].DNSName, want.DNSName)
+				}
+				if got[i].RecordType != want.RecordType {
+					t.Errorf("impact[%d].RecordType = %s, want %s", i, got[i].RecordType, want.RecordType)
+				}
+				if got[i].Action != want.Action {
+					t.Errorf("impact[%d].Action = %s, want %s", i, got[i].Action, want.Action)
+				}
+				if !slices.Equal(got[i].OldTargets, want.OldTargets) {
+					t.Errorf("impact[%d].OldTargets = %v, want %v", i, got[i].OldTargets, want.OldTargets)
+				}
+				if !slices.Equal(got[i].NewTargets, want.NewTargets) {
+					t.Errorf("impact[%d].NewTargets = %v, want %v", i, got[i].NewTargets, want.NewTargets)
+				}
 			}
 		})
 	}

--- a/internal/common/registry.go
+++ b/internal/common/registry.go
@@ -1,0 +1,8 @@
+package common
+
+const (
+	TxtRegistryPrefix              = "kuadrant-"
+	TxtRegistrySuffix              = ""
+	TxtRegistryWildcardReplacement = "wildcard"
+	TxtRegistryEncryptAESKey       = ""
+)

--- a/internal/controller/base_dnsrecord_reconciler.go
+++ b/internal/controller/base_dnsrecord_reconciler.go
@@ -20,6 +20,7 @@ import (
 	externaldnsprovider "sigs.k8s.io/external-dns/provider"
 	externaldnsregistry "sigs.k8s.io/external-dns/registry"
 
+	"github.com/kuadrant/dns-operator/internal/common"
 	"github.com/kuadrant/dns-operator/internal/external-dns/plan"
 	"github.com/kuadrant/dns-operator/internal/external-dns/registry"
 	"github.com/kuadrant/dns-operator/internal/provider"
@@ -137,9 +138,9 @@ func (r *BaseDNSRecordReconciler) applyChanges(ctx context.Context, dnsRecord DN
 	var excludeDNSRecordTypes []string
 
 	var recordRegistry externaldnsregistry.Registry
-	recordRegistry, err := registry.NewTXTRegistry(ctx, dnsProvider, txtRegistryPrefix, txtRegistrySuffix,
-		dnsRecord.GetOwnerID(), txtRegistryCacheInterval, txtRegistryWildcardReplacement, managedDNSRecordTypes,
-		excludeDNSRecordTypes, txtRegistryEncryptEnabled, []byte(txtRegistryEncryptAESKey))
+	recordRegistry, err := registry.NewTXTRegistry(ctx, dnsProvider, common.TxtRegistryPrefix, common.TxtRegistrySuffix,
+		dnsRecord.GetOwnerID(), txtRegistryCacheInterval, common.TxtRegistryWildcardReplacement, managedDNSRecordTypes,
+		excludeDNSRecordTypes, txtRegistryEncryptEnabled, []byte(common.TxtRegistryEncryptAESKey))
 	if err != nil {
 		return false, err
 	}

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -50,12 +50,8 @@ const (
 	DelegationRolePrimary   = "primary"
 	DelegationRoleSecondary = "secondary"
 
-	txtRegistryPrefix              = "kuadrant-"
-	txtRegistrySuffix              = ""
-	txtRegistryWildcardReplacement = "wildcard"
-	txtRegistryEncryptEnabled      = false
-	txtRegistryEncryptAESKey       = ""
-	txtRegistryCacheInterval       = time.Duration(0)
+	txtRegistryEncryptEnabled = false
+	txtRegistryCacheInterval  = time.Duration(0)
 )
 
 var (

--- a/internal/controller/dnsrecord_groups.go
+++ b/internal/controller/dnsrecord_groups.go
@@ -76,6 +76,7 @@ import (
 	"sigs.k8s.io/external-dns/plan"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common"
 	externaldnsplan "github.com/kuadrant/dns-operator/internal/external-dns/plan"
 	"github.com/kuadrant/dns-operator/internal/external-dns/registry"
 	externaldnsregistry "github.com/kuadrant/dns-operator/internal/external-dns/registry"
@@ -398,7 +399,7 @@ func (r *BaseDNSRecordReconciler) unpublishInactiveGroups(ctx context.Context, c
 	if err != nil {
 		return err
 	}
-	registryMap := externaldnsregistry.TxtRecordsToRegistryMap(allZoneEndpoints, txtRegistryPrefix, txtRegistrySuffix, txtRegistryWildcardReplacement, []byte(txtRegistryEncryptAESKey))
+	registryMap := externaldnsregistry.TxtRecordsToRegistryMap(allZoneEndpoints, common.TxtRegistryPrefix, common.TxtRegistrySuffix, common.TxtRegistryWildcardReplacement, []byte(common.TxtRegistryEncryptAESKey))
 	changes := &plan.Changes{}
 
 	// work out required changes to clean out inactive groups managed DNS Records (not including TXT records)
@@ -420,13 +421,13 @@ func (r *BaseDNSRecordReconciler) unpublishInactiveGroups(ctx context.Context, c
 			continue
 		}
 
-		// inactive targets is the targets of all inactive groups
 		inactiveTargets := registryHost.GetOtherGroupsTargets(activeGroups)
+		activeTargets := registryHost.GetGroupsTargets(activeGroups)
+		ungroupedTargets := registryHost.GetUngroupedTargets()
 
-		// remove all inactive targets from endpoint
 		newTargets := []string{}
 		for _, t := range endpoint.Targets {
-			if !slices.Contains(inactiveTargets, t) {
+			if !slices.Contains(inactiveTargets, t) || slices.Contains(activeTargets, t) || slices.Contains(ungroupedTargets, t) {
 				newTargets = append(newTargets, t)
 			}
 		}
@@ -466,7 +467,7 @@ func (r *BaseDNSRecordReconciler) unpublishInactiveGroups(ctx context.Context, c
 		labels := make(map[string]string)
 		for _, target := range e.Targets {
 			var labelsFromTarget endpoint.Labels
-			_, _, labelsFromTarget, err = registry.NewLabelsFromString(target, []byte(txtRegistryEncryptAESKey))
+			_, _, labelsFromTarget, err = registry.NewLabelsFromString(target, []byte(common.TxtRegistryEncryptAESKey))
 			if err != nil {
 				logger.V(1).Info("failed to parse labels from TXT target", "target", target, "error", err)
 				continue

--- a/internal/controller/helper_test.go
+++ b/internal/controller/helper_test.go
@@ -20,6 +20,7 @@ import (
 	externaldnsendpoint "sigs.k8s.io/external-dns/endpoint"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/common"
 	externaldnsregistry "github.com/kuadrant/dns-operator/internal/external-dns/registry"
 	"github.com/kuadrant/dns-operator/internal/provider"
 	inmemoryprovider "github.com/kuadrant/dns-operator/internal/provider/inmemory"
@@ -175,7 +176,7 @@ func readAuthoritativeRegistryMap(ctx context.Context, k8sClient client.Client, 
 	for _, record := range authRecordList.Items {
 		endpoints = append(endpoints, record.Spec.Endpoints...)
 	}
-	return externaldnsregistry.TxtRecordsToRegistryMap(endpoints, txtRegistryPrefix, txtRegistrySuffix, txtRegistryWildcardReplacement, []byte(txtRegistryEncryptAESKey))
+	return externaldnsregistry.TxtRecordsToRegistryMap(endpoints, common.TxtRegistryPrefix, common.TxtRegistrySuffix, common.TxtRegistryWildcardReplacement, []byte(common.TxtRegistryEncryptAESKey))
 }
 
 // filterDNSEndpoints returns only A, AAAA, and CNAME endpoints from a record list.

--- a/internal/external-dns/registry/group.go
+++ b/internal/external-dns/registry/group.go
@@ -143,7 +143,7 @@ func (h *RegistryHost) HasGroup(group types.Group) bool {
 func (h *RegistryHost) GetUngroupedTargets() []string {
 	targets := map[string]struct{}{}
 	for _, o := range h.UngroupedOwners {
-		for _, t := range strings.Split(o.Labels["targets"], ",") {
+		for _, t := range strings.Split(o.Labels["targets"], ";") {
 			if t != "" {
 				targets[t] = struct{}{}
 			}
@@ -188,7 +188,7 @@ func (g *RegistryGroup) GetOwnerIDs() []string {
 func (g *RegistryGroup) GetTargets() []string {
 	targets := map[string]struct{}{}
 	for _, o := range g.Owners {
-		for _, t := range strings.Split(o.Labels["targets"], ",") {
+		for _, t := range strings.Split(o.Labels["targets"], ";") {
 			if t != "" {
 				targets[t] = struct{}{}
 			}


### PR DESCRIPTION
## Summary
- Adds a `--dry-run` flag to the `remove-active-group` CLI command that previews the impact of removing a failover group without making DNS changes
- Uses the TXT registry data structure to analyse which DNS endpoints would be deleted or modified, displaying results in a table
- Refactors confirmation prompt to use the shared `inputYes` helper for consistency with `add-active-group`

Closes #782

## Test plan
- [x] Unit tests for `AnalyseGroupRemovalImpact` covering: empty endpoints, single-group DELETE, remaining-group no-impact, mixed-group MODIFY, ungrouped-owner preservation, non-managed record type filtering, no-registry-entry filtering, multiple endpoints
- [x] `RemainingGroups` field assertions in all test cases
- [x] `go build`, `go vet`, `make test-unit` all pass
- [x] Verify `--dry-run` flag is registered with help text
- [x] Verify no DNS mutations occur in dry-run path (`continue` before `ApplyChanges`)
- [ ] Manual test: run `remove-active-group --dry-run` against a real provider to verify output formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry-run option to preview active-group removal without making changes.
  * Preview results show whether DNS TXT records would be deleted or updated, along with affected endpoints.
* **Bug Fixes**
  * Legacy, unrecognised and irrelevant TXT records are now safely skipped.
  * Targets shared with active or ungrouped records are retained during inactive-group cleanup.
  * Improved interactive confirmation handling for active-group removal.
  * Improved parsing of target lists in registry records.
* **Tests**
  * Added coverage for endpoint deletion, updates, retention, ignored records and multiple affected endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->