### PR TITLE
fix(ci): switch image builds to docker buildx

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
         id: go
       - name: Install yq tool
         run: make yq
@@ -130,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-tags: ${{ github.ref_name }}
-      image: ${{ steps.build-catalog-image.outputs.imageid }}
+      image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog:${{ github.ref_name }}
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
@@ -152,9 +153,12 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
         id: go
       - name: Generate Catalog Content
         run: make catalog
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # ratchet:docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -133,8 +133,8 @@ jobs:
     needs: [build, build-bundle]
     runs-on: ubuntu-latest
     outputs:
-      build-tags: ${{ steps.build-image.outputs.tags }}
-      image: ${{ steps.push-to-quay.outputs.registry-path }}
+      build-tags: ${{ github.ref_name }}
+      image: ${{ steps.build-catalog-image.outputs.imageid }}
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
@@ -152,40 +152,44 @@ jobs:
       - name: Verify referenced bundle tag matches the bundle tag currently being built
         if: ${{ needs.build-bundle.outputs.image != steps.parsed-operator-bundle.outputs.image }}
         run: exit 1
-      - name: Run make catalog-build
-        run: make catalog-build
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
-          image: ${{ env.OPERATOR_NAME }}-catalog
-          tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-          context: ./tmp/catalog
-          dockerfiles: |
-            ./tmp/catalog/index.Dockerfile
-
-      - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ steps.parsed-operator-bundle.outputs.image }}"
-
-      - name: Push Image
+          go-version-file: go.mod
+        id: go
+      - name: Generate Catalog Content
+        run: make catalog
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
+      - name: Login to container registry
         if: github.repository_owner == 'kuadrant'
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Extract metadata
+        id: catalog-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+      - name: Build and Push Catalog Image
+        id: build-catalog-image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: ./catalog
+          file: ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: ${{ github.repository_owner == 'kuadrant' }}
+          provenance: false
+          tags: ${{ steps.catalog-meta.outputs.tags }}
+          build-args: QUAY_IMAGE_EXPIRY=never
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          echo "Image(s) pushed:"
+          echo "${{ steps.catalog-meta.outputs.tags }}"
 
   verify-builds:
     name: Ensure all image references are equal (operator, bundle, catalog)

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -15,75 +15,73 @@ jobs:
     name: Build and Push image
     runs-on: ubuntu-latest
     outputs:
-      build-tags: ${{ steps.build-image.outputs.tags }}
-      image: ${{ steps.push-to-quay.outputs.registry-path }}
+      build-tags: ${{ github.ref_name }}
+      image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ github.ref_name }}
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
-
       - name: Read release string version
         id: release
         run: |
           version=`make read-release-version`
           echo version=$version >> $GITHUB_OUTPUT
-
       - name: Print tags
         run: echo "Git reference name = ${{ github.ref_name }}, release version = ${{ steps.release.outputs.version }}"
       - name: Verify git reference name matches the release version
         if: ${{ github.ref_name != steps.release.outputs.version }}
         run: exit 1
-
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
+      - name: Login to container registry
+        if: github.repository_owner == 'kuadrant'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
-          image: ${{ env.OPERATOR_NAME }}
-          tags: ${{ github.ref_name }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+      - name: Build and Push Image
+        id: build-image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: ${{ github.repository_owner == 'kuadrant' }}
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GIT_SHA=${{ github.sha }}
             DIRTY=false
             VERSION=${{ github.ref_name }}
-
-          dockerfiles: |
-            ./Dockerfile
-
-      - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}"
-
-      - name: Push Image
-        if: github.repository_owner == 'kuadrant'
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
-          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
-          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          echo "Image(s) pushed:"
+          echo "${{ steps.meta.outputs.tags }}"
 
   build-bundle:
     name: Build and Push bundle image
     needs: [build]
     runs-on: ubuntu-latest
     outputs:
