### PR TITLE
fix: allow metadata changes through watch predicate

### DIFF
--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -421,7 +423,7 @@ func (r *DNSRecordReconciler) SetupWithManager(mgr ctrl.Manager, maxRequeue, min
 	allowInsecureCert = allowInsecureHealthCert
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.DNSRecord{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, deletingPredicate{}))).
+		For(&v1alpha1.DNSRecord{}, builder.WithPredicates(predicate.Or(specOrMetadataChangedPredicate{}, deletingPredicate{}))).
 		Watches(&v1alpha1.DNSHealthCheckProbe{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 			logger := log.FromContext(ctx)
 			probe, ok := o.(*v1alpha1.DNSHealthCheckProbe)
@@ -471,10 +473,36 @@ func generationChanged(record *v1alpha1.DNSRecord) bool {
 	return record.Generation != record.Status.ObservedGeneration
 }
 
+// specOrMetadataChangedPredicate allows Update events through when the spec
+// (generation) or metadata (finalizers, labels, annotations) changed.
+// Status-only updates are filtered out to prevent tight reconciliation loops.
+type specOrMetadataChangedPredicate struct {
+	predicate.Funcs
+}
+
+func (specOrMetadataChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+	if e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() {
+		return true
+	}
+	if !slices.Equal(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers()) {
+		return true
+	}
+	if !maps.Equal(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
+		return true
+	}
+	if !maps.Equal(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations()) {
+		return true
+	}
+	return false
+}
+
 // deletingPredicate allows Update events through when the object has a deletion
 // timestamp set, so the deletion state machine progresses without waiting for
-// scheduled requeues. Combined with predicate.GenerationChangedPredicate via
-// predicate.Or() to also allow spec changes through.
+// scheduled requeues. Combined with specOrMetadataChangedPredicate via
+// predicate.Or() to also allow spec and metadata changes through.
 type deletingPredicate struct {
 	predicate.Funcs
 }

--- a/internal/controller/dnsrecord_controller_unit_test.go
+++ b/internal/controller/dnsrecord_controller_unit_test.go
@@ -3,6 +3,12 @@ package controller
 import (
 	"testing"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/kuadrant/dns-operator/api/v1alpha1"
 )
 
 func TestClampTime(t *testing.T) {
@@ -52,6 +58,139 @@ func TestClampTime(t *testing.T) {
 			got := r.ClampTime(minRequeue, maxRequeue, tt.sinceTransition)
 			if got != tt.want {
 				t.Errorf("ClampTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpecOrMetadataChangedPredicate_Update(t *testing.T) {
+	p := specOrMetadataChangedPredicate{}
+
+	tests := []struct {
+		name string
+		old  *v1alpha1.DNSRecord
+		new  *v1alpha1.DNSRecord
+		want bool
+	}{
+		{
+			name: "nil old object returns false",
+			new:  &v1alpha1.DNSRecord{},
+			want: false,
+		},
+		{
+			name: "nil new object returns false",
+			old:  &v1alpha1.DNSRecord{},
+			want: false,
+		},
+		{
+			name: "generation changed returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 2}},
+			want: true,
+		},
+		{
+			name: "finalizer added returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, Finalizers: []string{"kuadrant.io/dns-record"}}},
+			want: true,
+		},
+		{
+			name: "finalizer removed returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, Finalizers: []string{"kuadrant.io/dns-record"}}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			want: true,
+		},
+		{
+			name: "label added returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"provider": "inmemory"}}},
+			want: true,
+		},
+		{
+			name: "label value changed returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"provider": "inmemory"}}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, Labels: map[string]string{"provider": "aws"}}},
+			want: true,
+		},
+		{
+			name: "annotation added returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, Annotations: map[string]string{"key": "value"}}},
+			want: true,
+		},
+		{
+			name: "status-only change returns false",
+			old: &v1alpha1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, ResourceVersion: "100"},
+			},
+			new: &v1alpha1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1, ResourceVersion: "101"},
+				Status:     v1alpha1.DNSRecordStatus{OwnerID: "abc123"},
+			},
+			want: false,
+		},
+		{
+			name: "no changes returns false",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := event.UpdateEvent{}
+			if tt.old != nil {
+				e.ObjectOld = tt.old
+			}
+			if tt.new != nil {
+				e.ObjectNew = tt.new
+			}
+			if got := p.Update(e); got != tt.want {
+				t.Errorf("Update() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComposedPredicate_DeletingObject(t *testing.T) {
+	composed := predicate.Or(specOrMetadataChangedPredicate{}, deletingPredicate{})
+	now := metav1.Now()
+
+	tests := []struct {
+		name string
+		old  *v1alpha1.DNSRecord
+		new  *v1alpha1.DNSRecord
+		want bool
+	}{
+		{
+			name: "deleting object with no other changes returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, DeletionTimestamp: &now}},
+			want: true,
+		},
+		{
+			name: "non-deleting status-only change returns false",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}},
+			new: &v1alpha1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status:     v1alpha1.DNSRecordStatus{OwnerID: "abc123"},
+			},
+			want: false,
+		},
+		{
+			name: "deleting object with finalizer change returns true",
+			old:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, Finalizers: []string{"kuadrant.io/dns-record"}, DeletionTimestamp: &now}},
+			new:  &v1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1, DeletionTimestamp: &now}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := event.UpdateEvent{ObjectOld: tt.old, ObjectNew: tt.new}
+			if got := composed.Update(e); got != tt.want {
+				t.Errorf("Update() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Replaces `GenerationChangedPredicate` with `specOrMetadataChangedPredicate` in the DNSRecord controller watch setup
- Allows finalizer and label updates to trigger immediate reconciliation instead of waiting for 5s requeue delays

The `GenerationChangedPredicate` (introduced in #809) filtered all non-spec update events, including metadata-only changes like finalizer and label additions. This caused the reconciler to rely on `RequeueAfter` delays between each intermediate step (finalizer → labels → publish+status), resulting in a ~15s minimum before `OwnerID` appeared in status — exceeding downstream test timeouts.

The new predicate allows updates through when generation, finalizers, labels, or annotations change, while still filtering status-only updates to prevent tight reconciliation loops. This is consistent with #821 which fixed the same class of issue for the deletion path.

## Test plan

- [x] dns-operator unit tests pass
- [x] All 31 kuadrant-operator DNS integration tests pass (previously failing test now completes in ~6.6s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DNS record updates now reconcile correctly when relevant metadata, labels, annotations, or finaliser changes occur.
  - Status-only updates continue to be ignored, reducing unnecessary processing.
  - Deletion handling now reflects the updated update-event behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->