### PR TITLE
ci: add runner configuration test workflow

### DIFF
--- a/.github/workflows/test-runners.yaml
+++ b/.github/workflows/test-runners.yaml
@@ -24,6 +24,8 @@ jobs:
           df -h /
       - name: Run lint
         run: make lint
+      - name: Run unit tests
+        run: make test-unit
 
   test-ubuntu-24-04-standard:
     name: GitHub Hosted - ubuntu-24.04 (standard)
@@ -42,42 +44,8 @@ jobs:
           df -h /
       - name: Run lint
         run: make lint
-
-  test-github-hosted-8-cores:
-    name: GitHub Hosted - 8 cores
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Show runner specs
-        run: |
-          echo "=== GitHub Hosted 8-core Runner ==="
-          nproc
-          free -h
-          df -h /
-      - name: Run lint
-        run: make lint
-
-  test-ubuntu-24-04-8-cores:
-    name: GitHub Hosted - ubuntu-24.04-8-cores
-    runs-on: ubuntu-24.04-8-cores
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Show runner specs
-        run: |
-          echo "=== GitHub Hosted ubuntu-24.04 8-core Runner ==="
-          nproc
-          free -h
-          df -h /
-      - name: Run lint
-        run: make lint
+      - name: Run unit tests
+        run: make test-unit
 
   test-ubuntu-24-10-standard:
     name: GitHub Hosted - ubuntu-24.10 (standard)
@@ -96,24 +64,8 @@ jobs:
           df -h /
       - name: Run lint
         run: make lint
-
-  test-ubuntu-24-10-8-cores:
-    name: GitHub Hosted - ubuntu-24.10-8-cores
-    runs-on: ubuntu-24.10-8-cores
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Show runner specs
-        run: |
-          echo "=== GitHub Hosted ubuntu-24.10 8-core Runner ==="
-          nproc
-          free -h
-          df -h /
-      - name: Run lint
-        run: make lint
+      - name: Run unit tests
+        run: make test-unit
 
   test-cncf-group-default:
     name: CNCF Group - Default
@@ -133,3 +85,5 @@ jobs:
           df -h /
       - name: Run lint
         run: make lint
+      - name: Run unit tests
+        run: make test-unit

--- a/.github/workflows/test-runners.yaml
+++ b/.github/workflows/test-runners.yaml
@@ -1,0 +1,61 @@
+name: Test Runner Configuration
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-github-hosted-8-cores:
+    name: GitHub Hosted - 8 cores
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== GitHub Hosted 8-core Runner ==="
+          nproc
+          free -h
+          df -h /
+
+  test-cncf-group-default:
+    name: CNCF Group - Default
+    runs-on:
+      group: Default
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== CNCF Runner Group: Default ==="
+          nproc
+          free -h
+          df -h /
+
+  test-cncf-label-8-32:
+    name: CNCF Label - 8-32
+    runs-on: [self-hosted, cncf-ubuntu-8-32]
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== CNCF Runner Label: cncf-ubuntu-8-32 ==="
+          nproc
+          free -h
+          df -h /
+
+  test-cncf-label-16-64:
+    name: CNCF Label - 16-64
+    runs-on: [self-hosted, cncf-ubuntu-16-64]
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== CNCF Runner Label: cncf-ubuntu-16-64 ==="
+          nproc
+          free -h
+          df -h /
+
+  test-cncf-label-32-128:
+    name: CNCF Label - 32-128
+    runs-on: [self-hosted, cncf-ubuntu-32-128]
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== CNCF Runner Label: cncf-ubuntu-32-128 ==="
+          nproc
+          free -h
+          df -h /

--- a/.github/workflows/test-runners.yaml
+++ b/.github/workflows/test-runners.yaml
@@ -13,7 +13,18 @@ jobs:
     steps:
       - name: Show runner specs
         run: |
-          echo "=== GitHub Hosted Standard Runner ==="
+          echo "=== GitHub Hosted Standard Runner (ubuntu-latest) ==="
+          nproc
+          free -h
+          df -h /
+
+  test-ubuntu-24-04-standard:
+    name: GitHub Hosted - ubuntu-24.04 (standard)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== GitHub Hosted ubuntu-24.04 Standard Runner ==="
           nproc
           free -h
           df -h /
@@ -59,39 +70,6 @@ jobs:
       - name: Show runner specs
         run: |
           echo "=== CNCF Runner Group: Default ==="
-          nproc
-          free -h
-          df -h /
-
-  test-cncf-label-8-32:
-    name: CNCF Label - 8-32
-    runs-on: [self-hosted, cncf-ubuntu-8-32]
-    steps:
-      - name: Show runner specs
-        run: |
-          echo "=== CNCF Runner Label: cncf-ubuntu-8-32 ==="
-          nproc
-          free -h
-          df -h /
-
-  test-cncf-label-16-64:
-    name: CNCF Label - 16-64
-    runs-on: [self-hosted, cncf-ubuntu-16-64]
-    steps:
-      - name: Show runner specs
-        run: |
-          echo "=== CNCF Runner Label: cncf-ubuntu-16-64 ==="
-          nproc
-          free -h
-          df -h /
-
-  test-cncf-label-32-128:
-    name: CNCF Label - 32-128
-    runs-on: [self-hosted, cncf-ubuntu-32-128]
-    steps:
-      - name: Show runner specs
-        run: |
-          echo "=== CNCF Runner Label: cncf-ubuntu-32-128 ==="
           nproc
           free -h
           df -h /

