### PR TITLE
feat: add group-aware Prometheus metrics for DNS Failover

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/onsi/gomega v1.36.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
+	github.com/prometheus/client_model v0.6.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
@@ -87,7 +88,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/internal/controller/dnsrecord_groups.go
+++ b/internal/controller/dnsrecord_groups.go
@@ -79,6 +79,7 @@ import (
 	externaldnsplan "github.com/kuadrant/dns-operator/internal/external-dns/plan"
 	"github.com/kuadrant/dns-operator/internal/external-dns/registry"
 	externaldnsregistry "github.com/kuadrant/dns-operator/internal/external-dns/registry"
+	"github.com/kuadrant/dns-operator/internal/metrics"
 	"github.com/kuadrant/dns-operator/internal/provider"
 	"github.com/kuadrant/dns-operator/types"
 )
@@ -444,6 +445,7 @@ func (r *BaseDNSRecordReconciler) unpublishInactiveGroups(ctx context.Context, c
 		}
 	}
 
+	hadCleanup := false
 	if changes.HasChanges() {
 		// changes against provider directly, as using the registry here
 		// would interfere with this controllers registry entries incorrectly.
@@ -452,6 +454,7 @@ func (r *BaseDNSRecordReconciler) unpublishInactiveGroups(ctx context.Context, c
 			logger.Error(err, "error unpublishing inactive group records")
 			return err
 		}
+		hadCleanup = true
 	}
 
 	// Clean out all TXT records that are registry entries for inactive groups,