-      build-tags: ${{ steps.build-image.outputs.tags }}
-      image: ${{ steps.push-to-quay.outputs.registry-path }}
+      build-tags: ${{ github.ref_name }}
+      image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle:${{ github.ref_name }}
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        id: go
       - name: Install yq tool
-        run: |
-          # following sub-shells running make target should have yq already installed
-          make yq
+        run: make yq
       - name: Read operator image reference URL from the manifest bundle
         id: parsed-operator-image
         run: |
@@ -94,39 +92,37 @@ jobs:
       - name: Verify referenced operator image tag matches the tag currently being built
         if: ${{ needs.build.outputs.image != steps.parsed-operator-image.outputs.url }}
         run: exit 1
-
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.OPERATOR_NAME }}-bundle
-          tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-          build-args: QUAY_IMAGE_EXPIRY=never
-          dockerfiles: |
-            ./bundle.Dockerfile
-
-      - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ steps.parsed-operator-image.outputs.url }}"
-
-      - name: Push Image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
+      - name: Login to container registry
         if: github.repository_owner == 'kuadrant'
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Extract metadata
+        id: bundle-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+      - name: Build and Push Bundle Image
+        id: build-bundle-image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: .
+          file: ./bundle.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: ${{ github.repository_owner == 'kuadrant' }}
+          provenance: false
+          tags: ${{ steps.bundle-meta.outputs.tags }}
+          build-args: QUAY_IMAGE_EXPIRY=never
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          echo "Image(s) pushed:"
+          echo "${{ steps.bundle-meta.outputs.tags }}"
 
   build-catalog:
     name: Build and Push catalog image

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -127,39 +127,44 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
-
-      - name: Run make catalog-build
-        run: make catalog-build BUNDLE_IMG=${{ needs.build-bundle.outputs.bundle-image }}
-
-      - name: Install qemu dependency
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        id: go
+      - name: Generate Catalog Content
         run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.OPERATOR_NAME }}-catalog
