### PR TITLE
Fix domain filtering and TXT record quotes for failover cli commands

### DIFF
--- a/cmd/plugin/failover/add-active-group.go
+++ b/cmd/plugin/failover/add-active-group.go
@@ -106,7 +106,7 @@ func addActiveGroup(_ *cobra.Command, args []string) error {
 		var endpoints []*externaldnsendpoint.Endpoint
 
 		providerForZone, err = common.GetProviderForConfig(ctx, resourceRef, provider.Config{
-			DomainFilter: externaldnsendpoint.NewRegexDomainFilter(domainRegexp, nil),
+			DomainFilter: externaldnsendpoint.NewDomainFilter([]string{domain}),
 			ZoneIDFilter: externaldnsprovider.ZoneIDFilter{
 				ZoneIDs: []string{zone.ID},
 			},
@@ -118,7 +118,7 @@ func addActiveGroup(_ *cobra.Command, args []string) error {
 
 		endpoints, err = providerForZone.Records(ctx)
 		if err != nil {
-			log.Error(err, "failed tp get endpoints")
+			log.Error(err, "failed to get endpoints")
 			continue
 		}
 

--- a/cmd/plugin/failover/remove-active-group.go
+++ b/cmd/plugin/failover/remove-active-group.go
@@ -87,7 +87,7 @@ func removeActiveGroup(_ *cobra.Command, args []string) error {
 
 	for _, zone := range allZones {
 		providerForZone, err := common.GetProviderForConfig(ctx, resourceRef, provider.Config{
-			DomainFilter: externaldnsendpoint.NewRegexDomainFilter(domainRegexp, nil),
+			DomainFilter: externaldnsendpoint.NewDomainFilter([]string{domain}),
 			ZoneIDFilter: externaldnsprovider.NewZoneIDFilter([]string{zone.ID}),
 		})
 		if err != nil {

--- a/cmd/plugin/failover/shared.go
+++ b/cmd/plugin/failover/shared.go
@@ -49,12 +49,12 @@ func generateGroupTXTRecordTargets(groups ...string) string {
 	groups = slices.Compact(groups)
 
 	if len(groups) == 0 || groups[0] == "" {
-		return fmt.Sprintf("\"%s\"", target)
+		return target
 	}
 
 	target += TXTRecordKeysSeparator + TXTRecordGroupKey + "=" + strings.Join(groups, GroupSeparator)
 
-	return fmt.Sprintf("\"%s\"", target)
+	return target
 }
 
 func EnsureGroupIsActive(groupName string, existingRecord *endpoint.Endpoint) *endpoint.Endpoint {
@@ -124,7 +124,7 @@ func compileTXTRecordTarget(activeGroups []string) string {
 	}
 	version := fmt.Sprintf("version=%s", TXTRecordVersion)
 
-	return fmt.Sprintf("\"%s%s\"", version, groups)
+	return fmt.Sprintf("%s%s", version, groups)
 }
 
 // GetDomainRegexp creates regexp to filter zones

--- a/cmd/plugin/failover/shared_test.go
+++ b/cmd/plugin/failover/shared_test.go
@@ -29,7 +29,7 @@ func TestGenerateGroupTXTRecord(t *testing.T) {
 			},
 			want: &endpoint.Endpoint{
 				DNSName: TXTRecordPrefix + "cat.com",
-				Targets: endpoint.Targets{fmt.Sprintf("\"version=%s%s%s=group1\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey)},
+				Targets: endpoint.Targets{fmt.Sprintf("version=%s%s%s=group1", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey)},
 			},
 		},
 		{
@@ -40,7 +40,7 @@ func TestGenerateGroupTXTRecord(t *testing.T) {
 			},
 			want: &endpoint.Endpoint{
 				DNSName: TXTRecordPrefix + "cat.com",
-				Targets: endpoint.Targets{fmt.Sprintf("\"version=%s%s%s=group1%sgroup2\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator)},
+				Targets: endpoint.Targets{fmt.Sprintf("version=%s%s%s=group1%sgroup2", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator)},
 			},
 		},
 		{
@@ -51,7 +51,7 @@ func TestGenerateGroupTXTRecord(t *testing.T) {
 			},
 			want: &endpoint.Endpoint{
 				DNSName: TXTRecordPrefix + "cat.com",
-				Targets: endpoint.Targets{fmt.Sprintf("\"version=%s\"", TXTRecordVersion)},
+				Targets: endpoint.Targets{fmt.Sprintf("version=%s", TXTRecordVersion)},
 			},
 		},
 		{
@@ -62,7 +62,7 @@ func TestGenerateGroupTXTRecord(t *testing.T) {
 			},
 			want: &endpoint.Endpoint{
 				DNSName: TXTRecordPrefix + "cat.com",
-				Targets: endpoint.Targets{fmt.Sprintf("\"version=%s%s%s=group1%sgroup2%sgroup3\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator, GroupSeparator)},
+				Targets: endpoint.Targets{fmt.Sprintf("version=%s%s%s=group1%sgroup2%sgroup3", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator, GroupSeparator)},
 			},
 		},
 		{
@@ -73,7 +73,7 @@ func TestGenerateGroupTXTRecord(t *testing.T) {
 			},
 			want: &endpoint.Endpoint{
 				DNSName: TXTRecordPrefix + "cat.com",
-				Targets: endpoint.Targets{fmt.Sprintf("\"version=%s\"", TXTRecordVersion)},
+				Targets: endpoint.Targets{fmt.Sprintf("version=%s", TXTRecordVersion)},
 			},
 		},
 	}
@@ -155,25 +155,31 @@ func TestGetActiveGroupsFromTarget(t *testing.T) {
 	}{
 		{
 			name:             "gets a single group",
-			target:           fmt.Sprintf("\"version=%s%s%s=group1\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
+			target:           fmt.Sprintf("version=%s%s%s=group1", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
 			want:             []string{"group1"},
 			isCurrentVersion: true,
 		},
 		{
 			name:             "gets multiple groups",
-			target:           fmt.Sprintf("\"version=%s%s%s=group1%sgroup2%sgroup3\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator, GroupSeparator),
+			target:           fmt.Sprintf("version=%s%s%s=group1%sgroup2%sgroup3", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator, GroupSeparator),
 			want:             []string{"group1", "group2", "group3"},
 			isCurrentVersion: true,
 		},
 		{
 			name:             "gets no groups",
-			target:           fmt.Sprintf("\"version=%s\"", TXTRecordVersion),
+			target:           fmt.Sprintf("version=%s", TXTRecordVersion),
 			want:             []string{},
 			isCurrentVersion: true,
 		},
 		{
+			name:             "gets a single group with quotes",
+			target:           fmt.Sprintf("\"version=%s%s%s=group1\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
+			want:             []string{"group1"},
+			isCurrentVersion: true,
+		},
+		{
 			name:             "reports legacy version",
-			target:           fmt.Sprintf("\"version=%s%s%s=group1\"", "legacyVersion", TXTRecordKeysSeparator, TXTRecordGroupKey),
+			target:           fmt.Sprintf("version=%s%s%s=group1", "legacyVersion", TXTRecordKeysSeparator, TXTRecordGroupKey),
 			want:             []string{},
 			isCurrentVersion: false,
 		},
@@ -202,27 +208,27 @@ func TestRemoveGroupFromActiveGroups(t *testing.T) {
 		{
 			name:   "removes a group from multiple groups",
 			group:  "group1",
-			target: fmt.Sprintf("\"version=%s%s%s=group1%sgroup2\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator),
-			want:   fmt.Sprintf("\"version=%s%s%s=group2\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
+			target: fmt.Sprintf("version=%s%s%s=group1%sgroup2", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator),
+			want:   fmt.Sprintf("version=%s%s%s=group2", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
 		},
 		{
 			name:   "removes a group from a single group",
 			group:  "group1",
-			target: fmt.Sprintf("\"version=%s%s%s=group1\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
-			want:   fmt.Sprintf("\"version=%s\"", TXTRecordVersion),
+			target: fmt.Sprintf("version=%s%s%s=group1", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
+			want:   fmt.Sprintf("version=%s", TXTRecordVersion),
 		},
 		{
 			// this should never happen but testing for it just in case
 			name:   "removes non existent group",
 			group:  "group1",
-			target: fmt.Sprintf("\"version=%s%s%s=group2\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
-			want:   fmt.Sprintf("\"version=%s%s%s=group2\"", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
+			target: fmt.Sprintf("version=%s%s%s=group2", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
+			want:   fmt.Sprintf("version=%s%s%s=group2", TXTRecordVersion, TXTRecordKeysSeparator, TXTRecordGroupKey),
 		},
 		{
 			name:   "ignores legacy records",
 			group:  "group1",
-			target: fmt.Sprintf("\"version=%s%s%s=group1%sgroup2\"", "legacyVersion", TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator),
-			want:   fmt.Sprintf("\"version=%s%s%s=group1%sgroup2\"", "legacyVersion", TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator),
+			target: fmt.Sprintf("version=%s%s%s=group1%sgroup2", "legacyVersion", TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator),
+			want:   fmt.Sprintf("version=%s%s%s=group1%sgroup2", "legacyVersion", TXTRecordKeysSeparator, TXTRecordGroupKey, GroupSeparator),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/external-dns/provider/aws/aws.go
+++ b/internal/external-dns/provider/aws/aws.go
@@ -405,7 +405,11 @@ func (p *AWSProvider) records(ctx context.Context, zones map[string]types.Hosted
 				if len(r.ResourceRecords) > 0 {
 					targets := make([]string, len(r.ResourceRecords))
 					for idx, rr := range r.ResourceRecords {
-						targets[idx] = aws.ToString(rr.Value)
+						val := aws.ToString(rr.Value)
+						if r.Type == types.RRTypeTxt {
+							val = stripTXTQuotes(val)
+						}
+						targets[idx] = val
 					}
 
 					ep := endpoint.NewEndpointWithTTL(wildcardUnescape(aws.ToString(r.Name)), string(r.Type), ttl, targets...)
@@ -740,6 +744,9 @@ func (p *AWSProvider) newChange(action types.ChangeAction, ep *endpoint.Endpoint
 		}
 		change.ResourceRecordSet.ResourceRecords = make([]types.ResourceRecord, len(ep.Targets))
 		for idx, val := range ep.Targets {
+			if change.ResourceRecordSet.Type == types.RRTypeTxt {
+				val = quoteTXTRecord(val)
+			}
 			change.ResourceRecordSet.ResourceRecords[idx] = types.ResourceRecord{
 				Value: aws.String(val),
 			}
@@ -1063,4 +1070,18 @@ func zoneTypeString(z *types.HostedZone) string {
 		return "public"
 	}
 	return "private"
+}
+
+func quoteTXTRecord(val string) string {
+	if strings.HasPrefix(val, "\"") && strings.HasSuffix(val, "\"") {
+		return val
+	}
+	return "\"" + val + "\""
+}
+
+func stripTXTQuotes(val string) string {
+	if strings.HasPrefix(val, "\"") && strings.HasSuffix(val, "\"") {
+		return val[1 : len(val)-1]
+	}
+	return val
 }


### PR DESCRIPTION
## Fixes

**Domain filtering fix (GCP, Azure):** The per-zone provider in `add-active-group` and `remove-active-group` CLI commands used `RegexDomainFilter` with pattern `^zone.example.com$`, which only matches the exact zone name. The active groups TXT record name is `kuadrant-active-groups.zone.example.com` — a subdomain that doesn't match the regex. Azure's `UpdateRecords()`/`DeleteRecords()` silently skips records that don't match the domain filter, so writes appeared to succeed but never actually applied.  GCP had the same filtering issue. Switched to list-based `DomainFilter{Filters: []string{domain}}` which matches subdomains. The `get-active-groups` command already used the correct filter.

**TXT record quoting fix (AWS):** The shared failover code wrapped TXT record values in literal double quotes (`"\"version=1;groups=...\""`). AWS Route53 requires this quoting at the API level, but GCP and Azure APIs accept raw, with literal quotes get stored as data, corrupting the value. Moved quoting responsibility into the AWS provider: `quoteTXTRecord()` ensures values are quoted before writing to Route53, `stripTXTQuotes()` normalizes them when reading back.

## Verification

```bash
# Before fix: add-active-group reports success on GCP/Azure but record is never created
kubectl-kuadrant_dns add-active-group test-group -d gcp.example.com --providerRef kuadrant/gcp-credentials -y
# added group "test-group" to active groups of "azure.example.com" zone
kubectl-kuadrant_dns get-active-groups -d gcp.example.com --providerRef kuadrant/gcp-credentials
# Output: no active groups found

# After fix: add-active-group correctly creates the record
kubectl-kuadrant_dns add-active-group test-group -d azure.example.com --providerRef kuadrant/azure-credentials -y
# added group "test-group" to active groups of "azure.example.com" zone
kubectl-kuadrant_dns get-active-groups -d azure.example.com --providerRef kuadrant/azure-credentials
# Output: `test-group` shown as an active group
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failover handling by applying exact domain matching for per-zone provider operations.
  * Corrected endpoint retrieval error messaging.
  * Standardised failover TXT record formatting, including compatibility with existing quoted records.
  * Improved Route 53 TXT record handling by normalising values when reading and formatting them correctly when updating.
* **Tests**
  * Added coverage for quoted and unquoted TXT record values and legacy-version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->