### PR TITLE
fix: resolve PR author and approver for chart sync dispatch

### DIFF
--- a/.github/workflows/dispatch-chart-sync.yaml
+++ b/.github/workflows/dispatch-chart-sync.yaml
@@ -1,7 +1,7 @@
 # Notifies the kuadrant-operator repo when this component's Helm chart changes.
 # Sends a repository_dispatch event containing the component name, source branch,
-# actor, and commit URL. The kuadrant-operator's sync-component-chart workflow
-# receives this event, syncs the updated chart, and creates a PR.
+# PR author/approver, and commit URL. The kuadrant-operator's sync-component-chart
+# workflow receives this event, syncs the updated chart, and creates a PR.
 
 name: Dispatch chart sync
 
@@ -16,6 +16,32 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.KUADRANT_DEV_PAT }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          PR_JSON=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0] // empty')
+          if [ -n "$PR_JSON" ]; then
+            AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+            PR_URL=$(echo "$PR_JSON" | jq -r '.html_url')
+            PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+            APPROVER=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --slurp \
+              | jq -r 'flatten | [.[] | select(.state == "APPROVED")] | sort_by(.submitted_at) | last | .user.login // empty')
+          else
+            AUTHOR="$ACTOR"
+            PR_URL=""
+            APPROVER=""
+          fi
+          {
+            echo "author=$AUTHOR"
+            echo "pr-url=$PR_URL"
+            echo "approver=${APPROVER:-}"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.KUADRANT_DEV_PAT }}
@@ -25,6 +51,8 @@ jobs:
             {
               "component": "dns-operator",
               "ref": "${{ github.ref_name }}",
-              "actor": "${{ github.actor }}",
-              "commit-url": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+              "actor": "${{ steps.pr.outputs.author }}",
+              "commit-url": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}",
+              "pr-url": "${{ steps.pr.outputs.pr-url }}",
+              "pr-approver": "${{ steps.pr.outputs.approver }}"
             }


### PR DESCRIPTION
## Summary

Resolves the PR author and approver from the merge commit via the GitHub API before dispatching the chart sync event to kuadrant-operator. Previously `github.actor` was used, which resolved to `github-merge-queue[bot]` when the merge queue merged a PR — meaning nobody was notified.

Now the dispatch payload includes:
- `actor`: the PR author (resolved from the merge commit's associated PR)
- `pr-url`: link to the upstream PR
- `pr-approver`: the person who approved the PR

Falls back to `github.actor` if no associated PR is found (e.g. direct pushes).

Relates to https://github.com/Kuadrant/dns-operator/pull/810
Relates to https://github.com/Kuadrant/kuadrant-operator/pull/2170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Dispatch notifications now include pull request author, link, number and latest approver details.
  - When no pull request is associated with an update, the triggering contributor is recorded instead.
  - Chart synchronisation events now provide clearer attribution and more consistent context for reviewing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->