@@ -482,7 +485,18 @@ func (r *BaseDNSRecordReconciler) unpublishInactiveGroups(ctx context.Context, c
 
 	if changes.HasChanges() {
 		err = dnsProvider.ApplyChanges(ctx, changes)
-		return err
+		if err != nil {
+			return err
+		}
+		hadCleanup = true
+	}
+
+	if hadCleanup {
+		metrics.IncInactiveGroupCleanup(
+			dnsRecord.GetDNSRecord().Name,
+			dnsRecord.GetDNSRecord().Namespace,
+			string(dnsRecord.GetGroup()),
+		)
 	}
 
 	return nil

--- a/internal/controller/dnsrecord_groups_unit_test.go
+++ b/internal/controller/dnsrecord_groups_unit_test.go
@@ -1,0 +1,159 @@
+//go:build unit
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/internal/metrics"
+	internalprovider "github.com/kuadrant/dns-operator/internal/provider"
+	"github.com/kuadrant/dns-operator/types"
+)
+
+type stubProvider struct {
+	endpoints []*endpoint.Endpoint
+	applied   []*plan.Changes
+}
+
+func (s *stubProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	return s.endpoints, nil
+}
+
+func (s *stubProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	s.applied = append(s.applied, changes)
+	return nil
+}
+
+func (s *stubProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	return endpoints, nil
+}
+
+func (s *stubProvider) GetDomainFilter() endpoint.DomainFilter {
+	return endpoint.DomainFilter{}
+}
+
+func (s *stubProvider) DNSZones(ctx context.Context) ([]internalprovider.DNSZone, error) {
+	return nil, nil
+}
+
+func (s *stubProvider) DNSZoneForHost(ctx context.Context, host string) (*internalprovider.DNSZone, error) {
+	return nil, nil
+}
+
+func (s *stubProvider) ProviderSpecific() internalprovider.ProviderSpecificLabels {
+	return internalprovider.ProviderSpecificLabels{}
+}
+
+func (s *stubProvider) Name() internalprovider.DNSProviderName {
+	return "stub"
+}
+
+func (s *stubProvider) Labels() map[string]string {
+	return nil
+}
+
+type stubTXTResolver struct {
+	groups string
+}
+
+func (s *stubTXTResolver) LookupTXT(ctx context.Context, host string, nameservers []string) ([]string, error) {
+	if s.groups != "" {
+		return []string{s.groups}, nil
+	}
+	return nil, nil
+}
+
+func getCleanupCounter(name, namespace, group string) float64 {
+	counter, err := metrics.GetInactiveGroupCleanupMetric(name, namespace, group)
+	if err != nil || counter == nil {
+		return 0
+	}
+	pb := &dto.Metric{}
+	_ = counter.Write(pb)
+	return pb.Counter.GetValue()
+}
+
+func TestUnpublishInactiveGroups_TXTOnlyCleanup(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctx := log.IntoContext(context.Background(), log.Log)
+
+	metrics.ResetInactiveGroupCleanup()
+
+	record := &v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-record",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			RootHost: "foo.example.com",
+		},
+		Status: v1alpha1.DNSRecordStatus{
+			Group:          types.Group("active-group"),
+			ZoneDomainName: "example.com",
+		},
+	}
+	accessor := &DNSRecord{DNSRecord: record}
+
+	prov := &stubProvider{
+		endpoints: []*endpoint.Endpoint{
+			// TXT registry entry for an inactive group — should be deleted
+			{
+				DNSName:    "kuadrant-foo.example.com",
+				RecordType: "TXT",
+				Targets:    []string{"\"heritage=external-dns,external-dns/owner=owner1,external-dns/group=old-group\""},
+			},
+			// TXT registry entry for the active group — should be kept
+			{
+				DNSName:    "kuadrant-foo.example.com",
+				RecordType: "TXT",
+				Targets:    []string{"\"heritage=external-dns,external-dns/owner=owner2,external-dns/group=active-group\""},
+			},
+		},
+	}
+
+	reconciler := &BaseDNSRecordReconciler{
+		TXTResolver: &stubTXTResolver{
+			groups: "groups=active-group",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().Build()
+
+	err := reconciler.unpublishInactiveGroups(ctx, fakeClient, accessor, prov)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify only TXT phase applied changes (no DNS record changes)
+	if len(prov.applied) != 1 {
+		t.Fatalf("expected 1 ApplyChanges call (TXT-only), got %d", len(prov.applied))
+	}
+	if len(prov.applied[0].Delete) != 1 {
+		t.Fatalf("expected 1 TXT record deleted, got %d", len(prov.applied[0].Delete))
+	}
+	deleted := prov.applied[0].Delete[0]
+	if deleted.DNSName != "kuadrant-foo.example.com" {
+		t.Errorf("expected deleted TXT record for kuadrant-foo.example.com, got %s", deleted.DNSName)
+	}
+	if len(deleted.Targets) == 0 || !strings.Contains(deleted.Targets[0], "external-dns/group=old-group") {
+		t.Errorf("expected deleted TXT target to contain external-dns/group=old-group, got %v", deleted.Targets)
+	}
+
+	// Verify the cleanup metric was incremented
+	val := getCleanupCounter("test-record", "test-ns", "active-group")
+	if val != 1 {
+		t.Errorf("expected cleanup counter to be 1, got %f", val)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,11 +10,44 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	kubeconfigprovider "sigs.k8s.io/multicluster-runtime/providers/kubeconfig"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
 	"github.com/kuadrant/dns-operator/internal/common/hash"
 )
+
+var inactiveGroupCleanupTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "dns_record_inactive_group_cleanup_total",
+		Help: "Counts cleanup operations that remove DNS records or TXT registry entries from inactive groups",
+	},
+	[]string{dnsRecordNameLabel, dnsRecordNamespaceLabel, dnsRecordGroupLabel},
+)
+
+func init() {
+	metrics.Registry.MustRegister(inactiveGroupCleanupTotal)
+}
+
+func IncInactiveGroupCleanup(name, namespace, group string) {
+	inactiveGroupCleanupTotal.With(prometheus.Labels{
+		dnsRecordNameLabel:      name,
+		dnsRecordNamespaceLabel: namespace,
+		dnsRecordGroupLabel:     group,
+	}).Inc()
+}
+
+func ResetInactiveGroupCleanup() {
+	inactiveGroupCleanupTotal.Reset()
+}
+
+func GetInactiveGroupCleanupMetric(name, namespace, group string) (prometheus.Counter, error) {
+	return inactiveGroupCleanupTotal.GetMetricWith(prometheus.Labels{
+		dnsRecordNameLabel:      name,
+		dnsRecordNamespaceLabel: namespace,
+		dnsRecordGroupLabel:     group,
+	})
+}
 
 const (
 	dnsRecordNameLabel           = "dns_record_name"

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -75,6 +75,12 @@ var (
 		[]string{dnsRecordNameLabel, dnsRecordNamespaceLabel, dnsRecordGroupLabel},
 		nil,
 	)
+	recordGroupActive = prometheus.NewDesc(
+		"dns_record_group_active",
+		"Reports whether each DNSRecord is active (1) or inactive (0)",
+		[]string{dnsRecordNameLabel, dnsRecordNamespaceLabel, dnsRecordGroupLabel},
+		nil,
+	)
 	multiClusterCount = prometheus.NewDesc(
 		"dns_provider_active_multi_cluster_count",
 		"Reports the number of secrets configured for multi cluster configuration",
@@ -98,6 +104,22 @@ func recordGroupInfoMetric(ch chan<- prometheus.Metric, record v1alpha1.DNSRecor
 		recordGroupInfo,
 		prometheus.GaugeValue,
 		1,
+		record.Name,
+		record.Namespace,
+		string(record.Status.Group),
+	)
+}
+
+func recordGroupActiveMetric(ch chan<- prometheus.Metric, record v1alpha1.DNSRecord) {
+	active := meta.IsStatusConditionTrue(record.Status.Conditions, string(v1alpha1.ConditionTypeActive))
+	var gauge float64
+	if active {
+		gauge = 1
+	}
+	ch <- prometheus.MustNewConstMetric(
+		recordGroupActive,
+		prometheus.GaugeValue,
+		gauge,
 		record.Name,
 		record.Namespace,
 		string(record.Status.Group),
@@ -295,6 +317,7 @@ func (c *LocalCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- authoritativeRecordSpecInfo
 	ch <- recordReady
 	ch <- recordGroupInfo
+	ch <- recordGroupActive
 }
 
 func (c *LocalCollector) Collect(ch chan<- prometheus.Metric) {
@@ -313,6 +336,7 @@ func (c *LocalCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, record := range dnsRecordList.Items {
 		recordReadyMetric(ch, record)
 		recordGroupInfoMetric(ch, record)
+		recordGroupActiveMetric(ch, record)
 		writeCounterMetric(ch, record)
 		if record.IsAuthoritativeRecord() {
 			specString, err := hash.GetCanonicalString(record.Spec)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,6 +24,7 @@ const (
 	dnsHealthCheckNameLabel      = "dns_health_check_name"
 	dnsHealthCheckNamespaceLabel = "dns_health_check_namespace"
 	dnsHealthCheckHostLabel      = "dns_health_check_host"
+	dnsRecordGroupLabel          = "group"
 )
 
 var (
@@ -68,6 +69,12 @@ var (
 		[]string{"root_host", "sha", dnsRecordNameLabel, dnsRecordNamespaceLabel},
 		nil,
 	)
+	recordGroupInfo = prometheus.NewDesc(
+		"dns_record_group_info",
+		"Reports the group assignment for each DNSRecord",
+		[]string{dnsRecordNameLabel, dnsRecordNamespaceLabel, dnsRecordGroupLabel},
+		nil,
+	)
 	multiClusterCount = prometheus.NewDesc(
 		"dns_provider_active_multi_cluster_count",
 		"Reports the number of secrets configured for multi cluster configuration",
@@ -83,6 +90,17 @@ func writeCounterMetric(ch chan<- prometheus.Metric, record v1alpha1.DNSRecord) 
 		float64(record.Status.WriteCounter),
 		record.Name,
 		record.Namespace,
+	)
+}
+
+func recordGroupInfoMetric(ch chan<- prometheus.Metric, record v1alpha1.DNSRecord) {
+	ch <- prometheus.MustNewConstMetric(
+		recordGroupInfo,
+		prometheus.GaugeValue,
+		1,
+		record.Name,
+		record.Namespace,
+		string(record.Status.Group),
 	)
 }
 
@@ -276,6 +294,7 @@ type LocalCollector struct {
 func (c *LocalCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- authoritativeRecordSpecInfo
 	ch <- recordReady
+	ch <- recordGroupInfo
 }
 
 func (c *LocalCollector) Collect(ch chan<- prometheus.Metric) {
@@ -293,6 +312,7 @@ func (c *LocalCollector) Collect(ch chan<- prometheus.Metric) {
 
 	for _, record := range dnsRecordList.Items {
 		recordReadyMetric(ch, record)
+		recordGroupInfoMetric(ch, record)
 		writeCounterMetric(ch, record)
 		if record.IsAuthoritativeRecord() {
 			specString, err := hash.GetCanonicalString(record.Spec)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,99 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
+	"github.com/kuadrant/dns-operator/types"
+)
+
+func collectMetrics(ch chan prometheus.Metric) []*dto.Metric {
+	var results []*dto.Metric
+	for m := range ch {
+		pb := &dto.Metric{}
+		_ = m.Write(pb)
+		results = append(results, pb)
+	}
+	return results
+}
+
+func labelValue(m *dto.Metric, name string) string {
+	for _, lp := range m.Label {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func TestRecordGroupInfoMetric_Grouped(t *testing.T) {
+	record := v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-record",
+			Namespace: "test-ns",
+		},
+		Status: v1alpha1.DNSRecordStatus{
+			Group: types.Group("us-east"),
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	recordGroupInfoMetric(ch, record)
+	close(ch)
+
+	metrics := collectMetrics(ch)
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if got := m.Gauge.GetValue(); got != 1 {
+		t.Errorf("expected gauge value 1, got %f", got)
+	}
+	if got := labelValue(m, "dns_record_name"); got != "test-record" {
+		t.Errorf("expected dns_record_name=test-record, got %s", got)
+	}
+	if got := labelValue(m, "dns_record_namespace"); got != "test-ns" {
+		t.Errorf("expected dns_record_namespace=test-ns, got %s", got)
+	}
+	if got := labelValue(m, "group"); got != "us-east" {
+		t.Errorf("expected group=us-east, got %s", got)
+	}
+}
+
+func TestRecordGroupInfoMetric_Ungrouped(t *testing.T) {
+	record := v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ungrouped-record",
+			Namespace: "default",
+		},
+		Status: v1alpha1.DNSRecordStatus{},
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	recordGroupInfoMetric(ch, record)
+	close(ch)
+
+	metrics := collectMetrics(ch)
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if got := m.Gauge.GetValue(); got != 1 {
+		t.Errorf("expected gauge value 1, got %f", got)
+	}
+	if got := labelValue(m, "dns_record_name"); got != "ungrouped-record" {
+		t.Errorf("expected dns_record_name=ungrouped-record, got %s", got)
+	}
+	if got := labelValue(m, "dns_record_namespace"); got != "default" {
+		t.Errorf("expected dns_record_namespace=default, got %s", got)
+	}
+	if got := labelValue(m, "group"); got != "" {
+		t.Errorf("expected group to be empty, got %s", got)
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -97,3 +97,106 @@ func TestRecordGroupInfoMetric_Ungrouped(t *testing.T) {
 		t.Errorf("expected group to be empty, got %s", got)
 	}
 }
+
+func TestRecordGroupActiveMetric_Active(t *testing.T) {
+	record := v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "active-record",
+			Namespace: "test-ns",
+		},
+		Status: v1alpha1.DNSRecordStatus{
+			Group: types.Group("us-east"),
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(v1alpha1.ConditionTypeActive),
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	recordGroupActiveMetric(ch, record)
+	close(ch)
+
+	metrics := collectMetrics(ch)
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if got := m.Gauge.GetValue(); got != 1 {
+		t.Errorf("expected gauge value 1, got %f", got)
+	}
+	if got := labelValue(m, "dns_record_name"); got != "active-record" {
+		t.Errorf("expected dns_record_name=active-record, got %s", got)
+	}
+	if got := labelValue(m, "dns_record_namespace"); got != "test-ns" {
+		t.Errorf("expected dns_record_namespace=test-ns, got %s", got)
+	}
+	if got := labelValue(m, "group"); got != "us-east" {
+		t.Errorf("expected group=us-east, got %s", got)
+	}
+}
+
+func TestRecordGroupActiveMetric_Inactive(t *testing.T) {
+	record := v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inactive-record",
+			Namespace: "test-ns",
+		},
+		Status: v1alpha1.DNSRecordStatus{
+			Group: types.Group("us-west"),
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(v1alpha1.ConditionTypeActive),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	recordGroupActiveMetric(ch, record)
+	close(ch)
+
+	metrics := collectMetrics(ch)
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if got := m.Gauge.GetValue(); got != 0 {
+		t.Errorf("expected gauge value 0, got %f", got)
+	}
+	if got := labelValue(m, "group"); got != "us-west" {
+		t.Errorf("expected group=us-west, got %s", got)
+	}
+}
+
+func TestRecordGroupActiveMetric_Ungrouped(t *testing.T) {
+	record := v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ungrouped-record",
+			Namespace: "default",
+		},
+		Status: v1alpha1.DNSRecordStatus{},
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	recordGroupActiveMetric(ch, record)
+	close(ch)
+
+	metrics := collectMetrics(ch)
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if got := m.Gauge.GetValue(); got != 0 {
+		t.Errorf("expected gauge value 0 for ungrouped record (no Active condition), got %f", got)
+	}
+	if got := labelValue(m, "group"); got != "" {
+		t.Errorf("expected group to be empty, got %s", got)
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package metrics
 
 import (
@@ -5,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kuadrant/dns-operator/api/v1alpha1"
@@ -198,5 +201,41 @@ func TestRecordGroupActiveMetric_Ungrouped(t *testing.T) {
 	}
 	if got := labelValue(m, "group"); got != "" {
 		t.Errorf("expected group to be empty, got %s", got)
+	}
+}
+
+func TestIncInactiveGroupCleanup(t *testing.T) {
+	inactiveGroupCleanupTotal.Reset()
+
+	IncInactiveGroupCleanup("test-record", "test-ns", "us-east")
+	IncInactiveGroupCleanup("test-record", "test-ns", "us-east")
+	IncInactiveGroupCleanup("other-record", "test-ns", "us-west")
+
+	m1, err := inactiveGroupCleanupTotal.GetMetricWith(prometheus.Labels{
+		"dns_record_name":      "test-record",
+		"dns_record_namespace": "test-ns",
+		"group":                "us-east",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pb1 := &dto.Metric{}
+	_ = m1.Write(pb1)
+	if got := pb1.Counter.GetValue(); got != 2 {
+		t.Errorf("expected counter value 2 for us-east, got %f", got)
+	}
+
+	m2, err := inactiveGroupCleanupTotal.GetMetricWith(prometheus.Labels{
+		"dns_record_name":      "other-record",
+		"dns_record_namespace": "test-ns",
+		"group":                "us-west",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pb2 := &dto.Metric{}
+	_ = m2.Write(pb2)
+	if got := pb2.Counter.GetValue(); got != 1 {
+		t.Errorf("expected counter value 1 for us-west, got %f", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `dns_record_group_info` gauge reporting each DNSRecord's group assignment (#816)
- Add `dns_record_group_active` gauge reporting active (1) / inactive (0) state per DNSRecord (#817)
- Add `dns_record_inactive_group_cleanup_total` counter tracking cleanup operations on inactive groups (#818)

All metrics are emitted via the existing `LocalCollector` (gauges) or direct registration (counter) and scraped by the existing ServiceMonitor. Unit tests cover all metric emission paths.

Part of #776 — DNS Failover via Groups — Tech Preview (User Story 2: Group-aware observability).

## Test plan

- [x] Unit tests for `dns_record_group_info` (grouped and ungrouped records)
- [x] Unit tests for `dns_record_group_active` (active, inactive, and ungrouped records)
- [x] Unit tests for `dns_record_inactive_group_cleanup_total` (counter increment with multiple label combinations)
- [ ] `go vet` passes on affected packages
- [ ] Verify metrics appear on `/metrics` endpoint in a running cluster

Closes #816
Closes #817
Closes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics showing DNS record group assignments and whether groups are active.
  * Added a counter for successful inactive-group DNS and TXT cleanup operations, including record and group details.

* **Tests**
  * Added coverage for grouped, ungrouped, active, and inactive DNS record states.
  * Added validation that inactive TXT entries are removed while active entries remain.
  * Added checks for cleanup counter increments across multiple label sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->