### PR TITLE
fix: restore 1s requeue for deletion status update

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -173,7 +173,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		dnsRecord.SetStatusZoneID("")
 		dnsRecord.SetStatusDomainOwners(nil)
 
-		return r.updateStatusAndRequeue(ctx, r.Client, previous, dnsRecord, defaultValidationRequeue)
+		return r.updateStatusAndRequeue(ctx, r.Client, previous, dnsRecord, time.Second)
 	}
 
 	if !controllerutil.ContainsFinalizer(dnsRecord.GetDNSRecord(), DNSRecordFinalizer) {


### PR DESCRIPTION
## Summary

- Restores `time.Second` requeue duration for the `ProviderEndpointsRemoved` status update during deletion, which was inadvertently changed to `defaultValidationRequeue` (5s) in #778

## Context

The refactor in #778 replaced all requeue durations with `defaultValidationRequeue` (5s), including the final deletion status update that previously used `time.Second`. Combined with the new watch predicate (`GenerationChangedPredicate || deletingPredicate`) that filters status-only update events, this slows deletion cleanup: the controller must wait for the full `RequeueAfter` rather than being immediately re-triggered by the watch.

This causes consistent timeouts in the kuadrant-operator integration tests, where the `AfterEach` cleanup waits for DNSRecords to be fully deleted within a 10-second window. The DNSRecord gets stuck with its finalizer because the deletion state machine takes multiple requeue cycles at 5s each.

## Test plan

- [x] Verified locally: kuadrant-operator integration tests (envoygateway, 31/31 DNS specs) pass with this fix
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS record deletion cleanup by retrying status updates after one second, enabling faster completion of cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->