### PR TITLE
Match the whole group name instead of substring for add-active-group

### DIFF
--- a/cmd/plugin/failover/add-active-group.go
+++ b/cmd/plugin/failover/add-active-group.go
@@ -3,7 +3,7 @@ package failover
 import (
 	"context"
 	"fmt"
-	"strings"
+	"slices"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -132,12 +132,14 @@ func addActiveGroup(_ *cobra.Command, args []string) error {
 				break
 			}
 		}
-		if groupTXTRecord != nil && strings.Contains(groupTXTRecord.Targets[0], groupName) {
-			log.Info("Found existing TXT record for domain that already contains group name.", "zone DNS Name", zone.DNSName, "record", groupName)
-			output.Formatter.Print("Nothing to do")
-			log.V(1).Info(fmt.Sprintf("existing record name: %s, targets: %s", groupRecordName, groupTXTRecord.Targets))
-			continue
-
+		if groupTXTRecord != nil {
+			existingGroups, _ := GetActiveGroupsFromTarget(groupTXTRecord.Targets[0])
+			if slices.Contains(existingGroups, groupName) {
+				log.Info("Found existing TXT record for domain that already contains group name.", "zone DNS Name", zone.DNSName, "record", groupName)
+				output.Formatter.Print("Nothing to do")
+				log.V(1).Info(fmt.Sprintf("existing record name: %s, targets: %s", groupRecordName, groupTXTRecord.Targets))
+				continue
+			}
 		}
 
 		log.Info(fmt.Sprintf("Setting group %s as active group", groupName))

--- a/cmd/plugin/failover/remove-active-group.go
+++ b/cmd/plugin/failover/remove-active-group.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -118,7 +119,8 @@ func removeActiveGroup(_ *cobra.Command, args []string) error {
 			continue
 		}
 
-		if !strings.Contains(groupTXTRecord.Targets[0], groupName) {
+		existingGroups, _ := GetActiveGroupsFromTarget(groupTXTRecord.Targets[0])
+		if !slices.Contains(existingGroups, groupName) {
 			log.V(1).Info(fmt.Sprintf("TXT record does not contain group %s. Groups: %s. Skipping", groupTXTRecord.Targets[0], groupName))
 			continue
 		}


### PR DESCRIPTION
## Summary

The `add-active-group` and `remove-active-group` CLI commands used `strings.Contains` to check if a group exists in the TXT record target. This is a substring match, so a group named `test` would match `test-group1` — causing `add-active-group` to skip adding the new group and `remove-active-group` to attempt removal of a non-existent group. Switched to parsing the actual groups list via `GetActiveGroupsFromTarget()` and checking for exact membership with `slices.Contains`.

## Verification

```bash
# add-active-group before fix: adding "test" falsely matches "test-group1" substring
kubectl-kuadrant_dns add-active-group test-group1 -d aws.example.com --providerRef kuadrant/aws-credentials -y
# added group "test-group1" to active groups of "aws.example.com" zone
kubectl-kuadrant_dns add-active-group test -d aws.example.com --providerRef kuadrant/aws-credentials -y
# Output: "Nothing to do" — incorrectly thinks `test` group already exists
kubectl-kuadrant_dns get-active-groups -d aws.example.com --providerRef kuadrant/aws-credentials
# Output: shows only `test-group1` group in the active groups txt record

# remove-active-group before fix: adding "test" falsely matches "test-group1" substring
kubectl-kuadrant_dns remove-active-group test -d aws.example.com --providerRef kuadrant/aws-credentials -y
# Removing active group test from the record: kuadrant-active-groups.aws.example.com
# Do you want to proceed? [Y/N] Y
kubectl-kuadrant_dns get-active-groups -d aws.example.com --providerRef kuadrant/aws-credentials
# Output: shows `test-group1` group is still in the active groups txt record

# rebuild the dns cli with the fix implemented in the PR
make build-cli && make cp-cli 

# After fix: `test` is correctly identified as a new group
kubectl-kuadrant_dns add-active-group test-group1 -d aws.example.com --providerRef kuadrant/aws-credentials -y
# added group "test-group1" to active groups of "aws.example.com" zone
kubectl-kuadrant_dns add-active-group test -d aws.example.com --providerRef kuadrant/aws-credentials -y
# added group "test" to active groups of "aws.example.com" zone
kubectl-kuadrant_dns get-active-groups -d aws.example.com --providerRef kuadrant/aws-credentials
# Output: shows that both groups were added correctly: `test, test-group1`