-          tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-          context: ./tmp/catalog
-          dockerfiles: |
-            ./tmp/catalog/index.Dockerfile
-
-      - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Bundle IMG = ${{ needs.build-bundle.outputs.bundle-image }}"
-
-      - name: Push Image
+          make catalog \
+            BUNDLE_IMG=${{ needs.build-bundle.outputs.bundle-image }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
+      - name: Login to container registry
         if: github.repository_owner == 'kuadrant'
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Extract metadata
+        id: catalog-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=latest,enable=${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+      - name: Build and Push Catalog Image
+        id: build-catalog-image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: ./catalog
+          file: ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: ${{ github.repository_owner == 'kuadrant' }}
+          provenance: false
+          tags: ${{ steps.catalog-meta.outputs.tags }}
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          echo "Image(s) pushed:"
+          echo "${{ steps.catalog-meta.outputs.tags }}"

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
         id: go
       - name: Run make bundle
         run: make bundle IMG=${{ needs.build.outputs.build-image }}
@@ -125,11 +126,14 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
         id: go
       - name: Generate Catalog Content
         run: |
           make catalog \
             BUNDLE_IMG=${{ needs.build-bundle.outputs.bundle-image }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # ratchet:docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
 
 env:
-  IMG_TAGS: ${{ github.sha }} ${{ github.ref_name }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   IMG_REGISTRY_REPO: dns-operator
@@ -20,105 +19,100 @@ jobs:
     name: Build and Push image
     runs-on: ubuntu-latest
     outputs:
-      build-tags: ${{ steps.build-image.outputs.tags }}
-      build-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
+      build-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ github.sha }}
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
-
       - name: Read release string version
         id: release
         run: |
           version=`make read-release-version`
           echo version=$version >> $GITHUB_OUTPUT
-
-      - name: Add latest tag
-        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
-        id: add-latest-tag
-        run: |
-          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
+      - name: Login to container registry
+        if: github.repository_owner == 'kuadrant'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
-          image: ${{ env.OPERATOR_NAME }}
-          tags: ${{ env.IMG_TAGS }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=latest,enable=${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+      - name: Build and Push Image
+        id: build-image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: ${{ github.repository_owner == 'kuadrant' }}
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GIT_SHA=${{ github.sha }}
             DIRTY=false
             VERSION=${{ steps.release.outputs.version }}
-
-          dockerfiles: |
-            ./Dockerfile
-
-      - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}"
-
-      - name: Push Image
-        if: github.repository_owner == 'kuadrant'
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
-          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
-          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          echo "Image(s) pushed:"
+          echo "${{ steps.meta.outputs.tags }}"
 
   build-bundle:
     name: Build and Push bundle image
     needs: [build]
     runs-on: ubuntu-latest
     outputs:
-      bundle-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ steps.build-image.outputs.image }}:${{ github.sha }}
+      bundle-image: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle:${{ github.sha }}
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
-
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        id: go
       - name: Run make bundle
         run: make bundle IMG=${{ needs.build.outputs.build-image }}
-
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.OPERATOR_NAME }}-bundle
-          tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-          dockerfiles: |
-            ./bundle.Dockerfile
-
-      - name: Print Build Info
-        run: echo "Image = ${{ steps.build-image.outputs.image }}, Tags = ${{ steps.build-image.outputs.tags }}, Operator IMG = ${{ needs.build.outputs.build-image }}"
-
-      - name: Push Image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
+      - name: Login to container registry
         if: github.repository_owner == 'kuadrant'
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Extract metadata
+        id: bundle-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
+        with:
+          images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=latest,enable=${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+      - name: Build and Push Bundle Image
+        id: build-bundle-image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: .
+          file: ./bundle.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: ${{ github.repository_owner == 'kuadrant' }}
+          provenance: false
+          tags: ${{ steps.bundle-meta.outputs.tags }}
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          echo "Image(s) pushed:"
+          echo "${{ steps.bundle-meta.outputs.tags }}"
 
   build-catalog:
     name: Build and Push catalog image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mirror.gcr.io/library/golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary

Brings the dns-operator CI image build workflows in line with authorino-operator, limitador-operator, and kuadrant-operator.

- **Fix broken catalog build**: The `build-catalog` job referenced stale `./tmp/catalog/index.Dockerfile` paths from the pre-FBC era. Switched to `make catalog` + correct `./catalog/dns-operator-catalog.Dockerfile` paths, matching all other operators.
- **Switch from buildah to docker buildx**: Replace `redhat-actions/buildah-build` + `redhat-actions/push-to-registry` with `docker/setup-buildx-action` + `docker/build-push-action` across all three jobs (build, build-bundle, build-catalog) in both `build-images.yaml` and `build-images-for-tag-release.yaml`.
- **Enable cross-compilation**: Add `--platform=$BUILDPLATFORM` to the Dockerfile builder stage so Go compiles natively via `GOARCH` instead of running under QEMU emulation. This is the main speed improvement (ref: limitador-operator commit `865083d`).

## Changes

- `.github/workflows/build-images.yaml` — all three jobs updated
- `.github/workflows/build-images-for-tag-release.yaml` — all three jobs updated
- `Dockerfile` — add `--platform=$BUILDPLATFORM` to builder stage

## Test plan

- [x] Trigger `Build and Publish Images` workflow via `workflow_dispatch` on this branch
- [x] Verify all three jobs (build, build-bundle, build-catalog) pass
- [x] Verify images are tagged correctly (commit SHA, branch name)
- [x] Compare build times against a recent main build

Executed here https://github.com/Kuadrant/dns-operator/actions/runs/32146164367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release**
  * Improved container image builds and publishing for operator, bundle, and catalog images.
  * Added consistent image tags based on commits, branches, releases, and the main branch.
  * Improved build portability across platforms.
  * Updated catalog generation and build metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->