--- a/.github/workflows/test-runners.yaml
+++ b/.github/workflows/test-runners.yaml
@@ -7,6 +7,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  test-github-hosted-standard:
+    name: GitHub Hosted - Standard (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== GitHub Hosted Standard Runner ==="
+          nproc
+          free -h
+          df -h /
+
+  test-github-hosted-4-cores:
+    name: GitHub Hosted - 4 cores
+    runs-on: ubuntu-latest-4-cores
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== GitHub Hosted 4-core Runner ==="
+          nproc
+          free -h
+          df -h /
+
   test-github-hosted-8-cores:
     name: GitHub Hosted - 8 cores
     runs-on: ubuntu-latest-8-cores
@@ -14,6 +36,17 @@ jobs:
       - name: Show runner specs
         run: |
           echo "=== GitHub Hosted 8-core Runner ==="
+          nproc
+          free -h
+          df -h /
+
+  test-github-hosted-16-cores:
+    name: GitHub Hosted - 16 cores
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - name: Show runner specs
+        run: |
+          echo "=== GitHub Hosted 16-core Runner ==="
           nproc
           free -h
           df -h /

--- a/.github/workflows/test-runners.yaml
+++ b/.github/workflows/test-runners.yaml
@@ -1,6 +1,9 @@
 name: Test Runner Configuration
 
 on:
+  push:
+    branches:
+      - gh-runner-test
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-runners.yaml
+++ b/.github/workflows/test-runners.yaml
@@ -11,65 +11,125 @@ jobs:
     name: GitHub Hosted - Standard (ubuntu-latest)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Show runner specs
         run: |
           echo "=== GitHub Hosted Standard Runner (ubuntu-latest) ==="
           nproc
           free -h
           df -h /
+      - name: Run lint
+        run: make lint
 
   test-ubuntu-24-04-standard:
     name: GitHub Hosted - ubuntu-24.04 (standard)
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Show runner specs
         run: |
           echo "=== GitHub Hosted ubuntu-24.04 Standard Runner ==="
           nproc
           free -h
           df -h /
-
-  test-github-hosted-4-cores:
-    name: GitHub Hosted - 4 cores
-    runs-on: ubuntu-latest-4-cores
-    steps:
-      - name: Show runner specs
-        run: |
-          echo "=== GitHub Hosted 4-core Runner ==="
-          nproc
-          free -h
-          df -h /
+      - name: Run lint
+        run: make lint
 
   test-github-hosted-8-cores:
     name: GitHub Hosted - 8 cores
     runs-on: ubuntu-latest-8-cores
     steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Show runner specs
         run: |
           echo "=== GitHub Hosted 8-core Runner ==="
           nproc
           free -h
           df -h /
+      - name: Run lint
+        run: make lint
 
-  test-github-hosted-16-cores:
-    name: GitHub Hosted - 16 cores
-    runs-on: ubuntu-latest-16-cores
+  test-ubuntu-24-04-8-cores:
+    name: GitHub Hosted - ubuntu-24.04-8-cores
+    runs-on: ubuntu-24.04-8-cores
     steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Show runner specs
         run: |
-          echo "=== GitHub Hosted 16-core Runner ==="
+          echo "=== GitHub Hosted ubuntu-24.04 8-core Runner ==="
           nproc
           free -h
           df -h /
+      - name: Run lint
+        run: make lint
+
+  test-ubuntu-24-10-standard:
+    name: GitHub Hosted - ubuntu-24.10 (standard)
+    runs-on: ubuntu-24.10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Show runner specs
+        run: |
+          echo "=== GitHub Hosted ubuntu-24.10 Standard Runner ==="
+          nproc
+          free -h
+          df -h /
+      - name: Run lint
+        run: make lint
+
+  test-ubuntu-24-10-8-cores:
+    name: GitHub Hosted - ubuntu-24.10-8-cores
+    runs-on: ubuntu-24.10-8-cores
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Show runner specs
+        run: |
+          echo "=== GitHub Hosted ubuntu-24.10 8-core Runner ==="
+          nproc
+          free -h
+          df -h /
+      - name: Run lint
+        run: make lint
 
   test-cncf-group-default:
     name: CNCF Group - Default
     runs-on:
       group: Default
     steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: false
       - name: Show runner specs
         run: |
           echo "=== CNCF Runner Group: Default ==="
           nproc
           free -h
           df -h /
+      - name: Run lint
+        run: make lint


### PR DESCRIPTION
Test various runner configurations to determine available labels and groups for CNCF-hosted and GitHub-managed runners. This will help identify the correct runner specifications to use for E2E tests.

Runs manually via workflow_dispatch to test:
- GitHub-hosted larger runners (8-cores)
- CNCF runner group (Default)
- CNCF runner labels (8-32, 16-64, 32-128 cores)